### PR TITLE
Improve constructor ambiguity handling and internal test guidance

### DIFF
--- a/FastMoq.Core/ConstructorAmbiguityBehavior.cs
+++ b/FastMoq.Core/ConstructorAmbiguityBehavior.cs
@@ -1,0 +1,20 @@
+using System.Runtime;
+
+namespace FastMoq
+{
+    /// <summary>
+    /// Controls how FastMoq resolves constructor ambiguity when multiple equally viable constructors remain after candidate filtering.
+    /// </summary>
+    public enum ConstructorAmbiguityBehavior
+    {
+        /// <summary>
+        /// Throw an <see cref="AmbiguousImplementationException"/> when FastMoq cannot reduce the candidate set to a single constructor.
+        /// </summary>
+        Throw = 0,
+
+        /// <summary>
+        /// When ambiguity remains, prefer the parameterless constructor from the current visibility scope if one exists; otherwise throw.
+        /// </summary>
+        PreferParameterlessConstructor = 1,
+    }
+}

--- a/FastMoq.Core/Extensions/TestClassExtensions.cs
+++ b/FastMoq.Core/Extensions/TestClassExtensions.cs
@@ -987,7 +987,7 @@ namespace FastMoq.Extensions
         {
             if (instanceParameterValues.Length == 0)
             {
-                return true;
+                return info.GetParameters().Length == 0;
             }
 
             var paramList = info.GetParameters().ToList();

--- a/FastMoq.Core/InstanceCreationFlags.cs
+++ b/FastMoq.Core/InstanceCreationFlags.cs
@@ -1,7 +1,7 @@
 namespace FastMoq
 {
     /// <summary>
-    /// Per-call overrides for constructor selection and optional-parameter resolution during instance creation.
+    /// Per-call overrides for constructor selection, ambiguity handling, and optional-parameter resolution during instance creation.
     /// <see cref="None"/> preserves the current <see cref="Mocker"/> defaults.
     /// </summary>
     [Flags]
@@ -31,5 +31,10 @@ namespace FastMoq
         /// Use declared default values for optional parameters, or <see langword="null"/> when no default value is available.
         /// </summary>
         UseDefaultOrNullOptionalParameters = 1 << 3,
+
+        /// <summary>
+        /// Prefer the parameterless constructor when constructor selection remains ambiguous within the current visibility scope.
+        /// </summary>
+        PreferParameterlessConstructorOnAmbiguity = 1 << 4,
     }
 }

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -1441,7 +1441,7 @@ namespace FastMoq
 
             if (!nonPublic && fallbackToNonPublicConstructors)
             {
-                return FindPreferredConstructor(type, true, false, optionalParameterResolution, excludeList);
+                return FindPreferredConstructor(type, true, false, constructorAmbiguityBehavior, optionalParameterResolution, excludeList);
             }
 
             var nonPublicConstructors = GetConstructors(type, true, optionalParameterResolution)
@@ -2243,7 +2243,7 @@ namespace FastMoq
         /// Builds constructor argument data for <typeparamref name="T"/> using the supplied optional-parameter policy.
         /// </summary>
         public object?[] GetArgData<T>(OptionalParameterResolutionMode optionalParameterResolution) where T : class =>
-            GetArgData<T>(publicOnly: null, optionalParameterResolution);
+            GetArgData<T>(publicOnly: null, optionalParameterResolution, Policy.DefaultConstructorAmbiguityBehavior);
 
         /// <summary>
         /// Builds constructor argument data for <typeparamref name="T"/> using the supplied creation flags.
@@ -2252,10 +2252,16 @@ namespace FastMoq
         {
             var publicOnly = ResolvePublicOnlyOverride(flags);
             var optionalParameterResolution = ResolveOptionalParameterResolution(flags);
-            return GetArgData<T>(publicOnly, optionalParameterResolution);
+            var constructorAmbiguityBehavior = ResolveConstructorAmbiguityBehavior(flags);
+            return GetArgData<T>(publicOnly, optionalParameterResolution, constructorAmbiguityBehavior);
         }
 
         internal object?[] GetArgData<T>(bool? publicOnly, OptionalParameterResolutionMode optionalParameterResolution) where T : class
+        {
+            return GetArgData<T>(publicOnly, optionalParameterResolution, Policy.DefaultConstructorAmbiguityBehavior);
+        }
+
+        internal object?[] GetArgData<T>(bool? publicOnly, OptionalParameterResolutionMode optionalParameterResolution, ConstructorAmbiguityBehavior constructorAmbiguityBehavior) where T : class
         {
             var type = typeof(T).IsInterface ? GetTypeFromInterface<T>() : new InstanceModel<T>();
             var flags = publicOnly == true
@@ -2265,7 +2271,7 @@ namespace FastMoq
                 .Where(c => c.GetParameters().All(p => p.ParameterType != type.InstanceType))
                 .Select(ci => new ConstructorModel(ci, new object?[ci.GetParameters().Length]))
                 .ToList();
-            var constructor = SelectPreferredConstructor(type.InstanceType, constructors)
+            var constructor = SelectPreferredConstructor(type.InstanceType, constructors, constructorAmbiguityBehavior)
                 ?? throw new NotImplementedException("Unable to find the constructor.");
 
             return constructor.ConstructorInfo == null

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -76,11 +76,14 @@ namespace FastMoq
         public const string SETUP = "Setup";
 
         private static readonly NullabilityInfoContext NullabilityContext = new();
+        private static readonly EventId ConstructorSelectionEventId = new(21021, nameof(ConstructorSelectionEventId));
+        private static readonly EventId ConstructorAmbiguityEventId = new(21071, nameof(ConstructorAmbiguityEventId));
 
         private readonly record struct InstanceConstructionRequest(
             bool? PublicOnly,
             Type?[]? ConstructorParameterTypes,
-            OptionalParameterResolutionMode OptionalParameterResolution);
+            OptionalParameterResolutionMode OptionalParameterResolution,
+            ConstructorAmbiguityBehavior ConstructorAmbiguityBehavior);
 
         /// <summary>
         /// The shared in-memory file system used by built-in file-system resolution helpers.
@@ -1096,12 +1099,12 @@ namespace FastMoq
         {
             ArgumentNullException.ThrowIfNull(type);
 
-            var constructor = GetConstructorByArgs(args, type, true, fallbackToNonPublicConstructors: true, OptionalParameterResolution);
+            var constructor = GetConstructorByArgs(args, type, true, fallbackToNonPublicConstructors: true, OptionalParameterResolution, Policy.DefaultConstructorAmbiguityBehavior);
             return CreateInstanceInternal(type, constructor.ConstructorInfo, OptionalParameterResolution, constructor.ParameterList);
         }
 
         internal T? CreateInstance<T>(bool? publicOnly, OptionalParameterResolutionMode optionalParameterResolution, params object?[] args) where T : class =>
-            CreateInstanceCore<T>(CreateInstanceConstructionRequest(publicOnly, null, optionalParameterResolution), args);
+            CreateInstanceCore<T>(CreateInstanceConstructionRequest(publicOnly, null, optionalParameterResolution, Policy.DefaultConstructorAmbiguityBehavior), args);
 
         /// <summary>
         /// Creates an instance of <typeparamref name="T"/> by selecting a constructor that matches the supplied parameter types.
@@ -1118,17 +1121,18 @@ namespace FastMoq
             CreateInstanceCore<T>(CreateInstanceConstructionRequest(flags, parameterTypes), Array.Empty<object?>());
 
         internal T? CreateInstanceByType<T>(bool? publicOnly, OptionalParameterResolutionMode optionalParameterResolution, params Type?[] parameterTypes) where T : class =>
-            CreateInstanceCore<T>(CreateInstanceConstructionRequest(publicOnly, parameterTypes, optionalParameterResolution), Array.Empty<object?>());
+            CreateInstanceCore<T>(CreateInstanceConstructionRequest(publicOnly, parameterTypes, optionalParameterResolution, Policy.DefaultConstructorAmbiguityBehavior), Array.Empty<object?>());
 
         private InstanceConstructionRequest CreateInstanceConstructionRequest(InstanceCreationFlags flags, Type?[]? constructorParameterTypes)
         {
             var publicOnly = ResolvePublicOnlyOverride(flags);
             var optionalParameterResolution = ResolveOptionalParameterResolution(flags);
-            return CreateInstanceConstructionRequest(publicOnly, constructorParameterTypes, optionalParameterResolution);
+            var constructorAmbiguityBehavior = ResolveConstructorAmbiguityBehavior(flags);
+            return CreateInstanceConstructionRequest(publicOnly, constructorParameterTypes, optionalParameterResolution, constructorAmbiguityBehavior);
         }
 
-        private InstanceConstructionRequest CreateInstanceConstructionRequest(bool? publicOnly, Type?[]? constructorParameterTypes, OptionalParameterResolutionMode optionalParameterResolution) =>
-            new(publicOnly, constructorParameterTypes, optionalParameterResolution);
+        private InstanceConstructionRequest CreateInstanceConstructionRequest(bool? publicOnly, Type?[]? constructorParameterTypes, OptionalParameterResolutionMode optionalParameterResolution, ConstructorAmbiguityBehavior constructorAmbiguityBehavior) =>
+            new(publicOnly, constructorParameterTypes, optionalParameterResolution, constructorAmbiguityBehavior);
 
         private static bool? ResolvePublicOnlyOverride(InstanceCreationFlags flags)
         {
@@ -1176,6 +1180,16 @@ namespace FastMoq
             return OptionalParameterResolution;
         }
 
+        private ConstructorAmbiguityBehavior ResolveConstructorAmbiguityBehavior(InstanceCreationFlags flags)
+        {
+            if (flags.HasFlag(InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity))
+            {
+                return ConstructorAmbiguityBehavior.PreferParameterlessConstructor;
+            }
+
+            return Policy.DefaultConstructorAmbiguityBehavior;
+        }
+
         /// <summary>
         /// Centralized creation logic used by all public CreateInstance* methods.
         /// </summary>
@@ -1212,7 +1226,7 @@ namespace FastMoq
                 return CreateInstanceInternal(targetType, constructor, request.OptionalParameterResolution, args) as T;
             }
 
