### PR TITLE
Add initial FastMoq.Azure package and Azure test helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,10 @@ When generating code:
     - Progress updates must stay grounded in the current task, files, and findings. Do not insert speculative filler, unrelated examples, or generic brainstorming text.
     - When a patch is too broad, split it into smaller targeted edits and complete local formatting cleanup before stopping.
     - If you touch a large partial class, preserve the surrounding style and fix any indentation or malformed XML introduced in the edited region before considering the work done.
+9. **Keep package and solution topology aligned**
+    - `FastMoq\FastMoq.csproj` must directly include every public release package project.
+    - When a non-test public release project is added, removed, or renamed, update both `FastMoq.sln` and `FastMoq-Release.sln` in the same change.
+    - Test-only or example-only project changes belong in `FastMoq.sln`, but do not require changes to `FastMoq-Release.sln`.
 
 ## 🔐 Static Analysis Rules (Sonar)
 Apply these consistently in generated code (and prefer refactoring existing code toward them when touched):

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,22 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Azure.Core" Version="1.50.0" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="[4.18.4]" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/FastMoq-Release.sln
+++ b/FastMoq-Release.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq", "FastMoq\FastMoq.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Abstractions", "FastMoq.Abstractions\FastMoq.Abstractions.csproj", "{970828D1-0EF2-4D0D-BF1B-BB85DEB38514}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Azure", "FastMoq.Azure\FastMoq.Azure.csproj", "{CADD0874-D3E6-40B3-A8D5-EB04047597EC}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Core", "FastMoq.Core\FastMoq.Core.csproj", "{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Database", "FastMoq.Database\FastMoq.Database.csproj", "{D58D5C37-1488-43F7-B9A3-FCB22D836181}"
@@ -35,6 +37,10 @@ Global
 		{970828D1-0EF2-4D0D-BF1B-BB85DEB38514}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{970828D1-0EF2-4D0D-BF1B-BB85DEB38514}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{970828D1-0EF2-4D0D-BF1B-BB85DEB38514}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Debug|Any CPU.ActiveCfg = Release|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/FastMoq.Azure/Credentials/AzureCredentialTestExtensions.cs
+++ b/FastMoq.Azure/Credentials/AzureCredentialTestExtensions.cs
@@ -1,0 +1,76 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace FastMoq.Azure.Credentials
+{
+    /// <summary>
+    /// Provides Azure credential registration helpers for <see cref="Mocker" />.
+    /// </summary>
+    public static class AzureCredentialTestExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="TokenCredential" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="credential">The credential to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddTokenCredential(this Mocker mocker, TokenCredential credential, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(credential);
+
+            return mocker.AddType<TokenCredential>(credential, replace);
+        }
+
+        /// <summary>
+        /// Registers a fixed-token <see cref="TokenCredential" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="token">The bearer token to return for every request.</param>
+        /// <param name="expiresOn">The token expiry to return. When omitted, the token expires one hour from construction.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddTokenCredential(this Mocker mocker, string token, DateTimeOffset? expiresOn = null, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+            return mocker.AddTokenCredential(new TestTokenCredential(token, expiresOn), replace);
+        }
+
+        /// <summary>
+        /// Registers a concrete <see cref="DefaultAzureCredential" /> and exposes it as both <see cref="DefaultAzureCredential" /> and <see cref="TokenCredential" />.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="credential">The credential to register.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddDefaultAzureCredential(this Mocker mocker, DefaultAzureCredential credential, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(credential);
+
+            mocker.AddType<DefaultAzureCredential>(credential, replace);
+            mocker.AddType<TokenCredential>(credential, replace);
+            return mocker;
+        }
+
+        /// <summary>
+        /// Registers a fixed-token <see cref="DefaultAzureCredential" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="token">The bearer token to return for every request.</param>
+        /// <param name="expiresOn">The token expiry to return. When omitted, the token expires one hour from construction.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddDefaultAzureCredential(this Mocker mocker, string token, DateTimeOffset? expiresOn = null, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+            return mocker.AddDefaultAzureCredential(new TestDefaultAzureCredential(token, expiresOn), replace);
+        }
+
+    }
+}

--- a/FastMoq.Azure/Credentials/TestDefaultAzureCredential.cs
+++ b/FastMoq.Azure/Credentials/TestDefaultAzureCredential.cs
@@ -1,0 +1,42 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace FastMoq.Azure.Credentials
+{
+    /// <summary>
+    /// Represents a concrete <see cref="DefaultAzureCredential" /> that returns a fixed access token for tests.
+    /// </summary>
+    public sealed class TestDefaultAzureCredential : DefaultAzureCredential
+    {
+        private readonly AccessToken _accessToken;
+
+        /// <summary>
+        /// Initializes a new <see cref="TestDefaultAzureCredential" /> instance.
+        /// </summary>
+        /// <param name="token">The bearer token to return for every request.</param>
+        /// <param name="expiresOn">The token expiry to return. When omitted, the token expires one hour from construction.</param>
+        public TestDefaultAzureCredential(string token, DateTimeOffset? expiresOn = null)
+            : base(false)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+            _accessToken = new AccessToken(token, expiresOn ?? DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        /// <inheritdoc />
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(requestContext);
+
+            return _accessToken;
+        }
+
+        /// <inheritdoc />
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(requestContext);
+
+            return ValueTask.FromResult(_accessToken);
+        }
+    }
+}

--- a/FastMoq.Azure/Credentials/TestDefaultAzureCredential.cs
+++ b/FastMoq.Azure/Credentials/TestDefaultAzureCredential.cs
@@ -26,16 +26,12 @@ namespace FastMoq.Azure.Credentials
         /// <inheritdoc />
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(requestContext);
-
             return _accessToken;
         }
 
         /// <inheritdoc />
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(requestContext);
-
             return ValueTask.FromResult(_accessToken);
         }
     }

--- a/FastMoq.Azure/Credentials/TestTokenCredential.cs
+++ b/FastMoq.Azure/Credentials/TestTokenCredential.cs
@@ -24,16 +24,12 @@ namespace FastMoq.Azure.Credentials
         /// <inheritdoc />
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(requestContext);
-
             return _accessToken;
         }
 
         /// <inheritdoc />
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(requestContext);
-
             return ValueTask.FromResult(_accessToken);
         }
     }

--- a/FastMoq.Azure/Credentials/TestTokenCredential.cs
+++ b/FastMoq.Azure/Credentials/TestTokenCredential.cs
@@ -1,0 +1,40 @@
+using Azure.Core;
+
+namespace FastMoq.Azure.Credentials
+{
+    /// <summary>
+    /// Represents a token credential that returns a fixed access token for every request.
+    /// </summary>
+    public sealed class TestTokenCredential : TokenCredential
+    {
+        private readonly AccessToken _accessToken;
+
+        /// <summary>
+        /// Initializes a new <see cref="TestTokenCredential" /> instance.
+        /// </summary>
+        /// <param name="token">The bearer token to return for every request.</param>
+        /// <param name="expiresOn">The token expiry to return. When omitted, the token expires one hour from construction.</param>
+        public TestTokenCredential(string token, DateTimeOffset? expiresOn = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+            _accessToken = new AccessToken(token, expiresOn ?? DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        /// <inheritdoc />
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(requestContext);
+
+            return _accessToken;
+        }
+
+        /// <inheritdoc />
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(requestContext);
+
+            return ValueTask.FromResult(_accessToken);
+        }
+    }
+}

--- a/FastMoq.Azure/DependencyInjection/AzureDependencyInjectionTestExtensions.cs
+++ b/FastMoq.Azure/DependencyInjection/AzureDependencyInjectionTestExtensions.cs
@@ -1,0 +1,170 @@
+using FastMoq.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastMoq.Azure.DependencyInjection
+{
+    /// <summary>
+    /// Provides Azure-oriented configuration, client registration, and typed service-provider helpers.
+    /// </summary>
+    public static class AzureDependencyInjectionTestExtensions
+    {
+        /// <summary>
+        /// Creates an in-memory Azure test configuration.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="initialValues">Optional key-value pairs to seed into the configuration.</param>
+        /// <returns>An in-memory configuration root.</returns>
+        public static IConfigurationRoot CreateAzureConfiguration(this Mocker mocker, IEnumerable<KeyValuePair<string, string?>>? initialValues = null)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            var builder = new ConfigurationBuilder();
+            if (initialValues is not null)
+            {
+                builder.AddInMemoryCollection(initialValues);
+            }
+
+            return builder.Build();
+        }
+
+        /// <summary>
+        /// Registers Azure-oriented configuration types for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="configuration">The configuration to register.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureConfiguration(this Mocker mocker, IConfiguration configuration, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            var configurationRoot = configuration as IConfigurationRoot;
+
+            mocker.AddType<IConfiguration>(configuration, replace);
+            if (configurationRoot is not null)
+            {
+                mocker.AddType<IConfigurationRoot>(configurationRoot, replace);
+            }
+
+            return mocker;
+        }
+
+        /// <summary>
+        /// Builds and registers an in-memory Azure test configuration for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="initialValues">The configuration values to seed into the configuration.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureConfiguration(this Mocker mocker, IEnumerable<KeyValuePair<string, string?>> initialValues, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(initialValues);
+
+            return mocker.AddAzureConfiguration(mocker.CreateAzureConfiguration(initialValues), replace);
+        }
+
+        /// <summary>
+        /// Creates a typed <see cref="IServiceProvider" /> with common Azure testing defaults.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="configureServices">Optional service registrations to apply after the Azure defaults.</param>
+        /// <param name="configurationValues">Optional configuration values to register as an in-memory configuration root.</param>
+        /// <returns>A real service provider suitable for Azure-focused tests.</returns>
+        public static IServiceProvider CreateAzureServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices = null, IEnumerable<KeyValuePair<string, string?>>? configurationValues = null)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            var configuration = mocker.CreateAzureConfiguration(configurationValues);
+
+            return mocker.CreateTypedServiceProvider(services =>
+            {
+                services.AddLogging();
+                services.AddOptions();
+                services.AddSingleton<IConfiguration>(configuration);
+                services.AddSingleton<IConfigurationRoot>(configuration);
+                configureServices?.Invoke(services);
+            });
+        }
+
+        /// <summary>
+        /// Registers a typed Azure-oriented <see cref="IServiceProvider" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="serviceProvider">The service provider to register.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureServiceProvider(this Mocker mocker, IServiceProvider serviceProvider, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            var configuration = serviceProvider.GetService(typeof(IConfiguration)) as IConfiguration;
+            var configurationRoot = serviceProvider.GetService(typeof(IConfigurationRoot)) as IConfigurationRoot ?? configuration as IConfigurationRoot;
+
+            mocker.AddServiceProvider(serviceProvider, replace);
+            if (configuration is not null)
+            {
+                mocker.AddType<IConfiguration>(configuration, replace);
+            }
+
+            if (configurationRoot is not null)
+            {
+                mocker.AddType<IConfigurationRoot>(configurationRoot, replace);
+            }
+
+            return mocker;
+        }
+
+        /// <summary>
+        /// Builds and registers a typed Azure-oriented <see cref="IServiceProvider" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="configureServices">Optional service registrations to apply after the Azure defaults.</param>
+        /// <param name="configurationValues">Optional configuration values to register as an in-memory configuration root.</param>
+        /// <param name="replace">True to replace existing registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices = null, IEnumerable<KeyValuePair<string, string?>>? configurationValues = null, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            return mocker.AddAzureServiceProvider(mocker.CreateAzureServiceProvider(configureServices, configurationValues), replace);
+        }
+
+        /// <summary>
+        /// Registers an Azure client instance as a singleton service.
+        /// </summary>
+        /// <typeparam name="TClient">The client type to register.</typeparam>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="client">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddAzureClient<TClient>(this IServiceCollection services, TClient client)
+            where TClient : class
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(client);
+
+            services.AddSingleton(client);
+            return services;
+        }
+
+        /// <summary>
+        /// Registers an Azure client instance for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <typeparam name="TClient">The client type to register.</typeparam>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="client">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureClient<TClient>(this Mocker mocker, TClient client, bool replace = false)
+            where TClient : class
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(client);
+
+            return mocker.AddType<TClient>(client, replace);
+        }
+    }
+}