-            var ctorModel = GetConstructorByArgs(args, targetType, false, ShouldFallbackToNonPublicConstructors(request.PublicOnly), request.OptionalParameterResolution);
+            var ctorModel = GetConstructorByArgs(args, targetType, false, ShouldFallbackToNonPublicConstructors(request.PublicOnly), request.OptionalParameterResolution, request.ConstructorAmbiguityBehavior);
             var created = CreateInstanceInternal(targetType, ctorModel.ConstructorInfo, request.OptionalParameterResolution, ctorModel.ParameterList);
             return created as T;
         }
@@ -1232,11 +1246,11 @@ namespace FastMoq
             return allowNonPublicConstructors ?? !ShouldCreateStrictMocks();
         }
 
-        private ConstructorModel GetConstructorByArgs(object?[] args, Type instanceType, bool nonPublic, bool fallbackToNonPublicConstructors, OptionalParameterResolutionMode optionalParameterResolution)
+        private ConstructorModel GetConstructorByArgs(object?[] args, Type instanceType, bool nonPublic, bool fallbackToNonPublicConstructors, OptionalParameterResolutionMode optionalParameterResolution, ConstructorAmbiguityBehavior constructorAmbiguityBehavior)
         {
             return args.Length > 0
                 ? FindConstructor(instanceType, nonPublic, fallbackToNonPublicConstructors, optionalParameterResolution, args)
-                : FindPreferredConstructor(instanceType, nonPublic, fallbackToNonPublicConstructors, optionalParameterResolution);
+                : FindPreferredConstructor(instanceType, nonPublic, fallbackToNonPublicConstructors, constructorAmbiguityBehavior, optionalParameterResolution);
         }
 
         private bool TryGetExistingObject<T>(Type requestedType, IInstanceModel typeInstanceModel, out T? instance) where T : class
@@ -1397,10 +1411,15 @@ namespace FastMoq
         internal ConstructorModel FindPreferredConstructor(Type type, bool nonPublic, OptionalParameterResolutionMode optionalParameterResolution, List<ConstructorInfo>? excludeList = null)
         {
             var strict = Behavior.Has(MockFeatures.FailOnUnconfigured);
-            return FindPreferredConstructor(type, nonPublic, !strict, optionalParameterResolution, excludeList);
+            return FindPreferredConstructor(type, nonPublic, !strict, Policy.DefaultConstructorAmbiguityBehavior, optionalParameterResolution, excludeList);
         }
 
         private ConstructorModel FindPreferredConstructor(Type type, bool nonPublic, bool fallbackToNonPublicConstructors, OptionalParameterResolutionMode optionalParameterResolution, List<ConstructorInfo>? excludeList = null)
+        {
+            return FindPreferredConstructor(type, nonPublic, fallbackToNonPublicConstructors, Policy.DefaultConstructorAmbiguityBehavior, optionalParameterResolution, excludeList);
+        }
+
+        private ConstructorModel FindPreferredConstructor(Type type, bool nonPublic, bool fallbackToNonPublicConstructors, ConstructorAmbiguityBehavior constructorAmbiguityBehavior, OptionalParameterResolutionMode optionalParameterResolution, List<ConstructorInfo>? excludeList = null)
         {
             excludeList ??= new();
 
@@ -1408,7 +1427,13 @@ namespace FastMoq
                 .Where(c => excludeList.TrueForAll(e => e != c.ConstructorInfo))
                 .ToList();
 
-            var preferredPublicConstructor = SelectPreferredConstructor(type, this.GetTestedConstructors(type, publicConstructors));
+            var preferredMarkedPublicConstructor = SelectMarkedPreferredConstructor(type, publicConstructors);
+            if (preferredMarkedPublicConstructor != null)
+            {
+                return preferredMarkedPublicConstructor;
+            }
+
+            var preferredPublicConstructor = SelectPreferredConstructor(type, this.GetTestedConstructors(type, publicConstructors), constructorAmbiguityBehavior);
             if (preferredPublicConstructor != null)
             {
                 return preferredPublicConstructor;
@@ -1424,11 +1449,22 @@ namespace FastMoq
                 .Where(c => c.ConstructorInfo?.IsPublic == false)
                 .ToList();
 
-            return SelectPreferredConstructor(type, this.GetTestedConstructors(type, nonPublicConstructors))
+            var preferredMarkedNonPublicConstructor = SelectMarkedPreferredConstructor(type, nonPublicConstructors);
+            if (preferredMarkedNonPublicConstructor != null)
+            {
+                return preferredMarkedNonPublicConstructor;
+            }
+
+            return SelectPreferredConstructor(type, this.GetTestedConstructors(type, nonPublicConstructors), constructorAmbiguityBehavior)
                 ?? throw new NotImplementedException("Unable to find the constructor.");
         }
 
         private ConstructorModel? SelectPreferredConstructor(Type type, List<ConstructorModel>? constructors)
+        {
+            return SelectPreferredConstructor(type, constructors, Policy.DefaultConstructorAmbiguityBehavior);
+        }
+
+        private ConstructorModel? SelectPreferredConstructor(Type type, List<ConstructorModel>? constructors, ConstructorAmbiguityBehavior constructorAmbiguityBehavior)
         {
             constructors ??= [];
             if (constructors.Count == 0)
@@ -1440,11 +1476,76 @@ namespace FastMoq
             var bestMatches = constructors.Where(c => c.ParameterList.Length == largestArity).ToList();
             if (bestMatches.Count > 1)
             {
+                if (constructorAmbiguityBehavior == ConstructorAmbiguityBehavior.PreferParameterlessConstructor)
+                {
+                    var parameterlessConstructor = constructors.SingleOrDefault(c => c.ParameterList.Length == 0);
+                    if (parameterlessConstructor != null)
+                    {
+                        LogConstructorSelection(
+                            LogLevel.Warning,
+                            ConstructorSelectionEventId,
+                            $"Type '{type.Name}' encountered ambiguous constructors {FormatConstructorList(bestMatches)} and fell back to parameterless constructor {FormatConstructorSignature(parameterlessConstructor.ConstructorInfo)}.");
+                        return parameterlessConstructor;
+                    }
+                }
+
+                LogConstructorSelection(
+                    LogLevel.Warning,
+                    ConstructorAmbiguityEventId,
+                    $"Type '{type.Name}' encountered ambiguous constructors {FormatConstructorList(bestMatches)}.");
                 throw this.GetAmbiguousConstructorImplementationException(type);
             }
 
             return bestMatches[0];
         }
+
+        private ConstructorModel? SelectMarkedPreferredConstructor(Type type, List<ConstructorModel> constructors)
+        {
+            var preferredConstructors = constructors
+                .Where(c => c.ConstructorInfo?.IsDefined(typeof(PreferredConstructorAttribute), false) == true)
+                .ToList();
+
+            if (preferredConstructors.Count == 0)
+            {
+                return null;
+            }
+
+            if (preferredConstructors.Count > 1)
+            {
+                var message = $"Type '{type.Name}' has multiple constructors marked with [PreferredConstructor]: {FormatConstructorList(preferredConstructors)}.";
+                LogConstructorSelection(LogLevel.Warning, ConstructorAmbiguityEventId, message);
+                throw new InvalidOperationException(message);
+            }
+
+            var preferredConstructor = preferredConstructors[0];
+            LogConstructorSelection(
+                LogLevel.Information,
+                ConstructorSelectionEventId,
+                $"Type '{type.Name}' selected constructor {FormatConstructorSignature(preferredConstructor.ConstructorInfo)} via [PreferredConstructor].");
+            return preferredConstructor;
+        }
+
+        private void LogConstructorSelection(LogLevel logLevel, EventId eventId, string message)
+        {
+            LoggingCallback(logLevel, eventId, message, null);
+        }
+
+        private static string FormatConstructorList(IEnumerable<ConstructorModel> constructors)
+        {
+            return string.Join("; ", constructors.Select(c => FormatConstructorSignature(c.ConstructorInfo)));
+        }
+
+        private static string FormatConstructorSignature(ConstructorInfo? constructorInfo)
+        {
+            if (constructorInfo == null)
+            {
+                return "<unknown>";
+            }
+
+            var parameters = string.Join(", ", constructorInfo.GetParameters().Select(p => p.ParameterType.Name));
+            return $"{constructorInfo.DeclaringType?.Name}({parameters})";
+        }
+
         /// <summary>
         /// Determines whether the supplied type exposes a parameterless constructor.
         /// </summary>

--- a/FastMoq.Core/MockerPolicyOptions.cs
+++ b/FastMoq.Core/MockerPolicyOptions.cs
@@ -17,6 +17,12 @@ namespace FastMoq
         public bool DefaultFallbackToNonPublicConstructors { get; set; } = true;
 
         /// <summary>
+        /// Controls how FastMoq resolves constructor ambiguity when multiple equally viable constructors remain after candidate filtering.
+        /// The default preserves the existing throw behavior for backward compatibility.
+        /// </summary>
+        public ConstructorAmbiguityBehavior DefaultConstructorAmbiguityBehavior { get; set; } = ConstructorAmbiguityBehavior.Throw;
+
+        /// <summary>
         /// Indicates whether method invocation helpers should consider non-public methods by default when matching a target member.
         /// </summary>
         public bool DefaultFallbackToNonPublicMethods { get; set; } = true;

--- a/FastMoq.Core/MockerTestBase.cs
+++ b/FastMoq.Core/MockerTestBase.cs
@@ -25,6 +25,7 @@ namespace FastMoq
     /// }
     /// ]]></code>
     /// <para>The base class creates <c>OrderSubmitter</c> before the test body runs, so the test can assert directly against <see cref="Component"/>.</para>
+    /// <para>When a component exposes multiple constructors and the test should target one specific signature, prefer overriding <see cref="MockerTestBase{TComponent}.ComponentConstructorParameterTypes"/> or <see cref="CreateComponentAction"/> in the test base instead of modifying production constructors just for testing.</para>
     /// <code language="csharp"><![CDATA[
     /// public interface IOrderGateway
     /// {

--- a/FastMoq.Core/MockerTestBase_Constructors.cs
+++ b/FastMoq.Core/MockerTestBase_Constructors.cs
@@ -15,8 +15,16 @@ namespace FastMoq
         /// </summary>
         protected virtual InstanceCreationFlags ComponentCreationFlags => InstanceCreationFlags.None;
 
+        /// <summary>
+        /// Selects the constructor signature used by the default component-creation path.
+        /// Override this in a derived test base when the test should force a specific constructor without replacing <see cref="CreateComponentAction"/>.
+        /// Return <see langword="null"/> to keep FastMoq's normal constructor-selection rules.
+        /// Return an empty array to select the parameterless constructor explicitly.
+        /// </summary>
+        protected virtual Type?[]? ComponentConstructorParameterTypes => null;
+
         private Func<Mocker, TComponent> DefaultCreateAction =>
-            _ => Component = Mocks.CreateInstance<TComponent>(ComponentCreationFlags) ?? throw CannotCreateComponentException;
+            mocker => Component = CreateDefaultComponent(mocker) ?? throw CannotCreateComponentException;
 
         #endregion
 
@@ -189,6 +197,14 @@ namespace FastMoq
             Action<TComponent> createdComponentAction,
             params Type[] createArgumentTypes)
             : this(setupMocksAction, CreateActionWithTypes(createArgumentTypes), createdComponentAction) { }
+
+        private TComponent? CreateDefaultComponent(Mocker mocker)
+        {
+            var constructorParameterTypes = ComponentConstructorParameterTypes;
+            return constructorParameterTypes == null
+                ? mocker.CreateInstance<TComponent>(ComponentCreationFlags)
+                : mocker.CreateInstanceByType<TComponent>(ComponentCreationFlags, constructorParameterTypes);
+        }
 
         private static Func<Mocker, TComponent> CreateActionWithTypes(params Type[] args) =>
             m => m.CreateInstanceByType<TComponent>(args) ?? throw CannotCreateComponentException;

--- a/FastMoq.Core/PreferredConstructorAttribute.cs
+++ b/FastMoq.Core/PreferredConstructorAttribute.cs
@@ -1,0 +1,10 @@
+namespace FastMoq
+{
+    /// <summary>
+    /// Marks the constructor FastMoq should prefer during implicit constructor selection within the current visibility scope.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed class PreferredConstructorAttribute : Attribute
+    {
+    }
+}

--- a/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
+++ b/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
@@ -257,18 +257,27 @@ namespace FastMoq.Providers.MoqProvider
                 return null;
             }
 
-            var legacyType = legacyMock.GetType();
-            if (legacyType.IsGenericType && legacyType.GetGenericTypeDefinition() == typeof(Mock<>))
+            var legacyGenericMockedType = TryGetLegacyGenericMockedType(legacyMock.GetType());
+            if (legacyGenericMockedType == mockedType)
             {
-                var genericArgument = legacyType.GetGenericArguments()[0];
-                if (genericArgument == mockedType)
-                {
-                    var wrapperType = typeof(MoqFastMockGeneric<>).MakeGenericType(mockedType);
-                    return (IFastMock) Activator.CreateInstance(wrapperType, legacyMock)!;
-                }
+                var wrapperType = typeof(MoqFastMockGeneric<>).MakeGenericType(mockedType);
+                return (IFastMock) Activator.CreateInstance(wrapperType, legacyMock)!;
             }
 
             return new MoqFastMock(mock);
+        }
+
+        private static Type? TryGetLegacyGenericMockedType(Type legacyType)
+        {
+            for (var current = legacyType; current != null; current = current.BaseType)
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(Mock<>))
+                {
+                    return current.GetGenericArguments()[0];
+                }
+            }
+
+            return null;
         }
 
         private static void SetupLoggerCallback(Mock logger, Type mockedType, Action<LogLevel, EventId, string, Exception?> callback)

--- a/FastMoq.TestingExample/ExampleTests.cs
+++ b/FastMoq.TestingExample/ExampleTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FastMoq.Providers.MoqProvider;
 using Moq;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -60,8 +61,9 @@ namespace FastMoq.TestingExample
         {
             var iFile = new FileSystem().File;
             mocks.Behavior.Enabled |= MockFeatures.FailOnUnconfigured;
-            mocks.GetMock<IFileSystem>().Setup(x => x.File).Returns(iFile);
-            mocks.GetMock<IFileSystem>().Setup(x => x.Directory).Returns((IDirectory) null!);
+            var fileSystemMock = mocks.GetOrCreateMock<IFileSystem>();
+            fileSystemMock.Setup(x => x.File).Returns(iFile);
+            fileSystemMock.Setup(x => x.Directory).Returns((IDirectory) null!);
         }
     }
 
@@ -70,6 +72,7 @@ namespace FastMoq.TestingExample
         #region Fields
 
         private static bool testEventCalled;
+        private static Mock<IFileSystem> fileSystemMock = default!;
 
         #endregion
 
@@ -79,7 +82,7 @@ namespace FastMoq.TestingExample
         [Fact]
         public void Test1()
         {
-            Component.FileSystem.Should().Be(Mocks.GetMock<IFileSystem>().Object);
+            Component.FileSystem.Should().Be(fileSystemMock.Object);
             Component.FileSystem.Should().NotBeNull();
             Component.FileSystem.File.Should().NotBeNull();
             Component.FileSystem.Directory.Should().BeNull();
@@ -87,7 +90,7 @@ namespace FastMoq.TestingExample
             Component.CallTestEvent();
             testEventCalled.Should().BeTrue();
 
-            Mocks.GetMock<IFileSystem>().Setup(x => x.Directory).Returns(new FileSystem().Directory);
+            fileSystemMock.Setup(x => x.Directory).Returns(new FileSystem().Directory);
             Component.FileSystem.Directory.Should().NotBeNull();
         }
 
@@ -96,11 +99,11 @@ namespace FastMoq.TestingExample
 
         private static void SetupMocks(Mocker mocks)
         {
-            var mock = new Mock<IFileSystem>();
+            fileSystemMock = new Mock<IFileSystem>();
             var iFile = new FileSystem().File;
             mocks.Behavior.Enabled |= MockFeatures.FailOnUnconfigured;
-            mocks.AddMock(mock, true);
-            mocks.GetMock<IFileSystem>().Setup(x => x.File).Returns(iFile);
+            fileSystemMock.Setup(x => x.File).Returns(iFile);
+            mocks.AddType<IFileSystem>(fileSystemMock.Object, replace: true);
         }
     }
 }

--- a/FastMoq.TestingExample/RealWorldExampleTests.cs
+++ b/FastMoq.TestingExample/RealWorldExampleTests.cs
@@ -1,5 +1,6 @@
 using FastMoq.Extensions;
 using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -26,10 +27,14 @@ namespace FastMoq.TestingExample
                 TotalAmount = 149.90m,
             };
 
-            Mocks.GetMock<IInventoryGateway>()
+            var inventoryGateway = Mocks.GetOrCreateMock<IInventoryGateway>();
+            var paymentGateway = Mocks.GetOrCreateMock<IPaymentGateway>();
+            var orderRepository = Mocks.GetOrCreateMock<IOrderRepository>();
+
+            inventoryGateway
                 .Setup(x => x.ReserveAsync(request.Sku, request.Quantity, CancellationToken.None))
                 .ReturnsAsync(true);
-            Mocks.GetMock<IPaymentGateway>()
+            paymentGateway
                 .Setup(x => x.ChargeAsync(request.CustomerId, request.TotalAmount, CancellationToken.None))
                 .ReturnsAsync("pay_12345");
 
@@ -37,7 +42,7 @@ namespace FastMoq.TestingExample
 
             result.Success.Should().BeTrue();
             result.OrderId.Should().NotBeNull();
-            Mocks.GetMock<IOrderRepository>()
+            orderRepository.AsMoq()
                 .Verify(x => x.SaveAsync(
                     It.Is<OrderRecord>(order =>
                         order.CustomerId == request.CustomerId &&
@@ -61,7 +66,11 @@ namespace FastMoq.TestingExample
                 TotalAmount = 24.99m,
             };
 
-            Mocks.GetMock<IInventoryGateway>()
+            var inventoryGateway = Mocks.GetOrCreateMock<IInventoryGateway>();
+            var paymentGateway = Mocks.GetOrCreateMock<IPaymentGateway>();
+            var orderRepository = Mocks.GetOrCreateMock<IOrderRepository>();
+
+            inventoryGateway
                 .Setup(x => x.ReserveAsync(request.Sku, request.Quantity, CancellationToken.None))
                 .ReturnsAsync(false);
 
@@ -69,9 +78,9 @@ namespace FastMoq.TestingExample
 
             result.Success.Should().BeFalse();
             result.FailureReason.Should().Be("InventoryUnavailable");
-            Mocks.GetMock<IPaymentGateway>()
+            paymentGateway.AsMoq()
                 .Verify(x => x.ChargeAsync(It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()), Times.Never);
-            Mocks.GetMock<IOrderRepository>()
+            orderRepository.AsMoq()
                 .Verify(x => x.SaveAsync(It.IsAny<OrderRecord>(), It.IsAny<CancellationToken>()), Times.Never);
             Mocks.VerifyLogged(LogLevel.Warning, "Inventory reservation failed", 1);
         }
@@ -90,15 +99,18 @@ namespace FastMoq.TestingExample
                 new() { CustomerId = "C-200", EmailAddress = "grace@example.test", Segment = "Standard" },
             };
 
+            var customerCsvParser = Mocks.GetOrCreateMock<ICustomerCsvParser>();
+            var customerRepository = Mocks.GetOrCreateMock<ICustomerRepository>();
+
             Mocks.fileSystem.AddFile(FILE_PATH, new MockFileData(CSV));
-            Mocks.GetMock<ICustomerCsvParser>()
+            customerCsvParser
                 .Setup(x => x.Parse(CSV))
                 .Returns(parsedRows);
 
             var importedCount = await Component.ImportAsync(FILE_PATH, CancellationToken.None);
 
             importedCount.Should().Be(2);
-            Mocks.GetMock<ICustomerRepository>()
+            customerRepository.AsMoq()
                 .Verify(x => x.UpsertAsync(parsedRows, CancellationToken.None), Times.Once);
             Mocks.VerifyLogged(LogLevel.Information, "Imported 2 customers", 1);
         }