--- a/FastMoq.Azure/FastMoq.Azure.csproj
+++ b/FastMoq.Azure/FastMoq.Azure.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Authors>Winland, $(AssemblyName)</Authors>
+    <Company>$(Authors)</Company>
+    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Description>Shared Azure SDK testing helpers for FastMoq, including credentials, pageable builders, Key Vault helpers, and Azure-oriented service registration support.</Description>
+    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>FastMoq;Azure;testing;mocking;credentials;storage;keyvault</PackageTags>
+    <PackageLicenseFile>license.txt</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPackable>true</IsPackable>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <RootNamespace>FastMoq.Azure</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastMoq.Core\FastMoq.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/FastMoq.Azure/KeyVault/SecretClientTestExtensions.cs
+++ b/FastMoq.Azure/KeyVault/SecretClientTestExtensions.cs
@@ -1,0 +1,41 @@
+using Azure.Security.KeyVault.Secrets;
+using FastMoq.Azure.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastMoq.Azure.KeyVault
+{
+    /// <summary>
+    /// Provides <see cref="SecretClient" /> registration helpers for tests.
+    /// </summary>
+    public static class SecretClientTestExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="SecretClient" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="secretClient">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddSecretClient(this IServiceCollection services, SecretClient secretClient)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(secretClient);
+
+            return services.AddAzureClient(secretClient);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="SecretClient" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="secretClient">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddSecretClient(this Mocker mocker, SecretClient secretClient, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(secretClient);
+
+            return mocker.AddAzureClient(secretClient, replace);
+        }
+    }
+}

--- a/FastMoq.Azure/Pageable/AzureTestResponse.cs
+++ b/FastMoq.Azure/Pageable/AzureTestResponse.cs
@@ -20,7 +20,7 @@ namespace FastMoq.Azure.Pageable
         /// </summary>
         /// <param name="status">The HTTP status code to expose.</param>
         /// <param name="reasonPhrase">The reason phrase to expose.</param>
-        /// <param name="headers">Optional headers to expose through <see cref="Headers" />.</param>
+        /// <param name="headers">Optional headers to expose through <see cref="Response.Headers" />.</param>
         /// <param name="contentStream">An optional content stream.</param>
         /// <param name="clientRequestId">An optional client request identifier.</param>
         /// <param name="isError">True to mark the response as an error response.</param>