@@ -107,13 +119,15 @@ namespace FastMoq.TestingExample
         public async Task ImportAsync_ShouldReturnZeroAndLogWarning_WhenFileDoesNotExist()
         {
             const string FILE_PATH = @"c:\imports\missing.csv";
+            var customerCsvParser = Mocks.GetOrCreateMock<ICustomerCsvParser>();
+            var customerRepository = Mocks.GetOrCreateMock<ICustomerRepository>();
 
             var importedCount = await Component.ImportAsync(FILE_PATH, CancellationToken.None);
 
             importedCount.Should().Be(0);
-            Mocks.GetMock<ICustomerCsvParser>()
+            customerCsvParser.AsMoq()
                 .Verify(x => x.Parse(It.IsAny<string>()), Times.Never);
-            Mocks.GetMock<ICustomerRepository>()
+            customerRepository.AsMoq()
                 .Verify(x => x.UpsertAsync(It.IsAny<IReadOnlyList<CustomerImportRow>>(), It.IsAny<CancellationToken>()), Times.Never);
             Mocks.VerifyLogged(LogLevel.Warning, "Import file was not found", 1);
         }
@@ -135,7 +149,7 @@ namespace FastMoq.TestingExample
             Scenario
                 .With(() =>
                 {
-                    Mocks.GetMock<IInvoiceRepository>()
+                    Mocks.GetOrCreateMock<IInvoiceRepository>()
                         .Setup(x => x.GetPastDueAsync(now, CancellationToken.None))
                         .ReturnsAsync(invoices);
                 })
@@ -162,10 +176,10 @@ namespace FastMoq.TestingExample
             Scenario
                 .With(() =>
                 {
-                    Mocks.GetMock<IInvoiceRepository>()
+                    Mocks.GetOrCreateMock<IInvoiceRepository>()
                         .Setup(x => x.GetPastDueAsync(now, CancellationToken.None))
                         .ReturnsAsync(invoices);
-                    Mocks.GetMock<IEmailGateway>()
+                    Mocks.GetOrCreateMock<IEmailGateway>()
                         .Setup(x => x.SendReminderAsync("ap@contoso.test", 125m, CancellationToken.None))
                         .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
                 })
@@ -175,9 +189,9 @@ namespace FastMoq.TestingExample
 
             afterFailureAssertionRan.Should().BeTrue();
 
-            Mocks.GetMock<IInvoiceRepository>()
+            Mocks.GetOrCreateMock<IInvoiceRepository>().AsMoq()
                 .Verify(x => x.GetPastDueAsync(now, CancellationToken.None), Times.Once);
-            Mocks.GetMock<IEmailGateway>()
+            Mocks.GetOrCreateMock<IEmailGateway>().AsMoq()
                 .Verify(x => x.SendReminderAsync("ap@contoso.test", 125m, CancellationToken.None), Times.Once);
             Mocks.VerifyLogged(LogLevel.Information, "Sent 1 invoice reminders", 0);
         }

--- a/FastMoq.Tests.Web/ControllerHttpContextIntegrationTests.cs
+++ b/FastMoq.Tests.Web/ControllerHttpContextIntegrationTests.cs
@@ -1,4 +1,5 @@
 using FastMoq.Web.Extensions;
+using FastMoq.Providers.MoqProvider;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -53,7 +54,7 @@ namespace FastMoq.Tests.Web
         [Fact]
         public async Task Get_ShouldUseConfiguredHttpContext_AcrossControllerAndAccessor()
         {
-            Mocks.GetMock<IOrderReader>()
+            Mocks.GetOrCreateMock<IOrderReader>()
                 .Setup(x => x.GetOrdersAsync(true, "corr-123", "Test User", It.IsAny<CancellationToken>()))
                 .ReturnsAsync([new OrderDto(42, "open")]);
 

--- a/FastMoq.Tests.Web/MockerBlazorTestBaseTests.cs
+++ b/FastMoq.Tests.Web/MockerBlazorTestBaseTests.cs
@@ -186,7 +186,7 @@ namespace FastMoq.Tests.Web
             var obj = Mocks.GetObject<IHttpContextAccessor>();
             obj.HttpContext.Should().NotBeNull();
 
-            var obj2 = Mocks.GetMock<IHttpContextAccessor>().Object;
+            var obj2 = Mocks.GetOrCreateMock<IHttpContextAccessor>().Instance;
             obj2.HttpContext.Should().NotBeNull();
         }
 
@@ -205,7 +205,7 @@ namespace FastMoq.Tests.Web
             var obj3 = Mocks.GetObject<HttpContextAccessor>();
             obj3.HttpContext.Should().NotBeNull();
 
-            var obj4 = Mocks.GetMock<HttpContextAccessor>().Object;
+            var obj4 = Mocks.GetOrCreateMock<HttpContextAccessor>().Instance;
             obj4.HttpContext.Should().NotBeNull();
         }
 
@@ -216,7 +216,7 @@ namespace FastMoq.Tests.Web
         public void ClassProperties_NoResolution()
         {
             Mocks.InnerMockResolution = false;
-            var obj4 = Mocks.GetMock<HttpContextAccessor>().Object;
+            var obj4 = Mocks.GetOrCreateMock<HttpContextAccessor>().Instance;
             obj4.HttpContext.Should().BeNull();
         }
     }

--- a/FastMoq.Tests/DbContextTests.cs
+++ b/FastMoq.Tests/DbContextTests.cs
@@ -105,10 +105,12 @@ namespace FastMoq.Tests
             Mocks.Policy.EnabledBuiltInTypeResolutions &= ~BuiltInTypeResolutionFlags.DbContext;
 
             var dbContext = Mocks.GetObject<MyDbContext>();
+            var trackedMock = Mocks.GetOrCreateMock<MyDbContext>();
 
             dbContext.Should().NotBeNull();
             Mocks.Contains<MyDbContext>().Should().BeTrue();
-            Mocks.GetMock<MyDbContext>().Object.Should().BeSameAs(dbContext);
+            trackedMock.Instance.Should().BeSameAs(dbContext);
+            trackedMock.NativeMock.Should().BeSameAs(Mocks.GetMockDbContext<MyDbContext>());
         }
 
         [Fact]
@@ -147,11 +149,33 @@ namespace FastMoq.Tests
         public void GetMockDbContext_ShouldReturnSameInstanceAsComponent()
         {
             var mockDbContext = Mocks.GetMockDbContext(typeof(MyDbContext));
+            var trackedMock = Mocks.GetOrCreateMock<MyDbContext>();
+
             mockDbContext.Object.Should().BeSameAs(Component);
+            trackedMock.Instance.Should().BeSameAs(Component);
+            trackedMock.NativeMock.Should().BeSameAs(mockDbContext);
+        }
 
-            Mocks.GetMock<MyDbContext>().Object.Should().BeSameAs(Component);
+        [Fact]
+        public void GetOrCreateMock_DbContext_ShouldReturnTypedTrackedMock_WhenDbContextHelperTracksContextFirst()
+        {
+            var dbContextMock = Mocks.GetMockDbContext<MyDbContext>();
 
-            mockDbContext.Should().BeSameAs(Mocks.GetMock<MyDbContext>());
+            var trackedMock = Mocks.GetOrCreateMock<MyDbContext>();
+
+            trackedMock.Instance.Should().BeSameAs(dbContextMock.Object);
+            trackedMock.NativeMock.Should().BeSameAs(dbContextMock);
+        }
+
+        [Fact]
+        public void GetOrCreateMock_DbContext_ShouldReturnTypedTrackedMock_WhenBuiltInManagedResolutionTracksContextFirst()
+        {
+            var dbContext = Mocks.GetObject<MyDbContext>();
+
+            var trackedMock = Mocks.GetOrCreateMock<MyDbContext>();
+
+            trackedMock.Instance.Should().BeSameAs(dbContext);
+            trackedMock.NativeMock.Should().BeSameAs(Mocks.GetMockDbContext<MyDbContext>());
         }
 
         [Fact]

--- a/FastMoq.Tests/HttpTests.cs
+++ b/FastMoq.Tests/HttpTests.cs
@@ -1,4 +1,5 @@
 ﻿using FastMoq.Extensions;
+using FastMoq.Providers.MoqProvider;
 using FastMoq.Tests.TestClasses;
 using Moq.Protected;
 using System;
@@ -58,12 +59,12 @@ namespace FastMoq.Tests
         [Fact]
         public void GetObject_HttpClient_ShouldPreferTrackedMock_OverBuiltIn()
         {
-            var trackedMock = Mocks.GetMock<HttpClient>();
-            trackedMock.Object.BaseAddress = new Uri("http://tracked.fastmoq/");
+            var trackedMock = Mocks.GetOrCreateMock<HttpClient>();
+            trackedMock.Instance.BaseAddress = new Uri("http://tracked.fastmoq/");
 
             var httpClient = Mocks.GetObject<HttpClient>();
 
-            httpClient.Should().BeSameAs(trackedMock.Object);
+            httpClient.Should().BeSameAs(trackedMock.Instance);
         }
 
         [Fact]
@@ -211,7 +212,7 @@ namespace FastMoq.Tests
         public async Task TrackedHttpMessageHandlerMock_ShouldDriveHttpClientRequests()
         {
             // Add mocks / setup
-            Mock<HttpMessageHandler> handler = Mocks.GetMock<HttpMessageHandler>();
+            var handler = Mocks.GetOrCreateMock<HttpMessageHandler>();
 
             handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(() =>

--- a/FastMoq.Tests/InternalSampleServiceTests.cs
+++ b/FastMoq.Tests/InternalSampleServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using FluentAssertions;
+using System.IO.Abstractions;
+using Xunit;
+
+namespace FastMoq.Tests
+{
+    public class InternalSampleServiceTests
+    {
+        [Fact]
+        public void PublicTestClass_ShouldCreateInternalService_WhenInternalHarnessEnablesNonPublicFallback()
+        {
+            using var testBase = new InternalSampleServiceWithFallbackTestBase();
+
+            testBase.Sut.Should().NotBeNull();
+            testBase.Sut.HasJsonExtension("settings.json").Should().BeTrue();
+        }
+
+        [Fact]
+        public void PublicTestClass_ShouldExerciseInternalServiceBehavior_ThroughInternalHarness()
+        {
+            using var testBase = new InternalSampleServiceWithFallbackTestBase();
+
+            testBase.Sut.HasJsonExtension("settings.txt").Should().BeFalse();
+        }
+    }
+
+    internal sealed class InternalSampleServiceWithFallbackTestBase : MockerTestBase<InternalSampleService>
+    {
+        protected override Action<MockerPolicyOptions>? ConfigureMockerPolicy => policy =>
+        {
+            policy.DefaultFallbackToNonPublicConstructors = false;
+        };
+
+        protected override InstanceCreationFlags ComponentCreationFlags => InstanceCreationFlags.AllowNonPublicConstructorFallback;
+
+        internal InternalSampleService Sut => Component;
+    }
+
+    internal sealed class InternalSampleService
+    {
+        private readonly IFileSystem _fileSystem;
+
+        internal InternalSampleService(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public bool HasJsonExtension(string path)
+        {
+            return string.Equals(_fileSystem.Path.GetExtension(path), ".json", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/FastMoq.Tests/MockerCreationExtensionsTests.cs
+++ b/FastMoq.Tests/MockerCreationExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using FastMoq.Extensions;
+using FastMoq.Providers.MoqProvider;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
@@ -47,21 +48,21 @@ namespace FastMoq.Tests
         [Fact]
         public void SetupMockProperty_ShouldAssignValue_WhenUsingPropertyInfo()
         {
-            var mock = Mocks.GetMock<IFormFile>();
+            var mock = Mocks.GetOrCreateMock<IFormFile>().AsMoq();
             mock.SetupMockProperty(typeof(IFormFile).GetProperty("Headers"), new HeaderDictionary());
         }
 
         [Fact]
         public void SetupMockProperty_ShouldAssignValue_WhenUsingPropertyName()
         {
-            var mock = Mocks.GetMock<IFormFile>();
+            var mock = Mocks.GetOrCreateMock<IFormFile>().AsMoq();
             mock.SetupMockProperty("Headers", new HeaderDictionary());
         }
 
         [Fact]
         public void SetupMockProperty_ShouldAssignValue_WhenUsingPropertyExpression()
         {
-            var mock = Mocks.GetMock<IFormFile>();
+            var mock = Mocks.GetOrCreateMock<IFormFile>().AsMoq();
             mock.SetupMockProperty(x => x.Headers, new HeaderDictionary());
         }
     }

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -1,6 +1,7 @@
 using FastMoq.Extensions;
 using FastMoq.Models;
 using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
 using FastMoq.Tests.TestBase;
 using FastMoq.Tests.TestClasses;
 using Microsoft.EntityFrameworkCore;
@@ -434,11 +435,11 @@ namespace FastMoq.Tests
         }
 
         [Fact]
-        public void GetMock_IFileSystem_ShouldCreatePreconfiguredMock()
+        public void GetOrCreateMock_IFileSystem_ShouldCreatePreconfiguredMock()
         {
             // Arrange & Act
-            var fileSystemMock = Mocks.GetMock<IFileSystem>();
-            var fileSystemObject = fileSystemMock.Object;
+            var fileSystemMock = Mocks.GetOrCreateMock<IFileSystem>();
+            var fileSystemObject = fileSystemMock.Instance;
 
             // Assert - mock should be set up with delegated properties
             fileSystemObject.File.Should().NotBeNull();
@@ -451,12 +452,12 @@ namespace FastMoq.Tests
         }
 
         [Fact]
-        public void GetMock_IFileSystem_ShouldRemainPreconfigured_WhenFailOnUnconfiguredIsEnabled()
+        public void GetOrCreateMock_IFileSystem_ShouldRemainPreconfigured_WhenFailOnUnconfiguredIsEnabled()
         {
             Mocks.Behavior.Enabled |= MockFeatures.FailOnUnconfigured;
 
-            var fileSystemMock = Mocks.GetMock<IFileSystem>();
-            var fileSystemObject = fileSystemMock.Object;
+            var fileSystemMock = Mocks.GetOrCreateMock<IFileSystem>();
+            var fileSystemObject = fileSystemMock.Instance;
 
             fileSystemObject.File.Should().NotBeNull();
             fileSystemObject.Directory.Should().NotBeNull();
@@ -1129,7 +1130,7 @@ namespace FastMoq.Tests
                 return index;
             }
 
-            _ = Component.GetMock<IFile>();
+            _ = Component.GetOrCreateMock<IFile>();
             var mockCount = Component.mockCollection.Count;
 
             // Should not find it, because it doesn't exist.
@@ -1146,15 +1147,15 @@ namespace FastMoq.Tests
         }
 
         [Fact]
-        public void GetMockValueTest()
+        public void GetOrCreateMockValueTest()
         {
-            Mock<ITestClassMany> mock = Component.GetMock<ITestClassMany>();
+            var mock = Component.GetOrCreateMock<ITestClassMany>();
             mock.Setup(x => x.Value).Returns(1);
-            var mock1Object = mock.Object;
+            var mock1Object = mock.Instance;
 
-            Mock<ITestClassMany> mock2 = Component.GetMock<ITestClassMany>();
+            var mock2 = Component.GetOrCreateMock<ITestClassMany>();
             mock2.Setup(x => x.Value).Returns(2);
-            var mock2Object = mock2.Object;
+            var mock2Object = mock2.Instance;
 
             mock1Object.Value.Should().Be(mock2Object.Value);
         }
@@ -1162,29 +1163,35 @@ namespace FastMoq.Tests
         [Fact]
         public void GetObject()
         {
-            var a = Mocks.GetMock<IFileInfo>().Object;
+            var aMock = Mocks.GetOrCreateMock<IFileInfo>();
+            var a = aMock.Instance;
             a.Should().Be(Mocks.GetObject<IFileInfo>());
-            Mocks.GetMock<IFileInfo>().CallBase.Should().BeFalse();
+            ((Mock<IFileInfo>) aMock.NativeMock).CallBase.Should().BeFalse();
 
+            var bMock = Mocks.GetOrCreateMock<IDirectoryInfo>();
             var b = Mocks.GetObject<IDirectoryInfo>();
-            b.Should().Be(Mocks.GetMock<IDirectoryInfo>().Object);
-            Mocks.GetMock<IDirectoryInfo>().CallBase.Should().BeFalse();
+            b.Should().Be(bMock.Instance);
+            ((Mock<IDirectoryInfo>) bMock.NativeMock).CallBase.Should().BeFalse();
 
+            var cMock = Mocks.GetOrCreateMock<ITestClassNormal>();
             var c = Mocks.GetObject<ITestClassNormal>();
-            c.Should().Be(Mocks.GetMock<ITestClassNormal>().Object);
-            Mocks.GetMock<ITestClassNormal>().CallBase.Should().BeFalse();
+            c.Should().Be(cMock.Instance);
+            ((Mock<ITestClassNormal>) cMock.NativeMock).CallBase.Should().BeFalse();
 
+            var dMock = Mocks.GetOrCreateMock<TestClassNormal>();
             var d = Mocks.GetObject<TestClassNormal>();
-            d.Should().Be(Mocks.GetMock<TestClassNormal>().Object);
-            Mocks.GetMock<TestClassNormal>().CallBase.Should().BeTrue();
+            d.Should().Be(dMock.Instance);
+            ((Mock<TestClassNormal>) dMock.NativeMock).CallBase.Should().BeTrue();
 
+            var eMock = Mocks.GetOrCreateMock<ITestClassMany>();
             var e = Mocks.GetObject<ITestClassMany>();
-            e.Should().Be(Mocks.GetMock<ITestClassMany>().Object);
-            Mocks.GetMock<ITestClassMany>().CallBase.Should().BeFalse();
+            e.Should().Be(eMock.Instance);
+            ((Mock<ITestClassMany>) eMock.NativeMock).CallBase.Should().BeFalse();
 
+            var fMock = Mocks.GetOrCreateMock<TestClassMany>();
             var f = Mocks.GetObject<TestClassMany>();
-            f.Should().Be(Mocks.GetMock<TestClassMany>().Object);
-            Mocks.GetMock<TestClassMany>().CallBase.Should().BeTrue();
+            f.Should().Be(fMock.Instance);
+            ((Mock<TestClassMany>) fMock.NativeMock).CallBase.Should().BeTrue();
         }
 
         [Fact]
@@ -1309,7 +1316,7 @@ namespace FastMoq.Tests
             var expectedProvider = new Mock<IServiceProvider>().Object;
 
             _ = Component.GetObject<AbstractServiceProviderHolder>();
-            Component.GetMock<AbstractServiceProviderHolder>()
+            Component.GetOrCreateMock<AbstractServiceProviderHolder>()
                 .Setup(x => x.InstanceServices)
                 .Returns(expectedProvider);
 

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -285,6 +285,52 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void CreateBest_ShouldPreserveThrowBehaviorByDefault_WhenParameterlessFallbackIsAvailable()
+        {
+            new Action(() => Mocks.CreateInstance<SameArityPublicConstructorsWithParameterless>())
+                .Should().Throw<AmbiguousImplementationException>();
+        }
+
+        [Fact]
+        public void CreateBest_ShouldPreferParameterlessConstructor_WhenPolicyRequestsAmbiguityFallback()
+        {
+            Mocks.Policy.DefaultConstructorAmbiguityBehavior = ConstructorAmbiguityBehavior.PreferParameterlessConstructor;
+
+            var instance = Mocks.CreateInstance<SameArityPublicConstructorsWithParameterless>();
+
+            instance.Should().NotBeNull();
+            instance!.SelectedConstructor.Should().Be("parameterless");
+            Mocks.LogEntries.Should().Contain(entry => entry.Message.Contains("fell back to parameterless constructor", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void CreateBest_ShouldPreferParameterlessConstructor_WhenFlagRequestsAmbiguityFallback()
+        {
+            var instance = Mocks.CreateInstance<SameArityPublicConstructorsWithParameterless>(InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
+
+            instance.Should().NotBeNull();
+            instance!.SelectedConstructor.Should().Be("parameterless");
+        }
+
+        [Fact]
+        public void CreateBest_ShouldUsePreferredConstructorAttribute_WhenPresent()
+        {
+            var instance = Mocks.CreateInstance<PreferredConstructorTarget>();
+
+            instance.Should().NotBeNull();
+            instance!.SelectedConstructor.Should().Be("preferred");
+            Mocks.LogEntries.Should().Contain(entry => entry.Message.Contains("[PreferredConstructor]", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void CreateBest_ShouldThrow_WhenMultiplePreferredConstructorsExist()
+        {
+            new Action(() => Mocks.CreateInstance<MultiplePreferredConstructorsTarget>())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage("*multiple constructors marked with [PreferredConstructor]*");
+        }
+
+        [Fact]
         public void GetOrCreateMock_ShouldAllowNonPublicConstructorsByDefault_WhenLenient()
         {
             var fastMock = Mocks.GetOrCreateMock<NonPublicOnlyMockTarget>();
@@ -2090,6 +2136,59 @@ namespace FastMoq.Tests
         public SameArityPublicConstructors(IFile file)
         {
             ArgumentNullException.ThrowIfNull(file);
+        }
+    }
+
+    internal sealed class SameArityPublicConstructorsWithParameterless
+    {
+        public SameArityPublicConstructorsWithParameterless()
+        {
+            SelectedConstructor = "parameterless";
+        }
+
+        public SameArityPublicConstructorsWithParameterless(IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(fileSystem);
+            SelectedConstructor = nameof(IFileSystem);
+        }
+
+        public SameArityPublicConstructorsWithParameterless(IFile file)
+        {
+            ArgumentNullException.ThrowIfNull(file);
+            SelectedConstructor = nameof(IFile);
+        }
+
+        public string SelectedConstructor { get; }
+    }
+
+    internal sealed class PreferredConstructorTarget
+    {
+        public PreferredConstructorTarget(IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(fileSystem);
+            SelectedConstructor = nameof(IFileSystem);
+        }
+
+        [PreferredConstructor]
+        public PreferredConstructorTarget()
+        {
+            SelectedConstructor = "preferred";
+        }
+
+        public string SelectedConstructor { get; }
+    }
+
+    internal sealed class MultiplePreferredConstructorsTarget
+    {
+        [PreferredConstructor]
+        public MultiplePreferredConstructorsTarget()
+        {
+        }
+
+        [PreferredConstructor]
+        public MultiplePreferredConstructorsTarget(IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(fileSystem);
         }
     }
 

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -315,6 +315,16 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void CreateBest_ShouldPreferParameterlessConstructor_ForNonPublicFallback_WhenFlagRequestsAmbiguityFallback()
+        {
+            var instance = Mocks.CreateInstance<NonPublicAmbiguousConstructorsWithParameterless>(
+                InstanceCreationFlags.AllowNonPublicConstructorFallback | InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
+
+            instance.Should().NotBeNull();
+            instance!.SelectedConstructor.Should().Be("parameterless");
+        }
+
+        [Fact]
         public void CreateBest_ShouldUsePreferredConstructorAttribute_WhenPresent()
         {
             var instance = Mocks.CreateInstance<PreferredConstructorTarget>();
@@ -1311,6 +1321,22 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void GetArgData_ShouldHonorAmbiguityFallbackFlag()
+        {
+            var args = Component.GetArgData<SameArityPublicConstructorsWithParameterless>(
+                InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
+
+            args.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CreateInstanceByType_ShouldRequireExactParameterlessSignature_WhenEmptyTypeArrayIsProvided()
+        {
+            new Action(() => Mocks.CreateInstanceByType<NoParameterlessConstructorSelectionTarget>(Array.Empty<Type>()))
+                .Should().Throw<NotImplementedException>();
+        }
+
+        [Fact]
         public void GetObject_ShouldPreserveConfiguredMockPropertiesAcrossRepeatedResolutions()
         {
             var expectedProvider = new Mock<IServiceProvider>().Object;
@@ -2162,6 +2188,36 @@ namespace FastMoq.Tests
         }
 
         public string SelectedConstructor { get; }
+    }
+
+    internal sealed class NonPublicAmbiguousConstructorsWithParameterless
+    {
+        protected NonPublicAmbiguousConstructorsWithParameterless()
+        {
+            SelectedConstructor = "parameterless";
+        }
+
+        protected NonPublicAmbiguousConstructorsWithParameterless(IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(fileSystem);
+            SelectedConstructor = nameof(IFileSystem);
+        }
+
+        protected NonPublicAmbiguousConstructorsWithParameterless(IFile file)
+        {
+            ArgumentNullException.ThrowIfNull(file);
+            SelectedConstructor = nameof(IFile);
+        }
+
+        public string SelectedConstructor { get; }
+    }
+
+    internal sealed class NoParameterlessConstructorSelectionTarget
+    {
+        public NoParameterlessConstructorSelectionTarget(IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(fileSystem);
+        }
     }
 
     internal sealed class PreferredConstructorTarget

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -121,10 +121,11 @@ namespace FastMoq.Tests
         [Fact]
         public void GetNativeMock_ShouldReturnProviderNativeObject()
         {
+            var fastMock = Mocks.GetOrCreateMock<IFileSystemInfo>();
             var nativeMock = Mocks.GetNativeMock<IFileSystemInfo>();
 
             nativeMock.Should().BeOfType<Mock<IFileSystemInfo>>();
-            nativeMock.Should().BeSameAs(Mocks.GetMock<IFileSystemInfo>());
+            nativeMock.Should().BeSameAs(fastMock.NativeMock);
         }
 
         [Fact]
@@ -154,11 +155,11 @@ namespace FastMoq.Tests
         [Fact]
         public void GetMockModel_NativeMock_ShouldMatchCurrentProviderObject()
         {
-            Mocks.GetMock<IFileSystem>();
+            var fastMock = Mocks.GetOrCreateMock<IFileSystem>();
             var mockModel = Mocks.GetMockModel<IFileSystem>();
 
             mockModel.NativeMock.Should().BeOfType<Mock<IFileSystem>>();
-            mockModel.NativeMock.Should().BeSameAs(Mocks.GetNativeMock<IFileSystem>());
+            mockModel.NativeMock.Should().BeSameAs(fastMock.NativeMock);
         }
 
         [Fact]
@@ -407,13 +408,13 @@ namespace FastMoq.Tests
         public void GetObject_IFileSystem_ShouldReturnTrackedMockWhenExists()
         {
             // Arrange
-            var trackedMock = Mocks.GetMock<IFileSystem>();
+            var trackedMock = Mocks.GetOrCreateMock<IFileSystem>();
 
             // Act
             var result = Mocks.GetObject<IFileSystem>();
 
             // Assert - should return the tracked mock, not the built-in
-            result.Should().BeSameAs(trackedMock.Object);
+            result.Should().BeSameAs(trackedMock.Instance);
             Mocks.Contains<IFileSystem>().Should().BeTrue();
         }
 
@@ -806,8 +807,8 @@ namespace FastMoq.Tests
         public void CreateMockWithInjectParameters()
         {
             Mocks.AddType<ITestClassOne, TestClassOne>();
-            Mocks.GetMock<ITestClassOne>().Object.FileSystem.Should().NotBeNull();
-            Mocks.GetMock<TestClassOne>().Object.FileSystem.Should().NotBeNull();
+            Mocks.GetOrCreateMock<ITestClassOne>().Instance.FileSystem.Should().NotBeNull();
+            Mocks.GetOrCreateMock<TestClassOne>().Instance.FileSystem.Should().NotBeNull();
         }
 
         [Fact]
@@ -1460,7 +1461,7 @@ namespace FastMoq.Tests
             Mocks.GetObject<TestClassDouble1>().Value.Should().Be(33);
             Mocks.GetObject<TestClassDouble1>().Value = 44;
             Mocks.GetObject<TestClassDouble1>().Value.Should().Be(44);
-            Mocks.GetMock<TestClassDouble1>().Object.Value.Should().Be(44);
+            Mocks.GetOrCreateMock<TestClassDouble1>().Instance.Value.Should().Be(44);
         }
 
         [Fact]
@@ -1865,8 +1866,7 @@ namespace FastMoq.Tests
         [Fact]
         public void AddProperties_WritableProperty_ShouldHaveValue2()
         {
-            var mock = Mocks.GetMock<SubscriptionData>();
-            var obj = mock.Object;
+            var obj = Mocks.GetObject<SubscriptionData>();
             Component.AddProperties(obj, new KeyValuePair<string, object>("DisplayName", "TestDisplay"), new KeyValuePair<string, object>("SubscriptionId", "testSub"), new KeyValuePair<string, object>("tenantId", Guid.NewGuid()));
             obj.DisplayName.Should().NotBeNullOrEmpty();
             obj.SubscriptionId.Should().NotBeNullOrEmpty();
@@ -1879,8 +1879,7 @@ namespace FastMoq.Tests
         public void AddProperties_WritableProperty_WithAddType_ShouldHaveValues2()
         {
             Mocks.AddType("Display Name Test");
-            var mock = Mocks.GetMock<SubscriptionData>();
-            var obj = mock.Object;
+            var obj = Mocks.GetObject<SubscriptionData>();
             Component.AddProperties(obj, new KeyValuePair<string, object>("DisplayName", "TestDisplay"));
             obj.DisplayName.Should().Be("TestDisplay");
             obj.SubscriptionId.Should().Be("Display Name Test");
@@ -1891,8 +1890,7 @@ namespace FastMoq.Tests
         [Fact]
         public void AddProperties_Test()
         {
-            var mock = Mocks.GetMock<SubscriptionData>();
-            var obj = mock.Object;
+            var obj = Mocks.GetObject<SubscriptionData>();
             Component.AddProperties(obj,
                 new KeyValuePair<string, object>("DisplayName", "TestDisplay"),
                 new KeyValuePair<string, object>("TenantId", Guid.NewGuid()),
@@ -1926,8 +1924,7 @@ namespace FastMoq.Tests
             Mocks.AddType(Guid.NewGuid() as Guid?);
             Mocks.AddType(Guid.NewGuid());
             Mocks.OptionalParameterResolution = OptionalParameterResolutionMode.ResolveViaMocker;
-            var mock = Mocks.GetMock<SubscriptionData>();
-            var obj = mock.Object;
+            var obj = Mocks.GetObject<SubscriptionData>();
             obj.DisplayName.Should().Be("Test1");
             obj.SubscriptionId.Should().Be("Test2");
             obj.TenantId.Should().NotBeNull();
@@ -1956,8 +1953,7 @@ namespace FastMoq.Tests
             });
             Mocks.AddType(Guid.NewGuid() as Guid?);
             Mocks.AddType(Guid.NewGuid());
-            var mock = Mocks.GetMock<SubscriptionData>();
-            var obj = mock.Object;
+            var obj = Mocks.GetObject<SubscriptionData>();
             obj.DisplayName.Should().Be("Test1");
             obj.SubscriptionId.Should().Be("Test2");
             obj.TenantId.Should().NotBeNull();
@@ -2008,8 +2004,8 @@ namespace FastMoq.Tests
 
         private static void SetupAction(Mocker mocks)
         {
-            mocks.GetMock<IDirectory>().SetupAllProperties();
-            mocks.GetMock<IFileInfo>().SetupAllProperties();
+            ((Mock<IDirectory>)mocks.GetOrCreateMock<IDirectory>().NativeMock).SetupAllProperties();
+            ((Mock<IFileInfo>)mocks.GetOrCreateMock<IFileInfo>().NativeMock).SetupAllProperties();
         }
 
         private static OptionalParameterProbe CreateOptionalParameterProbe(ILogger? logger = null, IFileSystem? fileSystem = null)

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -567,13 +567,13 @@ namespace FastMoq.Tests
         {
             using var providerScope = PushProvider("moq");
             var mocker = new Mocker();
-            var dependency = mocker.GetMock<IExpressionConsumer>();
+            var dependency = mocker.GetOrCreateMock<IExpressionConsumer>();
 
             dependency
                 .Setup(x => x.Match(Mocker.BuildExpression<string>()))
                 .Returns(true);
 
-            var matched = dependency.Object.Match(value => value == "alpha");
+            var matched = dependency.Instance.Match(value => value == "alpha");
 
             matched.Should().BeTrue();
         }

--- a/FastMoq.Tests/TestBase/TestBaseTests.cs
+++ b/FastMoq.Tests/TestBase/TestBaseTests.cs
@@ -246,6 +246,45 @@ namespace FastMoq.Tests.TestBase
             }
         }
 
+        public class TestBaseComponentConstructorParameterTypesHook : MockerTestBase<ConstructorTestClass>
+        {
+            protected override Type?[]? ComponentConstructorParameterTypes => new Type?[] { typeof(IFileSystem), typeof(string) };
+
+            [Fact]
+            public void ComponentNotNull()
+            {
+                Component.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void ConstructorCreatedUsingCorrectTypes()
+            {
+                Mocks.ConstructorHistory.AsEnumerable().Should().NotBeEmpty();
+                var parameters = GetConstructor().GetParameters().Select(x => x.ParameterType).ToList();
+                parameters[0].Should().Be(typeof(IFileSystem));
+                parameters[1].Should().Be(typeof(string));
+            }
+        }
+
+        public class TestBaseComponentConstructorParameterTypesHookEmpty : MockerTestBase<ConstructorTestClass>
+        {
+            protected override Type?[]? ComponentConstructorParameterTypes => Array.Empty<Type>();
+
+            [Fact]
+            public void ComponentNotNull()
+            {
+                Component.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void ConstructorCreatedUsingParameterlessConstructor()
+            {
+                Mocks.ConstructorHistory.AsEnumerable().Should().NotBeEmpty();
+                var parameters = GetConstructor().GetParameters().Select(x => x.ParameterType).ToList();
+                parameters.Count().Should().Be(0);
+            }
+        }
+
         public class TestClassParametersTests : MockerTestBase<TestClassMany>
         {
             protected override Func<Mocker, TestClassMany> CreateComponentAction => m => m.CreateInstance<TestClassMany>(55, "test");

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -498,8 +498,7 @@ public class BlogServiceTests : MockerTestBase<BlogService>
 {
     protected override Action<Mocker> SetupMocksAction => mocker =>
     {
-        var dbContextMock = mocker.GetMockDbContext<BlogContext>();
-        mocker.AddType(_ => dbContextMock.Object);
+        _ = mocker.GetMockDbContext<BlogContext>();
     };
 
     [Fact]
@@ -579,8 +578,6 @@ public class BlogServiceAdvancedTests : MockerTestBase<BlogService>
         // Setup specific DbSet behavior if needed
         var blogSet = dbContextMock.Object.Set<Blog>();
         // Additional setup...
-        
-        mocker.AddType(_ => dbContextMock.Object);
     };
 
     [Fact]

--- a/docs/feature-parity/README.md
+++ b/docs/feature-parity/README.md
@@ -101,8 +101,7 @@ public class BlogServiceTests : MockerTestBase<BlogService>
 {
     protected override Action<Mocker> SetupMocksAction => mocker =>
     {
-        var dbContextMock = mocker.GetMockDbContext<BlogContext>();
-        mocker.AddType(_ => dbContextMock.Object);
+        _ = mocker.GetMockDbContext<BlogContext>();
     };
 
     [Fact]

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -152,7 +152,7 @@ Split-package example:
 
 In the current v4 transition layout, `FastMoq.Core` bundles the built-in `moq` provider and the internal `reflection` fallback. The default provider is `reflection`. Optional providers such as `nsubstitute` can be added explicitly and then selected by their canonical name once the package is present, or registered manually under a custom alias. You can also register your own provider by implementing `IMockingProvider`; the bundled providers are examples, not the only supported choices.
 
-The DbContext helper path now exposes explicit modes through `GetDbContextHandle<TContext>(...)`. `GetMockDbContext<TContext>()` remains the mocked-sets convenience entry point, and `DbContextTestMode.RealInMemory` is the real EF-backed option. The mocked-sets implementation still uses the existing moved Moq-based `DbContextMock<TContext>` path internally.
+The DbContext helper path now exposes explicit modes through `GetDbContextHandle<TContext>(...)`. `GetMockDbContext<TContext>()` remains the mocked-sets convenience entry point, `DbContextTestMode.RealInMemory` is the real EF-backed option, and provider-first APIs such as `GetOrCreateMock<TContext>()` and `GetMockModel<TContext>()` return the same tracked context after the helper creates it.
 
 ### Required Using Statements
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -202,11 +202,42 @@ internal sealed class InternalOrderRules
 If the component under test lives in another assembly, expose it to the test assembly with `InternalsVisibleTo` or an equivalent visibility rule first.
 FastMoq handles constructor resolution and injection at runtime; it does not bypass the compiler rule that prevents `public class MyTests : MockerTestBase<InternalType>` when `InternalType` is less accessible than the public test type.
 
+### Explicit Constructor Selection In Tests
+
+When a test needs a specific constructor, prefer a test-side override first.
+That keeps constructor choice inside the test harness and avoids changing production code only to satisfy test setup.
+
+For `MockerTestBase<TComponent>`, override `ComponentConstructorParameterTypes` when you want a specific signature but still want the default FastMoq creation path:
+
+```csharp
+internal sealed class OrderRulesTestBase : MockerTestBase<OrderRules>
+{
+    protected override Type?[]? ComponentConstructorParameterTypes
+        => new Type?[] { typeof(IFileSystem), typeof(string) };
+}
+```
+
+Use `CreateComponentAction` when the test needs full control over creation, custom argument values, or logic that cannot be expressed as a parameter-type signature:
+
+```csharp
+internal sealed class OrderRulesTestBase : MockerTestBase<OrderRules>
+{
+    protected override Func<Mocker, OrderRules> CreateComponentAction => mocker =>
+        mocker.CreateInstanceByType<OrderRules>(
+            InstanceCreationFlags.AllowNonPublicConstructorFallback,
+            typeof(IFileSystem),
+            typeof(string))!;
+}
+```
+
+The older `MockerTestBase(params Type[] createArgumentTypes)` constructor still works, but the override-based hook is the better default for new test bases because it keeps constructor intent local to the derived type.
+
 ### Constructor Ambiguity And Preferred Constructors
 
 FastMoq still throws by default when multiple same-rank constructors remain viable after candidate filtering. That preserves the current behavior for existing suites.
 
-If you want an explicit constructor override without switching to `CreateInstanceByType(...)`, mark the intended constructor:
+If you control the production type and want it to advertise a preferred default constructor for all callers, you can mark it explicitly with `[PreferredConstructor]`.
+That is secondary to the test-side hooks above and is most useful when constructor preference is part of the component's intended public shape, not just a test need:
 
 ```csharp
 internal sealed class OrderRules
@@ -232,8 +263,6 @@ var component = Mocks.CreateInstance<MyComponent>(
 ```
 
 FastMoq writes constructor-selection diagnostics into `Mocks.LogEntries` when `[PreferredConstructor]` is used or when ambiguity fallback is applied.
-
-Use the older methods when preserving existing tests or public API compatibility matters. Internally, FastMoq now routes constructor creation through the same shared resolution rules.
 
 ## Optional Constructor And Method Parameters
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -155,6 +155,84 @@ If you want to change the default constructor-fallback policy for the whole [Moc
 Mocks.Policy.DefaultFallbackToNonPublicConstructors = false;
 ```
 
+### Internal And Protected Components
+
+FastMoq can create components that use internal or protected constructors, but C# still enforces compile-time accessibility on the test type itself.
+
+If a test framework requires the outward test class to remain public, use a public test class plus an internal FastMoq harness:
+
+```csharp
+public class InternalOrderRulesTests
+{
+    [Fact]
+    public void PublicTestClass_CanExercise_InternalService()
+    {
+        using var harness = new InternalOrderRulesHarness();
+
+        harness.Sut.IsPriority("P1").Should().BeTrue();
+    }
+}
+
+internal sealed class InternalOrderRulesHarness : MockerTestBase<InternalOrderRules>
+{
+    protected override Action<MockerPolicyOptions>? ConfigureMockerPolicy => policy =>
+    {
+        policy.DefaultFallbackToNonPublicConstructors = false;
+    };
+
+    protected override InstanceCreationFlags ComponentCreationFlags
+        => InstanceCreationFlags.AllowNonPublicConstructorFallback;
+
+    internal InternalOrderRules Sut => Component;
+}
+
+internal sealed class InternalOrderRules
+{
+    internal InternalOrderRules()
+    {
+    }
+
+    public bool IsPriority(string code)
+    {
+        return code == "P1";
+    }
+}
+```
+
+If the component under test lives in another assembly, expose it to the test assembly with `InternalsVisibleTo` or an equivalent visibility rule first.
+FastMoq handles constructor resolution and injection at runtime; it does not bypass the compiler rule that prevents `public class MyTests : MockerTestBase<InternalType>` when `InternalType` is less accessible than the public test type.
+
+### Constructor Ambiguity And Preferred Constructors
+
+FastMoq still throws by default when multiple same-rank constructors remain viable after candidate filtering. That preserves the current behavior for existing suites.
+
+If you want an explicit constructor override without switching to `CreateInstanceByType(...)`, mark the intended constructor:
+
+```csharp
+internal sealed class OrderRules
+{
+    [PreferredConstructor]
+    public OrderRules()
+    {
+    }
+
+    public OrderRules(IFileSystem fileSystem)
+    {
+    }
+}
+```
+
+If you want FastMoq to fall back to a parameterless constructor when ambiguity remains, opt in explicitly through policy or a per-call flag:
+
+```csharp
+Mocks.Policy.DefaultConstructorAmbiguityBehavior = ConstructorAmbiguityBehavior.PreferParameterlessConstructor;
+
+var component = Mocks.CreateInstance<MyComponent>(
+    InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
+```
+
+FastMoq writes constructor-selection diagnostics into `Mocks.LogEntries` when `[PreferredConstructor]` is used or when ambiguity fallback is applied.
+
 Use the older methods when preserving existing tests or public API compatibility matters. Internally, FastMoq now routes constructor creation through the same shared resolution rules.
 
 ## Optional Constructor And Method Parameters

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -409,15 +409,15 @@ When you need to choose between pure mock behavior and a real EF in-memory conte
 protected override Action<Mocker> SetupMocksAction => mocker =>
 {
     var dbContextMock = mocker.GetMockDbContext<ApplicationDbContext>();
-    mocker.AddType(_ => dbContextMock.Object);
+    dbContextMock.Object.Database.EnsureCreated();
 };
 ```
 
 Recommended pattern:
 
 1. Create the context mock with [GetMockDbContext&lt;TContext&gt;()](xref:FastMoq.DbContextMockerExtensions.GetMockDbContext``1(FastMoq.Mocker)).
-2. Add the context object into the type map when the component under test expects the context itself.
-3. Seed test data through the resolved context object before calling the system under test.
+2. Seed test data through the resolved context object or `dbContextMock.Object` before calling the system under test.
+3. If you need the tracked provider-first handle for the same context, call `GetOrCreateMock<TContext>()` after the helper has tracked it; the returned mock exposes that same tracked context.
 
 This is the supported path for EF Core tests in this repo. It keeps DbSet setup and context creation aligned with the framework's existing helper behavior.
 

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -500,6 +500,35 @@ Use `InternalsVisibleTo` when the SUT lives in another assembly.
 The supported runtime behavior is: FastMoq can create the non-public component once the test can legally reference it.
 The unsupported assumption is: FastMoq can make `public class MyTests : MockerTestBase<InternalType>` compile. That remains a compiler restriction, not a FastMoq runtime limitation.
 
+### Explicit Constructor Selection In Tests
+
+When tests need a specific constructor, prefer selecting it from the test base instead of annotating production code for test-only reasons.
+
+For `MockerTestBase<TComponent>`, the primary hook is `ComponentConstructorParameterTypes`:
+
+```csharp
+internal sealed class OrderRulesTestBase : MockerTestBase<OrderRules>
+{
+    protected override Type?[]? ComponentConstructorParameterTypes
+        => new Type?[] { typeof(IFileSystem), typeof(string) };
+}
+```
+
+If constructor selection also needs custom creation logic, use `CreateComponentAction`:
+
+```csharp
+internal sealed class OrderRulesTestBase : MockerTestBase<OrderRules>
+{
+    protected override Func<Mocker, OrderRules> CreateComponentAction => mocker =>
+        mocker.CreateInstanceByType<OrderRules>(
+            InstanceCreationFlags.AllowNonPublicConstructorFallback,
+            typeof(IFileSystem),
+            typeof(string))!;
+}
+```
+
+The older `MockerTestBase(params Type[] createArgumentTypes)` constructor remains available for compatibility, but the property-based hook is the recommended path for new test bases.
+
 ### Constructor Ambiguity Overrides
 
 FastMoq keeps the existing ambiguity-throw behavior by default.
@@ -514,7 +543,7 @@ var component = Mocks.CreateInstance<MyComponent>(
     InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
 ```
 
-If one constructor should win regardless of arity, mark it explicitly:
+If production code itself should advertise a preferred default constructor for all callers, mark it explicitly:
 
 ```csharp
 internal sealed class OrderRules

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -381,7 +381,7 @@ Practical guidance:
 - if you install `FastMoq`, keep using `GetMockDbContext<TContext>()` as before
 - if you install `FastMoq.Core` directly, also install `FastMoq.Database`
 - use `GetDbContextHandle<TContext>(...)` when you need to choose explicitly between mocked sets and a real in-memory EF context
-- do not assume the mocked-sets helper is provider-neutral yet; today that path still uses the moved Moq-based implementation
+- once `GetMockDbContext<TContext>()` or `GetDbContextHandle<TContext>(...)` has tracked the DbContext in mocked-sets mode, `GetOrCreateMock<TContext>()` and `GetMockModel<TContext>()` return that same tracked context through the provider-first APIs
 
 Current repo behavior now makes the mode split explicit:
 

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -464,6 +464,74 @@ The default constructor-fallback policy is now also explicit at the `Mocker` lev
 Mocks.Policy.DefaultFallbackToNonPublicConstructors = false;
 ```
 
+### Public Test Classes And Internal Components
+
+FastMoq now supports non-public component construction through the same flags-based model, but it does not change C# accessibility rules.
+
+If a public test class needs to validate an internal or protected component, keep the public test as a wrapper and move the `MockerTestBase<TComponent>` inheritance into an internal helper:
+
+```csharp
+public class InternalOrderRulesTests
+{
+    [Fact]
+    public void PublicTestClass_CanExercise_InternalService()
+    {
+        using var harness = new InternalOrderRulesHarness();
+
+        harness.Sut.IsPriority("P1").Should().BeTrue();
+    }
+}
+
+internal sealed class InternalOrderRulesHarness : MockerTestBase<InternalOrderRules>
+{
+    protected override Action<MockerPolicyOptions>? ConfigureMockerPolicy => policy =>
+    {
+        policy.DefaultFallbackToNonPublicConstructors = false;
+    };
+
+    protected override InstanceCreationFlags ComponentCreationFlags
+        => InstanceCreationFlags.AllowNonPublicConstructorFallback;
+
+    internal InternalOrderRules Sut => Component;
+}
+```
+
+Use `InternalsVisibleTo` when the SUT lives in another assembly.
+The supported runtime behavior is: FastMoq can create the non-public component once the test can legally reference it.
+The unsupported assumption is: FastMoq can make `public class MyTests : MockerTestBase<InternalType>` compile. That remains a compiler restriction, not a FastMoq runtime limitation.
+
+### Constructor Ambiguity Overrides
+
+FastMoq keeps the existing ambiguity-throw behavior by default.
+That means a suite that already expected an `AmbiguousImplementationException` continues to behave the same way until you opt into a different fallback rule.
+
+Current additive options are:
+
+```csharp
+Mocks.Policy.DefaultConstructorAmbiguityBehavior = ConstructorAmbiguityBehavior.PreferParameterlessConstructor;
+
+var component = Mocks.CreateInstance<MyComponent>(
+    InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity);
+```
+
+If one constructor should win regardless of arity, mark it explicitly:
+
+```csharp
+internal sealed class OrderRules
+{
+    [PreferredConstructor]
+    public OrderRules()
+    {
+    }
+
+    public OrderRules(IFileSystem fileSystem)
+    {
+    }
+}
+```
+
+Constructor-selection diagnostics for these paths are captured in `Mocks.LogEntries`.
+
 ### Obsolete `MockOptional`
 
 Old pattern:

--- a/docs/samples/ecommerce-orders/README.md
+++ b/docs/samples/ecommerce-orders/README.md
@@ -290,8 +290,7 @@ public class OrderRepositoryTests : MockerTestBase<OrderRepository>
 {
     protected override Action<Mocker> SetupMocksAction => mocker =>
     {
-        var dbContextMock = mocker.GetMockDbContext<ECommerceDbContext>();
-        mocker.AddType(_ => dbContextMock.Object);
+        _ = mocker.GetMockDbContext<ECommerceDbContext>();
     };
 
     [Fact]

--- a/docs/whats-new/README.md
+++ b/docs/whats-new/README.md
@@ -153,7 +153,9 @@ The new database surface includes:
 
 `GetMockDbContext<TContext>()` remains available through the `FastMoq` namespace for low-churn usage, but the implementation and EF-specific dependencies now live in `FastMoq.Database`.
 
-The mocked-sets path still uses the existing Moq-based `DbContextMock<TContext>` internals, while real EF-backed in-memory behavior is now exposed explicitly through `DbContextTestMode.RealInMemory`.
+The mocked-sets helper continues to create and configure the tracked DbContext, while real EF-backed in-memory behavior is now exposed explicitly through `DbContextTestMode.RealInMemory`. That same tracked context is also available through provider-first retrieval such as `GetOrCreateMock<TContext>()`.
+
+Constructor-selection updates in this PR also add an explicit `MockerTestBase<TComponent>.ComponentConstructorParameterTypes` hook, a `[PreferredConstructor]` attribute for production types that advertise a default constructor choice, and `ConstructorAmbiguityBehavior` policy support for opt-in fallback behavior.
 
 ### Compatibility and behavior cleanup
 


### PR DESCRIPTION
## Summary
- add additive constructor ambiguity control via `MockerPolicyOptions.DefaultConstructorAmbiguityBehavior` and `InstanceCreationFlags.PreferParameterlessConstructorOnAmbiguity`
- add `[PreferredConstructor]`, constructor-selection diagnostics in `Mocks.LogEntries`, and `MockerTestBase<TComponent>.ComponentConstructorParameterTypes` for test-side constructor selection
- add the issue 42 proof/docs for public tests that use an internal FastMoq harness for internal or protected services
- fix provider-first DbContext rewrap so `GetOrCreateMock<TContext>()` and `GetMockModel<TContext>()` return the tracked context created by `GetMockDbContext<TContext>()` and `GetDbContextHandle<TContext>(...)`
- modernize ordinary tests and docs to use provider-first retrieval and document the supported DbContext behavior instead of the earlier workaround wording

Closes #21
Closes #71