--- a/FastMoq.Azure/Pageable/AzureTestResponse.cs
+++ b/FastMoq.Azure/Pageable/AzureTestResponse.cs
@@ -1,0 +1,152 @@
+using Azure;
+using Azure.Core;
+
+namespace FastMoq.Azure.Pageable
+{
+    /// <summary>
+    /// Represents a lightweight Azure SDK <see cref="Response" /> implementation for test helpers.
+    /// </summary>
+    public sealed class AzureTestResponse : Response
+    {
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _headers;
+        private readonly int _statusCode;
+        private readonly string _reasonPhrase;
+        private readonly bool _isError;
+        private string _clientRequestId;
+        private Stream? _contentStream;
+
+        /// <summary>
+        /// Initializes a new <see cref="AzureTestResponse" /> instance.
+        /// </summary>
+        /// <param name="status">The HTTP status code to expose.</param>
+        /// <param name="reasonPhrase">The reason phrase to expose.</param>
+        /// <param name="headers">Optional headers to expose through <see cref="Headers" />.</param>
+        /// <param name="contentStream">An optional content stream.</param>
+        /// <param name="clientRequestId">An optional client request identifier.</param>
+        /// <param name="isError">True to mark the response as an error response.</param>
+        public AzureTestResponse(
+            int status = 200,
+            string reasonPhrase = "OK",
+            IEnumerable<HttpHeader>? headers = null,
+            Stream? contentStream = null,
+            string? clientRequestId = null,
+            bool isError = false)
+        {
+            ArgumentNullException.ThrowIfNull(reasonPhrase);
+
+            _statusCode = status;
+            _reasonPhrase = reasonPhrase;
+            _headers = CreateHeaderLookup(headers);
+            _contentStream = contentStream;
+            _clientRequestId = string.IsNullOrWhiteSpace(clientRequestId)
+                ? Guid.NewGuid().ToString("D")
+                : clientRequestId;
+            _isError = isError;
+        }
+
+        /// <inheritdoc />
+        public override int Status => _statusCode;
+
+        /// <inheritdoc />
+        public override string ReasonPhrase => _reasonPhrase;
+
+        /// <inheritdoc />
+        public override Stream? ContentStream
+        {
+            get => _contentStream;
+            set => _contentStream = value;
+        }
+
+        /// <inheritdoc />
+        public override string ClientRequestId
+        {
+            get => _clientRequestId;
+            set => _clientRequestId = value;
+        }
+
+        /// <inheritdoc />
+        public override bool IsError => _isError;
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            _contentStream?.Dispose();
+            _contentStream = null;
+        }
+
+        /// <inheritdoc />
+        protected override bool TryGetHeader(string name, out string value)
+        {
+            ArgumentNullException.ThrowIfNull(name);
+
+            if (_headers.TryGetValue(name, out var values))
+            {
+                value = string.Join(",", values);
+                return true;
+            }
+
+            value = default!;
+            return false;
+        }
+
+        /// <inheritdoc />
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        {
+            ArgumentNullException.ThrowIfNull(name);
+
+            if (_headers.TryGetValue(name, out var storedValues))
+            {
+                values = storedValues;
+                return true;
+            }
+
+            values = default!;
+            return false;
+        }
+
+        /// <inheritdoc />
+        protected override bool ContainsHeader(string name)
+        {
+            ArgumentNullException.ThrowIfNull(name);
+
+            return _headers.ContainsKey(name);
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<HttpHeader> EnumerateHeaders()
+        {
+            foreach (var header in _headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    yield return new HttpHeader(header.Key, value);
+                }
+            }
+        }
+
+        private static IReadOnlyDictionary<string, IReadOnlyList<string>> CreateHeaderLookup(IEnumerable<HttpHeader>? headers)
+        {
+            if (headers is null)
+            {
+                return new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var headerLookup = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in headers)
+            {
+                if (!headerLookup.TryGetValue(header.Name, out var values))
+                {
+                    values = new List<string>();
+                    headerLookup[header.Name] = values;
+                }
+
+                values.Add(header.Value);
+            }
+
+            return headerLookup.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyList<string>) pair.Value.ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/FastMoq.Azure/Pageable/PageableBuilder.cs
+++ b/FastMoq.Azure/Pageable/PageableBuilder.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using Azure;
+
+namespace FastMoq.Azure.Pageable
+{
+    /// <summary>
+    /// Creates synchronous and asynchronous Azure SDK pageable sequences for tests.
+    /// </summary>
+    public static class PageableBuilder
+    {
+        /// <summary>
+        /// Creates a single Azure SDK page with the provided values.
+        /// </summary>
+        /// <typeparam name="T">The value type stored in the page.</typeparam>
+        /// <param name="values">The values to include in the page.</param>
+        /// <param name="continuationToken">The continuation token for the next page, if any.</param>
+        /// <param name="response">The raw response to expose from the page.</param>
+        /// <returns>A single Azure SDK page.</returns>
+        public static Page<T> CreatePage<T>(IReadOnlyList<T> values, string? continuationToken = null, Response? response = null)
+            where T : notnull
+        {
+            ArgumentNullException.ThrowIfNull(values);
+
+            return Page<T>.FromValues(values, continuationToken, response ?? new AzureTestResponse());
+        }
+
+        /// <summary>
+        /// Creates an <see cref="AsyncPageable{T}" /> from explicit pages.
+        /// </summary>
+        /// <typeparam name="T">The value type stored in the pageable sequence.</typeparam>
+        /// <param name="pages">The pages to expose through the sequence.</param>
+        /// <returns>An asynchronous pageable sequence.</returns>
+        public static AsyncPageable<T> CreateAsyncPageable<T>(IEnumerable<Page<T>> pages)
+            where T : notnull
+        {
+            ArgumentNullException.ThrowIfNull(pages);
+
+            return AsyncPageable<T>.FromPages(pages.ToArray());
+        }
+
+        /// <summary>
+        /// Creates an <see cref="AsyncPageable{T}" /> by splitting values into test pages.
+        /// </summary>
+        /// <typeparam name="T">The value type stored in the pageable sequence.</typeparam>
+        /// <param name="values">The values to expose through the sequence.</param>
+        /// <param name="pageSize">The number of values to include per page.</param>
+        /// <param name="response">The raw response to expose from each page.</param>
+        /// <returns>An asynchronous pageable sequence.</returns>
+        public static AsyncPageable<T> CreateAsyncPageable<T>(IEnumerable<T> values, int pageSize = int.MaxValue, Response? response = null)
+            where T : notnull
+        {
+            return CreateAsyncPageable(CreatePages(values, pageSize, response ?? new AzureTestResponse()));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Pageable{T}" /> from explicit pages.
+        /// </summary>
+        /// <typeparam name="T">The value type stored in the pageable sequence.</typeparam>
+        /// <param name="pages">The pages to expose through the sequence.</param>
+        /// <returns>A synchronous pageable sequence.</returns>
+        public static Pageable<T> CreatePageable<T>(IEnumerable<Page<T>> pages)
+            where T : notnull
+        {
+            ArgumentNullException.ThrowIfNull(pages);
+
+            return Pageable<T>.FromPages(pages.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Pageable{T}" /> by splitting values into test pages.
+        /// </summary>
+        /// <typeparam name="T">The value type stored in the pageable sequence.</typeparam>
+        /// <param name="values">The values to expose through the sequence.</param>
+        /// <param name="pageSize">The number of values to include per page.</param>
+        /// <param name="response">The raw response to expose from each page.</param>
+        /// <returns>A synchronous pageable sequence.</returns>
+        public static Pageable<T> CreatePageable<T>(IEnumerable<T> values, int pageSize = int.MaxValue, Response? response = null)
+            where T : notnull
+        {
+            return CreatePageable(CreatePages(values, pageSize, response ?? new AzureTestResponse()));
+        }
+
+        private static IReadOnlyList<Page<T>> CreatePages<T>(IEnumerable<T> values, int pageSize, Response response)
+            where T : notnull
+        {
+            ArgumentNullException.ThrowIfNull(values);
+            ArgumentNullException.ThrowIfNull(response);
+
+            if (pageSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "Page size must be greater than zero.");
+            }
+
+            var bufferedValues = values as IReadOnlyList<T> ?? values.ToArray();
+            if (bufferedValues.Count == 0)
+            {
+                return [CreatePage(Array.Empty<T>(), null, response)];
+            }
+
+            var pages = new List<Page<T>>();
+            for (var index = 0; index < bufferedValues.Count; index += pageSize)
+            {
+                var pageValues = bufferedValues.Skip(index).Take(pageSize).ToArray();
+                var nextIndex = index + pageValues.Length;
+                var continuationToken = nextIndex < bufferedValues.Count
+                    ? nextIndex.ToString(CultureInfo.InvariantCulture)
+                    : null;
+
+                pages.Add(CreatePage(pageValues, continuationToken, response));
+            }
+
+            return pages;
+        }
+    }
+}

--- a/FastMoq.Azure/Storage/AzureStorageClientFactory.cs
+++ b/FastMoq.Azure/Storage/AzureStorageClientFactory.cs
@@ -1,0 +1,264 @@
+using Azure.Core;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+
+namespace FastMoq.Azure.Storage
+{
+    /// <summary>
+    /// Creates Azure Storage SDK clients from a shared connection string or service URI for tests.
+    /// </summary>
+    public sealed class AzureStorageClientFactory
+    {
+        private readonly string _connectionValue;
+        private readonly StorageConnectionMode _connectionMode;
+        private readonly TokenCredential? _credential;
+        private readonly BlobClientOptions _blobClientOptions;
+        private readonly QueueClientOptions _queueClientOptions;
+        private readonly TableClientOptions _tableClientOptions;
+
+        private AzureStorageClientFactory(
+            string connectionValue,
+            StorageConnectionMode connectionMode,
+            TokenCredential? credential,
+            BlobClientOptions? blobClientOptions,
+            QueueClientOptions? queueClientOptions,
+            TableClientOptions? tableClientOptions)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionValue);
+
+            _connectionValue = connectionValue;
+            _connectionMode = connectionMode;
+            _credential = credential;
+            _blobClientOptions = blobClientOptions ?? new BlobClientOptions();
+            _queueClientOptions = queueClientOptions ?? new QueueClientOptions
+            {
+                MessageEncoding = QueueMessageEncoding.Base64,
+            };
+            _tableClientOptions = tableClientOptions ?? new TableClientOptions();
+        }
+
+        /// <summary>
+        /// Gets the original connection string or service URI used to create the factory.
+        /// </summary>
+        public string ConnectionValue => _connectionValue;
+
+        /// <summary>
+        /// Gets a value indicating whether the factory was created from a connection string.
+        /// </summary>
+        public bool UsesConnectionString => _connectionMode == StorageConnectionMode.ConnectionString;
+
+        /// <summary>
+        /// Gets a value indicating whether the factory can create blob clients.
+        /// </summary>
+        public bool SupportsBlobClients => UsesConnectionString || _connectionMode == StorageConnectionMode.BlobServiceUri;
+
+        /// <summary>
+        /// Gets a value indicating whether the factory can create queue clients.
+        /// </summary>
+        public bool SupportsQueueClients => UsesConnectionString || _connectionMode == StorageConnectionMode.QueueServiceUri;
+
+        /// <summary>
+        /// Gets a value indicating whether the factory can create table clients.
+        /// </summary>
+        public bool SupportsTableClients => UsesConnectionString || _connectionMode == StorageConnectionMode.TableServiceUri;
+
+        /// <summary>
+        /// Creates a factory backed by an Azure Storage connection string.
+        /// </summary>
+        /// <param name="connectionString">The Azure Storage connection string.</param>
+        /// <param name="blobClientOptions">Optional blob client options.</param>
+        /// <param name="queueClientOptions">Optional queue client options.</param>
+        /// <param name="tableClientOptions">Optional table client options.</param>
+        /// <returns>A storage client factory backed by a connection string.</returns>
+        public static AzureStorageClientFactory FromConnectionString(
+            string connectionString,
+            BlobClientOptions? blobClientOptions = null,
+            QueueClientOptions? queueClientOptions = null,
+            TableClientOptions? tableClientOptions = null)
+        {
+            return new AzureStorageClientFactory(
+                connectionString,
+                StorageConnectionMode.ConnectionString,
+                credential: null,
+                blobClientOptions,
+                queueClientOptions,
+                tableClientOptions);
+        }
+
+        /// <summary>
+        /// Creates a factory backed by a blob service URI.
+        /// </summary>
+        /// <param name="blobServiceUri">The blob service URI.</param>
+        /// <param name="credential">The credential used to create blob clients.</param>
+        /// <param name="blobClientOptions">Optional blob client options.</param>
+        /// <returns>A storage client factory backed by a blob service URI.</returns>
+        public static AzureStorageClientFactory FromBlobServiceUri(string blobServiceUri, TokenCredential credential, BlobClientOptions? blobClientOptions = null)
+        {
+            ArgumentNullException.ThrowIfNull(credential);
+
+            return new AzureStorageClientFactory(
+                blobServiceUri,
+                StorageConnectionMode.BlobServiceUri,
+                credential,
+                blobClientOptions,
+                queueClientOptions: null,
+                tableClientOptions: null);
+        }
+
+        /// <summary>
+        /// Creates a factory backed by a queue service URI.
+        /// </summary>
+        /// <param name="queueServiceUri">The queue service URI.</param>
+        /// <param name="credential">The credential used to create queue clients.</param>
+        /// <param name="queueClientOptions">Optional queue client options.</param>
+        /// <returns>A storage client factory backed by a queue service URI.</returns>
+        public static AzureStorageClientFactory FromQueueServiceUri(string queueServiceUri, TokenCredential credential, QueueClientOptions? queueClientOptions = null)
+        {
+            ArgumentNullException.ThrowIfNull(credential);
+
+            return new AzureStorageClientFactory(
+                queueServiceUri,
+                StorageConnectionMode.QueueServiceUri,
+                credential,
+                blobClientOptions: null,
+                queueClientOptions,
+                tableClientOptions: null);
+        }
+
+        /// <summary>
+        /// Creates a factory backed by a table service URI.
+        /// </summary>
+        /// <param name="tableServiceUri">The table service URI.</param>
+        /// <param name="credential">The credential used to create table clients.</param>
+        /// <param name="tableClientOptions">Optional table client options.</param>
+        /// <returns>A storage client factory backed by a table service URI.</returns>
+        public static AzureStorageClientFactory FromTableServiceUri(string tableServiceUri, TokenCredential credential, TableClientOptions? tableClientOptions = null)
+        {
+            ArgumentNullException.ThrowIfNull(credential);
+
+            return new AzureStorageClientFactory(
+                tableServiceUri,
+                StorageConnectionMode.TableServiceUri,
+                credential,
+                blobClientOptions: null,
+                queueClientOptions: null,
+                tableClientOptions);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BlobContainerClient" />.
+        /// </summary>
+        /// <param name="containerName">The blob container name.</param>
+        /// <returns>A blob container client.</returns>
+        public BlobContainerClient CreateBlobContainerClient(string containerName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+            EnsureBlobSupport();
+
+            if (UsesConnectionString)
+            {
+                return new BlobContainerClient(_connectionValue, containerName, _blobClientOptions);
+            }
+
+            return new BlobContainerClient(CreateServiceUri(containerName), _credential!, _blobClientOptions);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="BlobClient" />.
+        /// </summary>
+        /// <param name="containerName">The blob container name.</param>
+        /// <param name="blobName">The blob name.</param>
+        /// <returns>A blob client.</returns>
+        public BlobClient CreateBlobClient(string containerName, string blobName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+            EnsureBlobSupport();
+
+            if (UsesConnectionString)
+            {
+                return new BlobClient(_connectionValue, containerName, blobName, _blobClientOptions);
+            }
+
+            return new BlobClient(CreateServiceUri(containerName, blobName), _credential!, _blobClientOptions);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="QueueClient" />.
+        /// </summary>
+        /// <param name="queueName">The queue name.</param>
+        /// <returns>A queue client.</returns>
+        public QueueClient CreateQueueClient(string queueName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+            EnsureQueueSupport();
+
+            if (UsesConnectionString)
+            {
+                return new QueueClient(_connectionValue, queueName, _queueClientOptions);
+            }
+
+            return new QueueClient(CreateServiceUri(queueName), _credential!, _queueClientOptions);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="TableClient" />.
+        /// </summary>
+        /// <param name="tableName">The table name.</param>
+        /// <returns>A table client.</returns>
+        public TableClient CreateTableClient(string tableName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+            EnsureTableSupport();
+
+            if (UsesConnectionString)
+            {
+                return new TableClient(_connectionValue, tableName, _tableClientOptions);
+            }
+
+            return new TableClient(new Uri(_connectionValue, UriKind.Absolute), tableName, _credential!, _tableClientOptions);
+        }
+
+        private Uri CreateServiceUri(params string[] segments)
+        {
+            var baseUri = _connectionValue.EndsWith("/", StringComparison.Ordinal)
+                ? new Uri(_connectionValue, UriKind.Absolute)
+                : new Uri(_connectionValue + "/", UriKind.Absolute);
+            var relativePath = string.Join("/", segments.Select(segment => segment.Trim('/')));
+            return new Uri(baseUri, relativePath);
+        }
+
+        private void EnsureBlobSupport()
+        {
+            if (!SupportsBlobClients)
+            {
+                throw new InvalidOperationException("This storage factory was not created for blob clients. Use FromBlobServiceUri(...) or FromConnectionString(...).");
+            }
+        }
+
+        private void EnsureQueueSupport()
+        {
+            if (!SupportsQueueClients)
+            {
+                throw new InvalidOperationException("This storage factory was not created for queue clients. Use FromQueueServiceUri(...) or FromConnectionString(...).");
+            }
+        }
+
+        private void EnsureTableSupport()
+        {
+            if (!SupportsTableClients)
+            {
+                throw new InvalidOperationException("This storage factory was not created for table clients. Use FromTableServiceUri(...) or FromConnectionString(...).");
+            }
+        }
+
+        private enum StorageConnectionMode
+        {
+            ConnectionString,
+            BlobServiceUri,
+            QueueServiceUri,
+            TableServiceUri,
+        }
+    }
+}

--- a/FastMoq.Azure/Storage/StorageClientTestExtensions.cs
+++ b/FastMoq.Azure/Storage/StorageClientTestExtensions.cs
@@ -12,6 +12,35 @@ namespace FastMoq.Azure.Storage
     public static class StorageClientTestExtensions
     {
         /// <summary>
+        /// Registers an <see cref="AzureStorageClientFactory" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="storageClientFactory">The storage client factory to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddAzureStorageClientFactory(this IServiceCollection services, AzureStorageClientFactory storageClientFactory)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return services.AddAzureClient(storageClientFactory);
+        }
+
+        /// <summary>
+        /// Registers an <see cref="AzureStorageClientFactory" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="storageClientFactory">The storage client factory to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddAzureStorageClientFactory(this Mocker mocker, AzureStorageClientFactory storageClientFactory, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return mocker.AddAzureClient(storageClientFactory, replace);
+        }
+
+        /// <summary>
         /// Registers a <see cref="TableClient" /> singleton in the supplied service collection.
         /// </summary>
         /// <param name="services">The service collection to update.</param>
@@ -81,6 +110,132 @@ namespace FastMoq.Azure.Storage
             ArgumentNullException.ThrowIfNull(blobClient);
 
             return services.AddAzureClient(blobClient);
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="TableClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddTableClient(this IServiceCollection services, AzureStorageClientFactory storageClientFactory, string tableName)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return services.AddTableClient(storageClientFactory.CreateTableClient(tableName));
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="TableClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddTableClient(this Mocker mocker, AzureStorageClientFactory storageClientFactory, string tableName, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return mocker.AddTableClient(storageClientFactory.CreateTableClient(tableName), replace);
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="BlobContainerClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="containerName">The container name.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddBlobContainerClient(this IServiceCollection services, AzureStorageClientFactory storageClientFactory, string containerName)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return services.AddBlobContainerClient(storageClientFactory.CreateBlobContainerClient(containerName));
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="BlobContainerClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="containerName">The container name.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddBlobContainerClient(this Mocker mocker, AzureStorageClientFactory storageClientFactory, string containerName, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return mocker.AddBlobContainerClient(storageClientFactory.CreateBlobContainerClient(containerName), replace);
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="BlobClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="containerName">The container name.</param>
+        /// <param name="blobName">The blob name.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddBlobClient(this IServiceCollection services, AzureStorageClientFactory storageClientFactory, string containerName, string blobName)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return services.AddBlobClient(storageClientFactory.CreateBlobClient(containerName, blobName));
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="BlobClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="containerName">The container name.</param>
+        /// <param name="blobName">The blob name.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddBlobClient(this Mocker mocker, AzureStorageClientFactory storageClientFactory, string containerName, string blobName, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return mocker.AddBlobClient(storageClientFactory.CreateBlobClient(containerName, blobName), replace);
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="QueueClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="queueName">The queue name.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddQueueClient(this IServiceCollection services, AzureStorageClientFactory storageClientFactory, string queueName)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return services.AddQueueClient(storageClientFactory.CreateQueueClient(queueName));
+        }
+
+        /// <summary>
+        /// Creates and registers a <see cref="QueueClient" /> from the supplied <see cref="AzureStorageClientFactory" />.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="storageClientFactory">The storage client factory to use.</param>
+        /// <param name="queueName">The queue name.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddQueueClient(this Mocker mocker, AzureStorageClientFactory storageClientFactory, string queueName, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(storageClientFactory);
+
+            return mocker.AddQueueClient(storageClientFactory.CreateQueueClient(queueName), replace);
         }
 
         /// <summary>

--- a/FastMoq.Azure/Storage/StorageClientTestExtensions.cs
+++ b/FastMoq.Azure/Storage/StorageClientTestExtensions.cs
@@ -1,0 +1,130 @@
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+using FastMoq.Azure.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastMoq.Azure.Storage
+{
+    /// <summary>
+    /// Provides common Azure Storage client registration helpers for tests.
+    /// </summary>
+    public static class StorageClientTestExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="TableClient" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="tableClient">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddTableClient(this IServiceCollection services, TableClient tableClient)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(tableClient);
+
+            return services.AddAzureClient(tableClient);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="TableClient" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="tableClient">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddTableClient(this Mocker mocker, TableClient tableClient, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(tableClient);
+
+            return mocker.AddAzureClient(tableClient, replace);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobContainerClient" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="blobContainerClient">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddBlobContainerClient(this IServiceCollection services, BlobContainerClient blobContainerClient)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(blobContainerClient);
+
+            return services.AddAzureClient(blobContainerClient);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobContainerClient" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="blobContainerClient">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddBlobContainerClient(this Mocker mocker, BlobContainerClient blobContainerClient, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(blobContainerClient);
+
+            return mocker.AddAzureClient(blobContainerClient, replace);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobClient" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="blobClient">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddBlobClient(this IServiceCollection services, BlobClient blobClient)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(blobClient);
+
+            return services.AddAzureClient(blobClient);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobClient" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="blobClient">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddBlobClient(this Mocker mocker, BlobClient blobClient, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(blobClient);
+
+            return mocker.AddAzureClient(blobClient, replace);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="QueueClient" /> singleton in the supplied service collection.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="queueClient">The client instance to register.</param>
+        /// <returns>The current <see cref="IServiceCollection" /> instance.</returns>
+        public static IServiceCollection AddQueueClient(this IServiceCollection services, QueueClient queueClient)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(queueClient);
+
+            return services.AddAzureClient(queueClient);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="QueueClient" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="queueClient">The client instance to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddQueueClient(this Mocker mocker, QueueClient queueClient, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(queueClient);
+
+            return mocker.AddAzureClient(queueClient, replace);
+        }
+    }
+}

--- a/FastMoq.Tests/Azure/AzureHelperTests.cs
+++ b/FastMoq.Tests/Azure/AzureHelperTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Azure.Storage.Blobs;
+using FastMoq;
+using FastMoq.Azure.Credentials;
+using FastMoq.Azure.DependencyInjection;
+using FastMoq.Azure.KeyVault;
+using FastMoq.Azure.Pageable;
+using FastMoq.Azure.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace FastMoq.Tests.Azure
+{
+    public class AzureHelperTests
+    {
+        [Fact]
+        public async Task CreateAsyncPageable_ShouldYieldAllValuesAndPreserveResponses()
+        {
+            var response = new AzureTestResponse(
+                status: 206,
+                headers:
+                [
+                    new HttpHeader("x-ms-request-id", "req-123"),
+                ]);
+            var pageable = PageableBuilder.CreateAsyncPageable(new[] { "one", "two", "three" }, pageSize: 2, response);
+
+            var values = new List<string>();
+            await foreach (var value in pageable)
+            {
+                values.Add(value);
+            }
+
+            var pages = new List<Page<string>>();
+            await foreach (var page in pageable.AsPages())
+            {
+                pages.Add(page);
+            }
+
+            values.Should().Equal("one", "two", "three");
+            pages.Should().HaveCount(2);
+            pages[0].ContinuationToken.Should().Be("2");
+            pages[1].ContinuationToken.Should().BeNull();
+            pages[0].GetRawResponse().Status.Should().Be(206);
+            pages[0].GetRawResponse().Headers.TryGetValue("x-ms-request-id", out var requestId).Should().BeTrue();
+            requestId.Should().Be("req-123");
+        }
+
+        [Fact]
+        public void CreatePageable_ShouldSupportExplicitPages()
+        {
+            var firstPage = PageableBuilder.CreatePage(new[] { 1, 2 }, continuationToken: "2");
+            var secondPage = PageableBuilder.CreatePage(new[] { 3 });
+
+            var pageable = PageableBuilder.CreatePageable(new[] { firstPage, secondPage });
+
+            pageable.Should().Equal(1, 2, 3);
+            pageable.AsPages().Select(page => page.ContinuationToken).Should().Equal("2", null);
+        }
+
+        [Fact]
+        public void AddTokenCredential_ShouldRegisterFixedCredential()
+        {
+            var mocker = new Mocker();
+
+            mocker.AddTokenCredential("token-value");
+
+            var credential = mocker.GetObject<TokenCredential>();
+            var accessToken = credential.GetToken(new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), CancellationToken.None);
+
+            accessToken.Token.Should().Be("token-value");
+        }
+
+        [Fact]
+        public void AddDefaultAzureCredential_ShouldExposeConcreteAndAbstractCredentialRegistrations()
+        {
+            var mocker = new Mocker();
+
+            mocker.AddDefaultAzureCredential("default-token");
+
+            var defaultCredential = mocker.GetObject<DefaultAzureCredential>();
+            var tokenCredential = mocker.GetObject<TokenCredential>();
+            var accessToken = defaultCredential.GetToken(new TokenRequestContext(new[] { "scope" }), CancellationToken.None);
+
+            tokenCredential.Should().BeSameAs(defaultCredential);
+            accessToken.Token.Should().Be("default-token");
+        }
+
+        [Fact]
+        public void CreateAzureServiceProvider_ShouldRegisterConfigurationLoggingAndClients()
+        {
+            var mocker = new Mocker();
+            var endpoint = new Uri("https://fastmoq-test.vault.azure.net/");
+            var secretClient = new SecretClient(endpoint, new TestTokenCredential("secret-token"));
+
+            var provider = mocker.CreateAzureServiceProvider(
+                services => services.AddSecretClient(secretClient),
+                new Dictionary<string, string?>
+                {
+                    ["Azure:KeyVault:Endpoint"] = endpoint.ToString(),
+                });
+
+            provider.GetRequiredService<ILoggerFactory>().Should().NotBeNull();
+            provider.GetRequiredService<IConfiguration>()["Azure:KeyVault:Endpoint"].Should().Be(endpoint.ToString());
+            provider.GetRequiredService<IConfigurationRoot>().Should().NotBeNull();
+            provider.GetRequiredService<SecretClient>().Should().BeSameAs(secretClient);
+        }
+
+        [Fact]
+        public void AddAzureServiceProvider_ShouldRegisterProviderAndConfigurationOnMocker()
+        {
+            var mocker = new Mocker();
+            var provider = mocker.CreateAzureServiceProvider(
+                configurationValues: new Dictionary<string, string?>
+                {
+                    ["Azure:Storage:QueueName"] = "jobs",
+                });
+
+            mocker.AddAzureServiceProvider(provider);
+
+            mocker.GetObject<IServiceProvider>().Should().BeSameAs(provider);
+            mocker.GetObject<IConfiguration>()["Azure:Storage:QueueName"].Should().Be("jobs");
+            mocker.GetObject<IConfigurationRoot>().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ClientRegistrationHelpers_ShouldRegisterKeyVaultAndStorageClients()
+        {
+            var mocker = new Mocker();
+            var secretClient = new SecretClient(new Uri("https://fastmoq-test.vault.azure.net/"), new TestTokenCredential("secret-token"));
+            var blobContainerClient = new BlobContainerClient(new Uri("https://fastmoqstorage.blob.core.windows.net/orders"));
+            var services = new ServiceCollection();
+
+            mocker.AddSecretClient(secretClient);
+            mocker.AddBlobContainerClient(blobContainerClient);
+            services.AddSecretClient(secretClient);
+            services.AddBlobContainerClient(blobContainerClient);
+
+            var provider = services.BuildServiceProvider();
+
+            mocker.GetObject<SecretClient>().Should().BeSameAs(secretClient);
+            mocker.GetObject<BlobContainerClient>().Should().BeSameAs(blobContainerClient);
+            provider.GetRequiredService<SecretClient>().Should().BeSameAs(secretClient);
+            provider.GetRequiredService<BlobContainerClient>().Should().BeSameAs(blobContainerClient);
+        }
+    }
+}

--- a/FastMoq.Tests/Azure/AzureHelperTests.cs
+++ b/FastMoq.Tests/Azure/AzureHelperTests.cs
@@ -7,7 +7,9 @@ using Azure;
 using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using Azure.Data.Tables;
 using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
 using FastMoq;
 using FastMoq.Azure.Credentials;
 using FastMoq.Azure.DependencyInjection;
@@ -73,7 +75,7 @@ namespace FastMoq.Tests.Azure
 
             mocker.AddTokenCredential("token-value");
 
-            var credential = mocker.GetObject<TokenCredential>();
+            var credential = mocker.GetRequiredObject<TokenCredential>();
             var accessToken = credential.GetToken(new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), CancellationToken.None);
 
             accessToken.Token.Should().Be("token-value");
@@ -86,8 +88,8 @@ namespace FastMoq.Tests.Azure
 
             mocker.AddDefaultAzureCredential("default-token");
 
-            var defaultCredential = mocker.GetObject<DefaultAzureCredential>();
-            var tokenCredential = mocker.GetObject<TokenCredential>();
+            var defaultCredential = mocker.GetRequiredObject<DefaultAzureCredential>();
+            var tokenCredential = mocker.GetRequiredObject<TokenCredential>();
             var accessToken = defaultCredential.GetToken(new TokenRequestContext(new[] { "scope" }), CancellationToken.None);
 
             tokenCredential.Should().BeSameAs(defaultCredential);
@@ -126,9 +128,9 @@ namespace FastMoq.Tests.Azure
 
             mocker.AddAzureServiceProvider(provider);
 
-            mocker.GetObject<IServiceProvider>().Should().BeSameAs(provider);
-            mocker.GetObject<IConfiguration>()["Azure:Storage:QueueName"].Should().Be("jobs");
-            mocker.GetObject<IConfigurationRoot>().Should().NotBeNull();
+            mocker.GetRequiredObject<IServiceProvider>().Should().BeSameAs(provider);
+            mocker.GetRequiredObject<IConfiguration>()["Azure:Storage:QueueName"].Should().Be("jobs");
+            mocker.GetRequiredObject<IConfigurationRoot>().Should().NotBeNull();
         }
 
         [Fact]
@@ -146,10 +148,77 @@ namespace FastMoq.Tests.Azure
 
             var provider = services.BuildServiceProvider();
 
-            mocker.GetObject<SecretClient>().Should().BeSameAs(secretClient);
-            mocker.GetObject<BlobContainerClient>().Should().BeSameAs(blobContainerClient);
+            mocker.GetRequiredObject<SecretClient>().Should().BeSameAs(secretClient);
+            mocker.GetRequiredObject<BlobContainerClient>().Should().BeSameAs(blobContainerClient);
             provider.GetRequiredService<SecretClient>().Should().BeSameAs(secretClient);
             provider.GetRequiredService<BlobContainerClient>().Should().BeSameAs(blobContainerClient);
+        }
+
+        [Fact]
+        public void AzureStorageClientFactory_ShouldCreateClientsFromConnectionString()
+        {
+            var factory = AzureStorageClientFactory.FromConnectionString("UseDevelopmentStorage=true");
+
+            var blobContainerClient = factory.CreateBlobContainerClient("orders");
+            var blobClient = factory.CreateBlobClient("orders", "payloads/order.json");
+            var queueClient = factory.CreateQueueClient("jobs");
+            var tableClient = factory.CreateTableClient("status");
+
+            factory.UsesConnectionString.Should().BeTrue();
+            factory.SupportsBlobClients.Should().BeTrue();
+            factory.SupportsQueueClients.Should().BeTrue();
+            factory.SupportsTableClients.Should().BeTrue();
+            blobContainerClient.Uri.AbsoluteUri.Should().Contain("/orders");
+            blobClient.Uri.AbsoluteUri.Should().Contain("/orders/payloads/order.json");
+            queueClient.Uri.AbsoluteUri.Should().Contain("/jobs");
+            tableClient.Uri.AbsoluteUri.Should().Contain("/status");
+        }
+
+        [Fact]
+        public void AzureStorageClientFactory_ShouldCreateClientsFromServiceUris()
+        {
+            var credential = new TestTokenCredential("storage-token");
+            var blobFactory = AzureStorageClientFactory.FromBlobServiceUri("https://fastmoqstorage.blob.core.windows.net", credential);
+            var queueFactory = AzureStorageClientFactory.FromQueueServiceUri("https://fastmoqstorage.queue.core.windows.net", credential);
+            var tableFactory = AzureStorageClientFactory.FromTableServiceUri("https://fastmoqstorage.table.core.windows.net", credential);
+
+            blobFactory.CreateBlobContainerClient("orders").Uri.Should().Be(new Uri("https://fastmoqstorage.blob.core.windows.net/orders"));
+            blobFactory.CreateBlobClient("orders", "payload.json").Uri.Should().Be(new Uri("https://fastmoqstorage.blob.core.windows.net/orders/payload.json"));
+            queueFactory.CreateQueueClient("jobs").Uri.Should().Be(new Uri("https://fastmoqstorage.queue.core.windows.net/jobs"));
+            tableFactory.CreateTableClient("status").Uri.Should().Be(new Uri("https://fastmoqstorage.table.core.windows.net/status"));
+
+            Action invalidQueueCreate = () => blobFactory.CreateQueueClient("jobs");
+            invalidQueueCreate.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void AzureStorageClientFactoryRegistrationHelpers_ShouldRegisterFactoryAndDerivedClients()
+        {
+            var mocker = new Mocker();
+            var factory = AzureStorageClientFactory.FromConnectionString("UseDevelopmentStorage=true");
+            var services = new ServiceCollection();
+
+            mocker.AddAzureStorageClientFactory(factory);
+            mocker.AddBlobContainerClient(factory, "orders");
+            mocker.AddQueueClient(factory, "jobs");
+            mocker.AddTableClient(factory, "status");
+
+            services.AddAzureStorageClientFactory(factory);
+            services.AddBlobContainerClient(factory, "orders");
+            services.AddQueueClient(factory, "jobs");
+            services.AddTableClient(factory, "status");
+
+            var provider = services.BuildServiceProvider();
+
+            mocker.GetRequiredObject<AzureStorageClientFactory>().Should().BeSameAs(factory);
+            mocker.GetRequiredObject<BlobContainerClient>().Uri.AbsoluteUri.Should().Contain("/orders");
+            mocker.GetRequiredObject<QueueClient>().Uri.AbsoluteUri.Should().Contain("/jobs");
+            mocker.GetRequiredObject<TableClient>().Uri.AbsoluteUri.Should().Contain("/status");
+
+            provider.GetRequiredService<AzureStorageClientFactory>().Should().BeSameAs(factory);
+            provider.GetRequiredService<BlobContainerClient>().Uri.AbsoluteUri.Should().Contain("/orders");
+            provider.GetRequiredService<QueueClient>().Uri.AbsoluteUri.Should().Contain("/jobs");
+            provider.GetRequiredService<TableClient>().Uri.AbsoluteUri.Should().Contain("/status");
         }
     }
 }

--- a/FastMoq.Tests/FastMoq.Tests.csproj
+++ b/FastMoq.Tests/FastMoq.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FastMoq.Azure\FastMoq.Azure.csproj" />
     <ProjectReference Include="..\FastMoq.AzureFunctions\FastMoq.AzureFunctions.csproj" />
     <ProjectReference Include="..\FastMoq.Core\FastMoq.Core.csproj" />
     <ProjectReference Include="..\FastMoq.Database\FastMoq.Database.csproj" />

--- a/FastMoq.code-workspace
+++ b/FastMoq.code-workspace
@@ -1,0 +1,94 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": ".config"
+		},
+		{
+			"path": ".gdn"
+		},
+		{
+			"path": ".git"
+		},
+		{
+			"path": ".github"
+		},
+		{
+			"path": ".vs"
+		},
+		{
+			"path": ".vscode"
+		},
+		{
+			"path": "api"
+		},
+		{
+			"path": "artifacts-local"
+		},
+		{
+			"path": "docfx-template"
+		},
+		{
+			"path": "docs"
+		},
+		{
+			"path": "FastMoq"
+		},
+		{
+			"path": "FastMoq.Abstractions"
+		},
+		{
+			"path": "FastMoq.Analyzers"
+		},
+		{
+			"path": "FastMoq.Analyzers.Tests"
+		},
+		{
+			"path": "FastMoq.Core"
+		},
+		{
+			"path": "FastMoq.Database"
+		},
+		{
+			"path": "FastMoq.Provider.Moq"
+		},
+		{
+			"path": "FastMoq.Provider.NSubstitute"
+		},
+		{
+			"path": "FastMoq.TestingExample"
+		},
+		{
+			"path": "FastMoq.Tests"
+		},
+		{
+			"path": "FastMoq.Tests.Blazor"
+		},
+		{
+			"path": "FastMoq.Tests.Web"
+		},
+		{
+			"path": "FastMoq.Web"
+		},
+		{
+			"path": "Help"
+		},
+		{
+			"path": "scripts"
+		},
+		{
+			"path": "test"
+		},
+		{
+			"path": "TestResults"
+		},
+		{
+			"path": "FastMoq.AzureFunctions"
+		},
+		{
+			"path": "FastMoq.Azure"
+		}
+	]
+}

--- a/FastMoq.sln
+++ b/FastMoq.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Tests", "FastMoq.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.TestingExample", "FastMoq.TestingExample\FastMoq.TestingExample.csproj", "{DF4B6B46-3071-4598-88AF-237F717269E7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Azure", "FastMoq.Azure\FastMoq.Azure.csproj", "{CADD0874-D3E6-40B3-A8D5-EB04047597EC}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Core", "FastMoq.Core\FastMoq.Core.csproj", "{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FastMoq.Abstractions", "FastMoq.Abstractions\FastMoq.Abstractions.csproj", "{B9131B12-63E3-4E14-B7D9-3CB808FB0C0F}"
@@ -53,6 +55,10 @@ Global
 		{DF4B6B46-3071-4598-88AF-237F717269E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF4B6B46-3071-4598-88AF-237F717269E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF4B6B46-3071-4598-88AF-237F717269E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CADD0874-D3E6-40B3-A8D5-EB04047597EC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E2FC5C0-5B64-48BA-92F6-DF0DD46298E0}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/FastMoq/FastMoq.csproj
+++ b/FastMoq/FastMoq.csproj
@@ -39,6 +39,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FastMoq.Analyzers\FastMoq.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\FastMoq.Abstractions\FastMoq.Abstractions.csproj" />
+    <ProjectReference Include="..\FastMoq.Azure\FastMoq.Azure.csproj" />
     <ProjectReference Include="..\FastMoq.AzureFunctions\FastMoq.AzureFunctions.csproj" />
     <ProjectReference Include="..\FastMoq.Core\FastMoq.Core.csproj" />
     <ProjectReference Include="..\FastMoq.Database\FastMoq.Database.csproj" />

--- a/FastMoq/packages.lock.json
+++ b/FastMoq/packages.lock.json
@@ -24,14 +24,13 @@
           "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
-      "Azure.Core": {
+      "Azure.Storage.Common": {
         "type": "Transitive",
-        "resolved": "1.44.1",
-        "contentHash": "YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+        "resolved": "12.23.0",
+        "contentHash": "X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.ClientModel": "1.1.0",
-          "System.Memory.Data": "6.0.0"
+          "Azure.Core": "1.44.1",
+          "System.IO.Hashing": "6.0.0"
         }
       },
       "Castle.Core": {
@@ -186,8 +185,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
@@ -238,15 +237,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
           "Microsoft.Extensions.Options": "10.0.5",
           "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -316,14 +306,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -430,16 +412,6 @@
         "resolved": "10.0.0",
         "contentHash": "+gopxHC5+vWE61Qq2i+aFblxjSiS4UyjUG5kpfXodWbeBVwXPeP66s8uAi0LPAwnhS5jInmYJNRFYUMn+sdtKg=="
       },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -509,15 +481,6 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -544,6 +507,28 @@
           "Microsoft.Extensions.Options": "10.0.0"
         }
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "SgvSBcMRvmEEyV10pcvxNVUbwYoShmj/9pxXFVr3AFjE26IUzuwYLtLgt58xkEnT0xJBjfObaXxcol3BMtmEAg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "PGOHaoQhKBKnXy1kfW+Gu9/rxStKsqR+UZKeVv4XAsATdzmfj9y9kkUOftIjVFvxP3oh2Sk7v65ylS0K/qYADA==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.71.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "xuR8E4Rd96M41CnUSCiOJ2DBh+z+zQSmyrYHdYhD6K4fXBcQGVnRCFQ0efROUYpP+p0zC1BLKr0JRpVuujTZSg=="
+      },
       "Microsoft.JSInterop": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -559,10 +544,11 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
         "dependencies": {
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
         }
       },
       "System.Diagnostics.EventLog": {
@@ -570,10 +556,15 @@
         "resolved": "10.0.0",
         "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
-      "System.Memory.Data": {
+      "System.IO.Hashing": {
         "type": "Transitive",
         "resolved": "6.0.0",
-        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ=="
+        "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -595,6 +586,22 @@
       },
       "fastmoq.abstractions": {
         "type": "Project"
+      },
+      "fastmoq.azure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "[1.50.0, )",
+          "Azure.Data.Tables": "[12.11.0, )",
+          "Azure.Identity": "[1.14.0, )",
+          "Azure.Security.KeyVault.Secrets": "[4.7.0, )",
+          "Azure.Storage.Blobs": "[12.24.0, )",
+          "Azure.Storage.Queues": "[12.22.0, )",
+          "FastMoq.Core": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration": "[9.0.5, )",
+          "Microsoft.Extensions.DependencyInjection": "[9.0.5, )",
+          "Microsoft.Extensions.Logging": "[9.0.5, )",
+          "Microsoft.Extensions.Options": "[9.0.5, )"
+        }
       },
       "fastmoq.azurefunctions": {
         "type": "Project",
@@ -641,6 +648,65 @@
           "bunit": "[2.7.2, )"
         }
       },
+      "Azure.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.50.0, )",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Azure.Data.Tables": {
+        "type": "CentralTransitive",
+        "requested": "[12.11.0, )",
+        "resolved": "12.11.0",
+        "contentHash": "MabH2HegMvZA1ocaMhEfW/idyTa3CoH64s43/V9/KFRGdVqEj0EETvd3ItDe6Bbs2teiR40KE9Kz9NLDc5DJJw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "xQ6mpNhifb8W/KG2BclhbJWAupvE3JF8lPEBF8t59Q5sc1yN0Ci+dvS0qXtc6m9auxwYpmc8rhOmK541dcGwmA==",
+        "dependencies": {
+          "Azure.Core": "1.46.1",
+          "Microsoft.Identity.Client": "4.71.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.71.1"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "uOPCojkm41V4dKTORyGzl3/f/lriKpxSQ43fWDn4StRJBVmbF1F/DNWJhwm207kCnqgE/W9+tskJSimIKHCZkw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.24.0, )",
+        "resolved": "12.24.0",
+        "contentHash": "0SWiMtEYcemn5U69BqVPdqGDwcbl+lsF9L3WFPpqk1Db5g+ytr3L3GmUxMbvvdPNuFwTf03kKtWJpW/qW33T8A==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0"
+        }
+      },
+      "Azure.Storage.Queues": {
+        "type": "CentralTransitive",
+        "requested": "[12.22.0, )",
+        "resolved": "12.22.0",
+        "contentHash": "HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
+        }
+      },
       "bunit": {
         "type": "CentralTransitive",
         "requested": "[2.7.2, )",
@@ -669,6 +735,46 @@
         "dependencies": {
           "Microsoft.Azure.Functions.Worker.Core": "2.51.0",
           "Microsoft.Azure.Functions.Worker.Grpc": "2.51.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
       "Moq": {
@@ -739,14 +845,13 @@
           "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
-      "Azure.Core": {
+      "Azure.Storage.Common": {
         "type": "Transitive",
-        "resolved": "1.44.1",
-        "contentHash": "YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+        "resolved": "12.23.0",
+        "contentHash": "X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.ClientModel": "1.1.0",
-          "System.Memory.Data": "6.0.0"
+          "Azure.Core": "1.44.1",
+          "System.IO.Hashing": "6.0.0"
         }
       },
       "Castle.Core": {
@@ -900,8 +1005,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
@@ -950,15 +1055,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -1029,14 +1125,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1144,16 +1232,6 @@
         "resolved": "8.0.22",
         "contentHash": "8cpr20qkP74aNODW+78wcPmAg/RbMR+So1mGcLkJTrLGCJ7LJPOF6nngvUg6VOS050op7FruMFJm/9PuxWm9oQ=="
       },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -1226,15 +1304,6 @@
           "System.Text.Json": "10.0.0"
         }
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -1252,6 +1321,28 @@
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "SgvSBcMRvmEEyV10pcvxNVUbwYoShmj/9pxXFVr3AFjE26IUzuwYLtLgt58xkEnT0xJBjfObaXxcol3BMtmEAg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "PGOHaoQhKBKnXy1kfW+Gu9/rxStKsqR+UZKeVv4XAsATdzmfj9y9kkUOftIjVFvxP3oh2Sk7v65ylS0K/qYADA==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.71.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "xuR8E4Rd96M41CnUSCiOJ2DBh+z+zQSmyrYHdYhD6K4fXBcQGVnRCFQ0efROUYpP+p0zC1BLKr0JRpVuujTZSg=="
+      },
       "Microsoft.JSInterop": {
         "type": "Transitive",
         "resolved": "8.0.22",
@@ -1267,10 +1358,11 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
         "dependencies": {
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
         }
       },
       "System.Diagnostics.DiagnosticSource": {
@@ -1283,6 +1375,11 @@
         "resolved": "10.0.0",
         "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -1290,8 +1387,8 @@
       },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ=="
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -1318,6 +1415,22 @@
       },
       "fastmoq.abstractions": {
         "type": "Project"
+      },
+      "fastmoq.azure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "[1.50.0, )",
+          "Azure.Data.Tables": "[12.11.0, )",
+          "Azure.Identity": "[1.14.0, )",
+          "Azure.Security.KeyVault.Secrets": "[4.7.0, )",
+          "Azure.Storage.Blobs": "[12.24.0, )",
+          "Azure.Storage.Queues": "[12.22.0, )",
+          "FastMoq.Core": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration": "[9.0.5, )",
+          "Microsoft.Extensions.DependencyInjection": "[9.0.5, )",
+          "Microsoft.Extensions.Logging": "[9.0.5, )",
+          "Microsoft.Extensions.Options": "[9.0.5, )"
+        }
       },
       "fastmoq.azurefunctions": {
         "type": "Project",
@@ -1365,6 +1478,65 @@
           "bunit": "[2.7.2, )"
         }
       },
+      "Azure.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.50.0, )",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Azure.Data.Tables": {
+        "type": "CentralTransitive",
+        "requested": "[12.11.0, )",
+        "resolved": "12.11.0",
+        "contentHash": "MabH2HegMvZA1ocaMhEfW/idyTa3CoH64s43/V9/KFRGdVqEj0EETvd3ItDe6Bbs2teiR40KE9Kz9NLDc5DJJw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "xQ6mpNhifb8W/KG2BclhbJWAupvE3JF8lPEBF8t59Q5sc1yN0Ci+dvS0qXtc6m9auxwYpmc8rhOmK541dcGwmA==",
+        "dependencies": {
+          "Azure.Core": "1.46.1",
+          "Microsoft.Identity.Client": "4.71.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.71.1"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "uOPCojkm41V4dKTORyGzl3/f/lriKpxSQ43fWDn4StRJBVmbF1F/DNWJhwm207kCnqgE/W9+tskJSimIKHCZkw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.24.0, )",
+        "resolved": "12.24.0",
+        "contentHash": "0SWiMtEYcemn5U69BqVPdqGDwcbl+lsF9L3WFPpqk1Db5g+ytr3L3GmUxMbvvdPNuFwTf03kKtWJpW/qW33T8A==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0"
+        }
+      },
+      "Azure.Storage.Queues": {
+        "type": "CentralTransitive",
+        "requested": "[12.22.0, )",
+        "resolved": "12.22.0",
+        "contentHash": "HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
+        }
+      },
       "bunit": {
         "type": "CentralTransitive",
         "requested": "[2.7.2, )",
@@ -1393,6 +1565,46 @@
         "dependencies": {
           "Microsoft.Azure.Functions.Worker.Core": "2.51.0",
           "Microsoft.Azure.Functions.Worker.Grpc": "2.51.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Moq": {
@@ -1473,14 +1685,13 @@
           "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
-      "Azure.Core": {
+      "Azure.Storage.Common": {
         "type": "Transitive",
-        "resolved": "1.44.1",
-        "contentHash": "YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+        "resolved": "12.23.0",
+        "contentHash": "X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.ClientModel": "1.1.0",
-          "System.Memory.Data": "6.0.0"
+          "Azure.Core": "1.44.1",
+          "System.IO.Hashing": "6.0.0"
         }
       },
       "Castle.Core": {
@@ -1633,8 +1844,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
@@ -1685,15 +1896,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "9.0.14",
           "Microsoft.Extensions.Options": "9.0.14",
           "Microsoft.Extensions.Primitives": "9.0.14"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -1764,14 +1966,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1879,16 +2073,6 @@
         "resolved": "9.0.11",
         "contentHash": "mPGUbBmnWCBFY5JaPzEoJmoxRM2LXZG0RKDt3TReavM8gz6p+JhulIGsoFKi/N8AWPj0judhk1sbG0wmUQvQFA=="
       },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -1961,15 +2145,6 @@
           "System.Text.Json": "10.0.0"
         }
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -1987,6 +2162,28 @@
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "SgvSBcMRvmEEyV10pcvxNVUbwYoShmj/9pxXFVr3AFjE26IUzuwYLtLgt58xkEnT0xJBjfObaXxcol3BMtmEAg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.71.1",
+        "contentHash": "PGOHaoQhKBKnXy1kfW+Gu9/rxStKsqR+UZKeVv4XAsATdzmfj9y9kkUOftIjVFvxP3oh2Sk7v65ylS0K/qYADA==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.71.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "xuR8E4Rd96M41CnUSCiOJ2DBh+z+zQSmyrYHdYhD6K4fXBcQGVnRCFQ0efROUYpP+p0zC1BLKr0JRpVuujTZSg=="
+      },
       "Microsoft.JSInterop": {
         "type": "Transitive",
         "resolved": "9.0.11",
@@ -2002,10 +2199,11 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
         "dependencies": {
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
         }
       },
       "System.Diagnostics.DiagnosticSource": {
@@ -2018,6 +2216,11 @@
         "resolved": "10.0.0",
         "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -2025,8 +2228,8 @@
       },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ=="
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -2053,6 +2256,22 @@
       },
       "fastmoq.abstractions": {
         "type": "Project"
+      },
+      "fastmoq.azure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "[1.50.0, )",
+          "Azure.Data.Tables": "[12.11.0, )",
+          "Azure.Identity": "[1.14.0, )",
+          "Azure.Security.KeyVault.Secrets": "[4.7.0, )",
+          "Azure.Storage.Blobs": "[12.24.0, )",
+          "Azure.Storage.Queues": "[12.22.0, )",
+          "FastMoq.Core": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration": "[9.0.5, )",
+          "Microsoft.Extensions.DependencyInjection": "[9.0.5, )",
+          "Microsoft.Extensions.Logging": "[9.0.5, )",
+          "Microsoft.Extensions.Options": "[9.0.5, )"
+        }
       },
       "fastmoq.azurefunctions": {
         "type": "Project",
@@ -2100,6 +2319,65 @@
           "bunit": "[2.7.2, )"
         }
       },
+      "Azure.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.50.0, )",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Azure.Data.Tables": {
+        "type": "CentralTransitive",
+        "requested": "[12.11.0, )",
+        "resolved": "12.11.0",
+        "contentHash": "MabH2HegMvZA1ocaMhEfW/idyTa3CoH64s43/V9/KFRGdVqEj0EETvd3ItDe6Bbs2teiR40KE9Kz9NLDc5DJJw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "xQ6mpNhifb8W/KG2BclhbJWAupvE3JF8lPEBF8t59Q5sc1yN0Ci+dvS0qXtc6m9auxwYpmc8rhOmK541dcGwmA==",
+        "dependencies": {
+          "Azure.Core": "1.46.1",
+          "Microsoft.Identity.Client": "4.71.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.71.1"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "uOPCojkm41V4dKTORyGzl3/f/lriKpxSQ43fWDn4StRJBVmbF1F/DNWJhwm207kCnqgE/W9+tskJSimIKHCZkw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.24.0, )",
+        "resolved": "12.24.0",
+        "contentHash": "0SWiMtEYcemn5U69BqVPdqGDwcbl+lsF9L3WFPpqk1Db5g+ytr3L3GmUxMbvvdPNuFwTf03kKtWJpW/qW33T8A==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0"
+        }
+      },
+      "Azure.Storage.Queues": {
+        "type": "CentralTransitive",
+        "requested": "[12.22.0, )",
+        "resolved": "12.22.0",
+        "contentHash": "HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+        "dependencies": {
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
+        }
+      },
       "bunit": {
         "type": "CentralTransitive",
         "requested": "[2.7.2, )",
@@ -2128,6 +2406,46 @@
         "dependencies": {
           "Microsoft.Azure.Functions.Worker.Core": "2.51.0",
           "Microsoft.Azure.Functions.Worker.Grpc": "2.51.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.5, )",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Moq": {

--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ The FastMoq version removes explicit mock declarations, subject construction, an
 
 ## Packages
 
-- FastMoq - Aggregate package that combines the primary FastMoq runtime, database helpers, Azure Functions helpers, and web support.
+- FastMoq - Aggregate package that combines the primary FastMoq runtime, shared Azure SDK helpers, database helpers, Azure Functions helpers, and web support.
 - FastMoq.Abstractions - Shared provider contracts used by core and provider packages.
 - FastMoq.Core - Core testing Mocker and provider-first resolution pipeline.
+- FastMoq.Azure - Shared Azure SDK testing helpers for credentials, pageable builders, Azure-oriented configuration, and common client registration.
 - FastMoq.AzureFunctions - Azure Functions worker helpers for typed FunctionContext.InstanceServices setup.
 - FastMoq.Database - Entity Framework and DbContext-focused helpers.
 - FastMoq.Provider.Moq - Moq compatibility provider and Moq-specific convenience extensions for v4 migration.
@@ -176,16 +177,25 @@ Azure Functions helper note:
 - if you install `FastMoq.Core` directly, add `FastMoq.AzureFunctions` and import `FastMoq.AzureFunctions.Extensions` before using `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)`
 - the typed `CreateTypedServiceProvider(...)` and `AddServiceProvider(...)` helpers remain in `FastMoq.Core`
 
+Azure SDK helper note:
+
+- if you install the aggregate `FastMoq` package, the shared Azure SDK helpers are included
+- if you install `FastMoq.Core` directly, add `FastMoq.Azure` before using `PageableBuilder`, `AddTokenCredential(...)`, `CreateAzureServiceProvider(...)`, or the Azure client registration helpers
+- the Azure helper namespaces are split by concern under `FastMoq.Azure.Pageable`, `FastMoq.Azure.Credentials`, `FastMoq.Azure.DependencyInjection`, `FastMoq.Azure.Storage`, and `FastMoq.Azure.KeyVault`
+
 Typical split-package install:
 
 ```bash
 dotnet add package FastMoq.Core
+dotnet add package FastMoq.Azure
 dotnet add package FastMoq.AzureFunctions
 dotnet add package FastMoq.Database
 dotnet add package FastMoq.Web
 ```
 
 `GetMockDbContext<TContext>()` keeps the same main call shape in the `FastMoq` namespace. If you install `FastMoq`, the EF helpers are included. If you install `FastMoq.Core` directly, add `FastMoq.Database` for DbContext support.
+
+`PageableBuilder`, `AddTokenCredential(...)`, `AddDefaultAzureCredential(...)`, `CreateAzureConfiguration(...)`, `CreateAzureServiceProvider(...)`, and the Azure client registration helpers live in the `FastMoq.Azure.*` namespaces.
 
 `CreateFunctionContextInstanceServices(...)` and `AddFunctionContextInstanceServices(...)` live in `FastMoq.AzureFunctions.Extensions`, while the generic `CreateTypedServiceProvider(...)` and `AddServiceProvider(...)` helpers stay in `FastMoq.Extensions`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,9 +106,11 @@ Practical guidance for moving from the `3.0.0` public release toward the current
 | **Background Jobs** | [Background Services](./cookbook/README.md#background-services-testing) | [Executable Testing Examples](./samples/testing-examples.md) |
 | **Blazor Apps** | [bUnit and Blazor test migration](./migration/bunit-and-blazor-testing.md) | [Executable Testing Examples](./samples/testing-examples.md) |
 
-Package note: `FastMoq` is the aggregate package. Provider contracts live in `FastMoq.Abstractions`, `FastMoq.Core` stays lighter, EF-specific helpers live in `FastMoq.Database`, Azure Functions worker helpers live in `FastMoq.AzureFunctions.Extensions`, provider-specific adapters live in `FastMoq.Provider.*`, and web helpers live in `FastMoq.Web.Extensions` while the primary runtime calls stay in the `FastMoq` or `FastMoq.Extensions` namespaces.
+Package note: `FastMoq` is the aggregate package. Provider contracts live in `FastMoq.Abstractions`, `FastMoq.Core` stays lighter, shared Azure SDK helpers live in the `FastMoq.Azure.*` namespaces, EF-specific helpers live in `FastMoq.Database`, Azure Functions worker helpers live in `FastMoq.AzureFunctions.Extensions`, provider-specific adapters live in `FastMoq.Provider.*`, and web helpers live in `FastMoq.Web.Extensions` while the primary runtime calls stay in the `FastMoq` or `FastMoq.Extensions` namespaces.
 
 Web helper note: if your test project references the aggregate `FastMoq` package, the web helpers are already included. If your test project references `FastMoq.Core` directly, add `FastMoq.Web` before using helpers such as `CreateHttpContext(...)`, `CreateControllerContext(...)`, `SetupClaimsPrincipal(...)`, `AddHttpContext(...)`, or `AddHttpContextAccessor(...)`.
+
+Azure SDK helper note: if your test project references the aggregate `FastMoq` package, the shared Azure SDK helpers are already included. If your test project references `FastMoq.Core` directly, add `FastMoq.Azure` before using `PageableBuilder`, the credential helpers, Azure-oriented configuration/service-provider helpers, or the client registration helpers.
 
 Azure Functions helper note: if your test project references the aggregate `FastMoq` package, the Azure Functions helpers are already included. If your test project references `FastMoq.Core` directly, add `FastMoq.AzureFunctions` and import `FastMoq.AzureFunctions.Extensions` before using `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)`.
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -79,8 +79,9 @@ Use this table when you are deciding which package line your test project should
 
 | If you want... | Install... | Why |
 | --- | --- | --- |
-| simplest all-in-one experience | `FastMoq` | Aggregate package that includes the primary runtime, database helpers, web support, and the FastMoq analyzer pack by default |
+| simplest all-in-one experience | `FastMoq` | Aggregate package that includes the primary runtime, shared Azure SDK helpers, database helpers, web support, Azure Functions helpers, and the FastMoq analyzer pack by default |
 | lighter core-only usage | `FastMoq.Core` | Provider-first runtime without the extra EF, web-specific, or analyzer package payloads |
+| Azure SDK credentials, pageable builders, or Azure-oriented DI/config helpers while using `FastMoq.Core` | `FastMoq.Azure` | Adds `PageableBuilder`, token/default-credential helpers, Azure-oriented configuration/service-provider helpers, and common Azure client registration helpers |
 | Azure Functions worker helpers while using `FastMoq.Core` | `FastMoq.AzureFunctions` | Adds `CreateFunctionContextInstanceServices(...)` and `AddFunctionContextInstanceServices(...)` in `FastMoq.AzureFunctions.Extensions` while keeping the typed `IServiceProvider` helpers in core |
 | DbContext and EF-specific helpers while using `FastMoq.Core` | `FastMoq.Database` | Adds `GetMockDbContext<TContext>()` and the explicit DbContext handle modes |
 | controller, `HttpContext`, `IHttpContextAccessor`, or claims-principal helpers while using `FastMoq.Core` | `FastMoq.Web` | Adds `CreateHttpContext(...)`, `CreateControllerContext(...)`, `SetupClaimsPrincipal(...)`, `AddHttpContext(...)`, and `AddHttpContextAccessor(...)` |
@@ -90,12 +91,13 @@ Use this table when you are deciding which package line your test project should
 
 Important package boundaries in the current v4 line:
 
-- `FastMoq` already includes the common end-user surface, including web, database, and Azure Functions helpers
+`FastMoq` already includes the common end-user surface, including shared Azure SDK helpers, web, database, and Azure Functions helpers
 - `FastMoq` also includes the FastMoq analyzer assets by default so most test projects get migration guidance without extra setup
-- `FastMoq.Core` stays lighter on purpose, so EF helpers, Azure Functions helpers, and web helpers are separate package decisions when you consume core directly
+- `FastMoq.Core` stays lighter on purpose, so shared Azure SDK helpers, EF helpers, Azure Functions helpers, and web helpers are separate package decisions when you consume core directly
 - `FastMoq.Core` does not include analyzer assets; add `FastMoq.Analyzers` explicitly if you want analyzer guidance in a core-only package graph
 - `FastMoq.Core` includes the built-in `reflection` provider and the bundled Moq compatibility runtime, but the Moq tracked-mock extension methods such as `Setup(...)` and `Protected()` still belong to the `FastMoq.Provider.Moq` package
 - provider-package extension methods still follow the provider-package docs and selection rules described in [Provider Selection and Setup](./provider-selection.md)
+- if you are wiring Azure SDK clients, pageable sequences, or token credentials through tests while consuming `FastMoq.Core` directly, add `FastMoq.Azure`
 - if you are wiring Azure Functions worker tests through `FunctionContext.InstanceServices`, add `FastMoq.AzureFunctions` when you consume `FastMoq.Core` directly
 - if you are unsure whether your web tests need another package, see the web-helper notes in [Testing Guide](./testing-guide.md#controller-testing) and the migration-specific notes in [Framework and web helper migration](../migration/framework-and-web-helpers.md#web-test-helpers)
 
@@ -115,6 +117,7 @@ If you prefer the split packages instead of the aggregate package:
 
 ```bash
 dotnet add package FastMoq.Core
+dotnet add package FastMoq.Azure
 dotnet add package FastMoq.AzureFunctions
 dotnet add package FastMoq.Database
 dotnet add package FastMoq.Web
@@ -137,6 +140,7 @@ Split-package example:
 
 ```xml
 <PackageReference Include="FastMoq.Core" Version="4.*" />
+<PackageReference Include="FastMoq.Azure" Version="4.*" />
 <PackageReference Include="FastMoq.AzureFunctions" Version="4.*" />
 <PackageReference Include="FastMoq.Database" Version="4.*" />
 <PackageReference Include="FastMoq.Web" Version="4.*" />
@@ -144,7 +148,7 @@ Split-package example:
 ```
 
 > Note: this guide targets the current v4 release line. For the release delta relative to the last public `3.0.0` package, see [What's New Since 3.0.0](../whats-new/README.md).
-> Note: in the current repository, `GetMockDbContext<TContext>()` keeps the same `FastMoq` namespace call shape, but direct `FastMoq.Core` consumers should add `FastMoq.Database` for EF-specific helpers. Direct Azure Functions helper consumers should add `FastMoq.AzureFunctions`. Direct web-helper consumers should add `FastMoq.Web`.
+> Note: in the current repository, `GetMockDbContext<TContext>()` keeps the same `FastMoq` namespace call shape, but direct `FastMoq.Core` consumers should add `FastMoq.Database` for EF-specific helpers. Direct shared Azure SDK helper consumers should add `FastMoq.Azure`. Direct Azure Functions helper consumers should add `FastMoq.AzureFunctions`. Direct web-helper consumers should add `FastMoq.Web`.
 
 In the current v4 transition layout, `FastMoq.Core` bundles the built-in `moq` provider and the internal `reflection` fallback. The default provider is `reflection`. Optional providers such as `nsubstitute` can be added explicitly and then selected by their canonical name once the package is present, or registered manually under a custom alias. You can also register your own provider by implementing `IMockingProvider`; the bundled providers are examples, not the only supported choices.
 


### PR DESCRIPTION
## Summary

Adds the initial `FastMoq.Azure` package to provide shared Azure SDK testing helpers for FastMoq.

This PR is the first delivery slice for #44 and focuses on the reusable Azure test foundation rather than Azure Functions trigger harnesses.

## What''s included

- adds the new public `FastMoq.Azure` package
- wires `FastMoq.Azure` into the aggregate package and release solution topology
- adds pageable and response helpers for Azure SDK test scenarios
- adds fixed token credential helpers for Azure authentication tests
- adds Azure-focused configuration and DI test helpers
- adds Key Vault client registration helpers
- adds storage client registration helpers
- adds `AzureStorageClientFactory` for creating blob, queue, and table clients from a shared connection string or service URI
- adds focused unit tests for the new Azure helpers
- updates package and docs references so the new package shows up in repo guidance

## Validation

Validated with:

- `dotnet build .\FastMoq-Release.sln -c Debug --no-restore`
- `dotnet build .\FastMoq-Release.sln -c Debug --no-restore -p:WarningsAsErrors=CA2264`
- `dotnet test .\FastMoq.Tests\FastMoq.Tests.csproj -c Debug --no-restore`
- `dotnet test .\FastMoq.Tests.Web\FastMoq.Tests.Web.csproj -c Debug --no-restore`
- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj -c Debug --no-restore`
- `dotnet test .\FastMoq.sln -c Debug --no-restore`

## Notes

- this PR advances #44 but does not complete the full issue scope
- follow-up work will cover the Azure Functions-oriented harness and downstream validation flow