### PR TITLE
Add code fix for FunctionContext helper migration

### DIFF
--- a/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
@@ -18,7 +18,12 @@ namespace FastMoq.Analyzers.Tests
     {
         public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source, params DiagnosticAnalyzer[] analyzers)
         {
-            var document = CreateDocument(source);
+            return await GetDiagnosticsAsync(source, includeAzureFunctionsHelpers: false, analyzers).ConfigureAwait(false);
+        }
+
+        public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source, bool includeAzureFunctionsHelpers, params DiagnosticAnalyzer[] analyzers)
+        {
+            var document = CreateDocument(source, includeAzureFunctionsHelpers);
             return await GetDiagnosticsAsync(document, analyzers).ConfigureAwait(false);
         }
 
@@ -36,9 +41,9 @@ namespace FastMoq.Analyzers.Tests
                 .ConfigureAwait(false);
         }
 
-        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId)
+        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false)
         {
-            var document = CreateDocument(source);
+            var document = CreateDocument(source, includeAzureFunctionsHelpers);
             var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
             var diagnostic = diagnostics.Single(item => item.Id == diagnosticId);
 
@@ -54,6 +59,19 @@ namespace FastMoq.Analyzers.Tests
             return changedRoot!.NormalizeWhitespace().ToFullString();
         }
 
+        public static async Task<ImmutableArray<string>> GetCodeFixTitlesAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false)
+        {
+            var document = CreateDocument(source, includeAzureFunctionsHelpers);
+            var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
+            var diagnostic = diagnostics.Single(item => item.Id == diagnosticId);
+
+            var actions = new List<CodeAction>();
+            var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
+            await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+            return actions.Select(action => action.Title).ToImmutableArray();
+        }
+
         public static string NormalizeCode(string source)
         {
             return CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))
@@ -62,7 +80,7 @@ namespace FastMoq.Analyzers.Tests
                 .ToFullString();
         }
 
-        private static Document CreateDocument(string source)
+        private static Document CreateDocument(string source, bool includeAzureFunctionsHelpers = false)
         {
             var workspace = new AdhocWorkspace();
             var projectId = ProjectId.CreateNewId();
@@ -73,7 +91,7 @@ namespace FastMoq.Analyzers.Tests
                 .WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Preview))
                 .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-            foreach (var metadataReference in GetMetadataReferences())
+            foreach (var metadataReference in GetMetadataReferences(includeAzureFunctionsHelpers))
             {
                 solution = solution.AddMetadataReference(projectId, metadataReference);
             }
@@ -82,13 +100,19 @@ namespace FastMoq.Analyzers.Tests
             return solution.GetDocument(documentId)!;
         }
 
-        private static IEnumerable<MetadataReference> GetMetadataReferences()
+        private static IEnumerable<MetadataReference> GetMetadataReferences(bool includeAzureFunctionsHelpers)
         {
             var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trustedPlatformAssemblies)
             {
                 foreach (var assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
                 {
+                    if (!includeAzureFunctionsHelpers &&
+                        string.Equals(Path.GetFileNameWithoutExtension(assemblyPath), "FastMoq.AzureFunctions", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     references.Add(assemblyPath);
                 }
             }
@@ -101,6 +125,13 @@ namespace FastMoq.Analyzers.Tests
             references.Add(typeof(Microsoft.Extensions.Logging.ILogger).Assembly.Location);
             references.Add(typeof(Microsoft.AspNetCore.Http.DefaultHttpContext).Assembly.Location);
             references.Add(typeof(Microsoft.AspNetCore.Mvc.ControllerContext).Assembly.Location);
+
+            if (includeAzureFunctionsHelpers)
+            {
+                references.Add(typeof(FastMoq.AzureFunctions.Extensions.FunctionContextTestExtensions).Assembly.Location);
+                references.Add(typeof(Microsoft.Azure.Functions.Worker.FunctionContext).Assembly.Location);
+                references.Add(typeof(Azure.Core.Serialization.ObjectSerializer).Assembly.Location);
+            }
 
             return references.Select(path => MetadataReference.CreateFromFile(path));
         }

--- a/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
+++ b/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FastMoq.Analyzers\FastMoq.Analyzers.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\FastMoq.AzureFunctions\FastMoq.AzureFunctions.csproj" />
     <ProjectReference Include="..\FastMoq.Core\FastMoq.Core.csproj" />
     <ProjectReference Include="..\FastMoq.Provider.Moq\FastMoq.Provider.Moq.csproj" />
     <ProjectReference Include="..\FastMoq.Provider.NSubstitute\FastMoq.Provider.NSubstitute.csproj" />

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -652,6 +652,118 @@ class Sample
         }
 
         [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_FunctionContextInstanceServicesReturnsUsage()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    abstract class FunctionContext
+    {
+        public virtual IServiceProvider InstanceServices { get; set; }
+    }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
+        context.SetupGet(x => x.InstanceServices).Returns(provider);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new ServiceProviderShimAnalyzer(), codeFixProvider, DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using FastMoq.AzureFunctions.Extensions;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    abstract class FunctionContext
+    {
+        public virtual IServiceProvider InstanceServices { get; set; }
+    }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
+        Mocks.AddFunctionContextInstanceServices(provider, replace: true);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_FunctionContextInstanceServicesSetupPropertyUsage()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    abstract class FunctionContext
+    {
+        public virtual IServiceProvider InstanceServices { get; set; }
+    }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
+        context.AsMoq().SetupProperty(x => x.InstanceServices, provider);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new ServiceProviderShimAnalyzer(), codeFixProvider, DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using FastMoq.AzureFunctions.Extensions;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    abstract class FunctionContext
+    {
+        public virtual IServiceProvider InstanceServices { get; set; }
+    }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
+        Mocks.AddFunctionContextInstanceServices(provider, replace: true);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task KnownTypeAuthoringAnalyzer_ShouldReport_WhenContextAwareAddTypeOverloadIsUsed()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -672,7 +672,7 @@ class Sample
     void Execute(Mocker Mocks, IServiceProvider provider)
     {
         var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
-        context.SetupGet(x => x.InstanceServices).Returns(provider);
+        context.Setup(x => x.InstanceServices).Returns(provider);
     }
 }";
 
@@ -680,7 +680,12 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
 
-            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new ServiceProviderShimAnalyzer(), codeFixProvider, DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                includeAzureFunctionsHelpers: true);
             var expected = AnalyzerTestHelpers.NormalizeCode(@"
 using System;
 using FastMoq;
@@ -700,11 +705,49 @@ class Sample
     void Execute(Mocker Mocks, IServiceProvider provider)
     {
         var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
-        Mocks.AddFunctionContextInstanceServices(provider, replace: true);
+        context.AddFunctionContextInstanceServices(provider);
     }
 }");
 
             Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportButNotOfferFix_WhenFunctionContextHelperPackageIsUnavailable()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    abstract class FunctionContext
+    {
+        public virtual IServiceProvider InstanceServices { get; set; }
+    }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
+        context.SetupGet(x => x.InstanceServices).Returns(provider);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers);
+
+            Assert.Empty(codeFixTitles);
         }
 
         [Fact]
@@ -736,7 +779,12 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
 
-            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new ServiceProviderShimAnalyzer(), codeFixProvider, DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                includeAzureFunctionsHelpers: true);
             var expected = AnalyzerTestHelpers.NormalizeCode(@"
 using System;
 using FastMoq;
@@ -756,7 +804,7 @@ class Sample
     void Execute(Mocker Mocks, IServiceProvider provider)
     {
         var context = Mocks.GetOrCreateMock<Microsoft.Azure.Functions.Worker.FunctionContext>();
-        Mocks.AddFunctionContextInstanceServices(provider, replace: true);
+        context.AddFunctionContextInstanceServices(provider);
     }
 }");
 

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -20,6 +20,7 @@ namespace FastMoq.Analyzers.CodeFixes
             DiagnosticIds.UseVerifyLogged,
             DiagnosticIds.UseConsistentMockRetrieval,
             DiagnosticIds.UseProviderFirstMockRetrieval,
+            DiagnosticIds.PreferTypedServiceProviderHelpers,
             DiagnosticIds.UseExplicitOptionalParameterResolution,
             DiagnosticIds.ReplaceInitializeCompatibilityWrapper,
             DiagnosticIds.PreferSetupOptionsHelper);
@@ -103,6 +104,30 @@ namespace FastMoq.Analyzers.CodeFixes
                                 "Use GetOrCreateMock<T>()",
                                 cancellationToken => ReplaceGetMockAsync(document, memberAccess, cancellationToken),
                                 diagnostic.Id),
+                            diagnostic);
+                        break;
+                    }
+
+                case DiagnosticIds.PreferTypedServiceProviderHelpers:
+                    {
+                        var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                        if (invocationExpression is null)
+                        {
+                            return;
+                        }
+
+                        var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                        if (semanticModel is null ||
+                            !FastMoqAnalysisHelpers.TryBuildFunctionContextInstanceServicesReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _))
+                        {
+                            return;
+                        }
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Use AddFunctionContextInstanceServices(...)",
+                                cancellationToken => ReplaceFunctionContextInstanceServicesInvocationAsync(document, invocationExpression, cancellationToken),
+                                nameof(DiagnosticIds.PreferTypedServiceProviderHelpers)),
                             diagnostic);
                         break;
                     }
@@ -302,11 +327,27 @@ namespace FastMoq.Analyzers.CodeFixes
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
 
-            if (updatedRoot is CompilationUnitSyntax compilationUnit && !compilationUnit.Usings.Any(@using => @using.Name?.ToString() == "FastMoq.Extensions"))
+            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions"));
+        }
+
+        private static async Task<Document> ReplaceFunctionContextInstanceServicesInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
             {
-                updatedRoot = compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("FastMoq.Extensions")));
+                return document;
             }
 
+            if (!FastMoqAnalysisHelpers.TryBuildFunctionContextInstanceServicesReplacement(invocationExpression, semanticModel, cancellationToken, out var targetInvocation, out var replacementText))
+            {
+                return document;
+            }
+
+            var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
+                .WithTriviaFrom(targetInvocation);
+            var updatedRoot = root.ReplaceNode(targetInvocation, replacementExpression);
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.AzureFunctions.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -324,6 +365,16 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementMemberAccess = memberAccess.WithName(replacementName);
             var updatedRoot = root.ReplaceNode(memberAccess, replacementMemberAccess);
             return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static SyntaxNode AddUsingDirectiveIfMissing(SyntaxNode root, string namespaceName)
+        {
+            if (root is CompilationUnitSyntax compilationUnit && !compilationUnit.Usings.Any(@using => @using.Name?.ToString() == namespaceName))
+            {
+                return compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+            }
+
+            return root;
         }
 
         private delegate string? ReplacementBuilder(Document document, SemanticModel semanticModel, SyntaxNode syntaxNode, CancellationToken cancellationToken);

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -118,6 +118,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
                         var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
                         if (semanticModel is null ||
+                            !FastMoqAnalysisHelpers.HasFunctionContextInstanceServicesMockHelper(semanticModel) ||
                             !FastMoqAnalysisHelpers.TryBuildFunctionContextInstanceServicesReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _))
                         {
                             return;

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -442,6 +442,12 @@ namespace FastMoq.Analyzers
                 TryBuildSetupOptionsAddTypeReplacement(invocationExpression, semanticModel, cancellationToken, out replacement);
         }
 
+        public static bool TryBuildFunctionContextInstanceServicesReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
+        {
+            return TryBuildFunctionContextInstanceServicesReturnsReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement) ||
+                TryBuildFunctionContextInstanceServicesSetupPropertyReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement);
+        }
+
         public static Location GetTargetNameLocation(ExpressionSyntax expression)
         {
             if (expression is MemberAccessExpressionSyntax memberAccess)
@@ -615,6 +621,114 @@ namespace FastMoq.Analyzers
             }
 
             currentApi = $"{method.Name}(x => x.InstanceServices)";
+            return true;
+        }
+
+        private static bool TryBuildFunctionContextInstanceServicesReturnsReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
+        {
+            targetInvocation = null!;
+            replacement = string.Empty;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name is not "Setup" and not "SetupGet" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax setupAccess ||
+                !TryResolveTrackedMockOrigin(setupAccess.Expression, semanticModel, cancellationToken, out var origin) ||
+                origin.ServiceType.ToDisplayString() != FUNCTION_CONTEXT_TYPE ||
+                invocationExpression.Parent is not MemberAccessExpressionSyntax returnsAccess ||
+                returnsAccess.Parent is not InvocationExpressionSyntax returnsInvocation ||
+                !TryGetMethodSymbol(returnsInvocation, semanticModel, cancellationToken, out var returnsMethod) ||
+                returnsMethod is null)
+            {
+                return false;
+            }
+
+            returnsMethod = returnsMethod.ReducedFrom ?? returnsMethod;
+            if (returnsMethod.Name != "Returns" ||
+                returnsInvocation.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            var providerExpression = Unwrap(returnsInvocation.ArgumentList.Arguments[0].Expression);
+            if (providerExpression is LambdaExpressionSyntax or AnonymousMethodExpressionSyntax)
+            {
+                return false;
+            }
+
+            if (!TryGetFunctionContextInstanceServicesMemberAccess(invocationExpression, semanticModel, cancellationToken, out _))
+            {
+                return false;
+            }
+
+            targetInvocation = returnsInvocation;
+            replacement = BuildFunctionContextInstanceServicesReplacement(origin.MockerExpression, providerExpression, semanticModel, returnsInvocation.SpanStart);
+            return true;
+        }
+
+        private static bool TryBuildFunctionContextInstanceServicesSetupPropertyReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
+        {
+            targetInvocation = null!;
+            replacement = string.Empty;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name != "SetupProperty" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !TryResolveTrackedMockOrigin(memberAccess.Expression, semanticModel, cancellationToken, out var origin) ||
+                origin.ServiceType.ToDisplayString() != FUNCTION_CONTEXT_TYPE ||
+                invocationExpression.ArgumentList.Arguments.Count < 2)
+            {
+                return false;
+            }
+
+            if (!TryGetFunctionContextInstanceServicesMemberAccess(invocationExpression, semanticModel, cancellationToken, out _))
+            {
+                return false;
+            }
+
+            var providerExpression = Unwrap(invocationExpression.ArgumentList.Arguments[1].Expression);
+            if (providerExpression is LambdaExpressionSyntax or AnonymousMethodExpressionSyntax)
+            {
+                return false;
+            }
+
+            targetInvocation = invocationExpression;
+            replacement = BuildFunctionContextInstanceServicesReplacement(origin.MockerExpression, providerExpression, semanticModel, invocationExpression.SpanStart);
+            return true;
+        }
+
+        private static bool TryGetFunctionContextInstanceServicesMemberAccess(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out MemberAccessExpressionSyntax memberAccessExpression)
+        {
+            memberAccessExpression = null!;
+
+            if (invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateExpression is not LambdaExpressionSyntax lambdaExpression ||
+                lambdaExpression.Body is not MemberAccessExpressionSyntax memberAccess ||
+                !TryGetPropertySymbol(memberAccess, semanticModel, cancellationToken, out var property) ||
+                property is null ||
+                property.Name != FUNCTION_CONTEXT_INSTANCE_SERVICES_PROPERTY ||
+                property.ContainingType.ToDisplayString() != FUNCTION_CONTEXT_TYPE)
+            {
+                return false;
+            }
+
+            memberAccessExpression = memberAccess;
             return true;
         }
 
@@ -1014,6 +1128,13 @@ namespace FastMoq.Analyzers
             return string.IsNullOrWhiteSpace(replaceArgument)
                 ? $"{mockerExpression}.SetupOptions<{optionsTypeName}>({setupArgument})"
                 : $"{mockerExpression}.SetupOptions<{optionsTypeName}>({setupArgument}, replace: {replaceArgument})";
+        }
+
+        private static string BuildFunctionContextInstanceServicesReplacement(ExpressionSyntax mockerExpressionSyntax, ExpressionSyntax providerExpressionSyntax, SemanticModel semanticModel, int position)
+        {
+            var mockerExpression = mockerExpressionSyntax.WithoutTrivia().ToString();
+            var providerExpression = providerExpressionSyntax.WithoutTrivia().ToString();
+            return $"{mockerExpression}.AddFunctionContextInstanceServices({providerExpression}, replace: true)";
         }
 
         private static IEnumerable<INamedTypeSymbol> GetCandidateTestTargetTypes(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -15,18 +15,26 @@ namespace FastMoq.Analyzers
 
     internal readonly struct TrackedMockOrigin
     {
-        public TrackedMockOrigin(ExpressionSyntax mockerExpression, ITypeSymbol serviceType, TrackedMockOriginKind kind)
+        public TrackedMockOrigin(ExpressionSyntax mockerExpression, ExpressionSyntax trackedMockExpression, ITypeSymbol serviceType, TrackedMockOriginKind kind)
         {
             MockerExpression = mockerExpression;
+            TrackedMockExpression = trackedMockExpression;
             ServiceType = serviceType;
             Kind = kind;
         }
 
         public ExpressionSyntax MockerExpression { get; }
 
+        public ExpressionSyntax TrackedMockExpression { get; }
+
         public ITypeSymbol ServiceType { get; }
 
         public TrackedMockOriginKind Kind { get; }
+
+        public TrackedMockOrigin WithTrackedMockExpression(ExpressionSyntax trackedMockExpression)
+        {
+            return new TrackedMockOrigin(MockerExpression, trackedMockExpression, ServiceType, Kind);
+        }
     }
 
     internal static class FastMoqAnalysisHelpers
@@ -227,9 +235,11 @@ namespace FastMoq.Analyzers
             if (expression is IdentifierNameSyntax identifierName && semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol is ILocalSymbol localSymbol)
             {
                 var declaration = localSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken) as VariableDeclaratorSyntax;
-                if (declaration?.Initializer?.Value is ExpressionSyntax initializer)
+                if (declaration?.Initializer?.Value is ExpressionSyntax initializer &&
+                    TryResolveTrackedMockOrigin(initializer, semanticModel, cancellationToken, out origin))
                 {
-                    return TryResolveTrackedMockOrigin(initializer, semanticModel, cancellationToken, out origin);
+                    origin = origin.WithTrackedMockExpression(identifierName);
+                    return true;
                 }
             }
 
@@ -255,6 +265,7 @@ namespace FastMoq.Analyzers
 
                 origin = new TrackedMockOrigin(
                     memberAccess.Expression,
+                    invocationExpression,
                     method.TypeArguments[0],
                     IsFastMoqMockerMethod(method, "GetMock") ? TrackedMockOriginKind.GetMock : TrackedMockOriginKind.GetOrCreateMock);
                 return true;
@@ -262,7 +273,11 @@ namespace FastMoq.Analyzers
 
             if ((method.Name == "AsMoq" || method.Name == "AsNSubstitute") && invocationExpression.Expression is MemberAccessExpressionSyntax adapterAccess)
             {
-                return TryResolveTrackedMockOrigin(adapterAccess.Expression, semanticModel, cancellationToken, out origin);
+                if (TryResolveTrackedMockOrigin(adapterAccess.Expression, semanticModel, cancellationToken, out origin))
+                {
+                    origin = origin.WithTrackedMockExpression(adapterAccess.Expression);
+                    return true;
+                }
             }
 
             origin = default;
@@ -444,6 +459,13 @@ namespace FastMoq.Analyzers
 
         public static bool TryBuildFunctionContextInstanceServicesReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
         {
+            if (!HasFunctionContextInstanceServicesMockHelper(semanticModel))
+            {
+                targetInvocation = null!;
+                replacement = string.Empty;
+                return false;
+            }
+
             return TryBuildFunctionContextInstanceServicesReturnsReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement) ||
                 TryBuildFunctionContextInstanceServicesSetupPropertyReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement);
         }
@@ -624,6 +646,24 @@ namespace FastMoq.Analyzers
             return true;
         }
 
+        public static bool HasFunctionContextInstanceServicesMockHelper(SemanticModel semanticModel)
+        {
+            var helperType = semanticModel.Compilation.GetTypeByMetadataName("FastMoq.AzureFunctions.Extensions.FunctionContextTestExtensions");
+            if (helperType is null)
+            {
+                return false;
+            }
+
+            return helperType
+                .GetMembers("AddFunctionContextInstanceServices")
+                .OfType<IMethodSymbol>()
+                .Any(method =>
+                    method.IsExtensionMethod &&
+                    method.Parameters.Length == 2 &&
+                    method.Parameters[0].Type.ToDisplayString() == "FastMoq.Providers.IFastMock" &&
+                    method.Parameters[1].Type.ToDisplayString() == SERVICE_PROVIDER_TYPE);
+        }
+
         private static bool TryBuildFunctionContextInstanceServicesReturnsReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
         {
             targetInvocation = null!;
@@ -667,7 +707,7 @@ namespace FastMoq.Analyzers
             }
 
             targetInvocation = returnsInvocation;
-            replacement = BuildFunctionContextInstanceServicesReplacement(origin.MockerExpression, providerExpression, semanticModel, returnsInvocation.SpanStart);
+            replacement = BuildFunctionContextInstanceServicesReplacement(origin.TrackedMockExpression, providerExpression);
             return true;
         }
 
@@ -704,7 +744,7 @@ namespace FastMoq.Analyzers
             }
 
             targetInvocation = invocationExpression;
-            replacement = BuildFunctionContextInstanceServicesReplacement(origin.MockerExpression, providerExpression, semanticModel, invocationExpression.SpanStart);
+            replacement = BuildFunctionContextInstanceServicesReplacement(origin.TrackedMockExpression, providerExpression);
             return true;
         }
 
@@ -1130,11 +1170,11 @@ namespace FastMoq.Analyzers
                 : $"{mockerExpression}.SetupOptions<{optionsTypeName}>({setupArgument}, replace: {replaceArgument})";
         }
 
-        private static string BuildFunctionContextInstanceServicesReplacement(ExpressionSyntax mockerExpressionSyntax, ExpressionSyntax providerExpressionSyntax, SemanticModel semanticModel, int position)
+        private static string BuildFunctionContextInstanceServicesReplacement(ExpressionSyntax trackedMockExpressionSyntax, ExpressionSyntax providerExpressionSyntax)
         {
-            var mockerExpression = mockerExpressionSyntax.WithoutTrivia().ToString();
+            var trackedMockExpression = trackedMockExpressionSyntax.WithoutTrivia().ToString();
             var providerExpression = providerExpressionSyntax.WithoutTrivia().ToString();
-            return $"{mockerExpression}.AddFunctionContextInstanceServices({providerExpression}, replace: true)";
+            return $"{trackedMockExpression}.AddFunctionContextInstanceServices({providerExpression})";
         }
 
         private static IEnumerable<INamedTypeSymbol> GetCandidateTestTargetTypes(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
+++ b/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
@@ -54,6 +54,27 @@ namespace FastMoq.AzureFunctions.Extensions
         }
 
         /// <summary>
+        /// Configures typed <see cref="FunctionContext.InstanceServices" /> behavior on a tracked <see cref="FunctionContext" /> mock without replacing the enclosing <see cref="Mocker" /> service registrations.
+        /// </summary>
+        /// <param name="fastMock">The tracked mock whose <see cref="FunctionContext.InstanceServices" /> getter should return <paramref name="instanceServices" />.</param>
+        /// <param name="instanceServices">The provider to expose through <see cref="FunctionContext.InstanceServices" />.</param>
+        /// <returns>The current tracked mock.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fastMock" /> does not represent a <see cref="FunctionContext" />.</exception>
+        public static IFastMock AddFunctionContextInstanceServices(this IFastMock fastMock, IServiceProvider instanceServices)
+        {
+            ArgumentNullException.ThrowIfNull(fastMock);
+            ArgumentNullException.ThrowIfNull(instanceServices);
+
+            if (!typeof(FunctionContext).IsAssignableFrom(fastMock.MockedType))
+            {
+                throw new ArgumentException($"The supplied mock must represent {typeof(FunctionContext).FullName}.", nameof(fastMock));
+            }
+
+            ConfigureFunctionContextInstanceServices(fastMock, instanceServices);
+            return fastMock;
+        }
+
+        /// <summary>
         /// Registers typed <see cref="FunctionContext.InstanceServices" /> behavior for the current <see cref="Mocker" /> instance.
         /// </summary>
         /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -2192,18 +2192,18 @@ namespace FastMoq.Tests
 
     internal sealed class NonPublicAmbiguousConstructorsWithParameterless
     {
-        protected NonPublicAmbiguousConstructorsWithParameterless()
+        private NonPublicAmbiguousConstructorsWithParameterless()
         {
             SelectedConstructor = "parameterless";
         }
 
-        protected NonPublicAmbiguousConstructorsWithParameterless(IFileSystem fileSystem)
+        private NonPublicAmbiguousConstructorsWithParameterless(IFileSystem fileSystem)
         {
             ArgumentNullException.ThrowIfNull(fileSystem);
             SelectedConstructor = nameof(IFileSystem);
         }
 
-        protected NonPublicAmbiguousConstructorsWithParameterless(IFile file)
+        private NonPublicAmbiguousConstructorsWithParameterless(IFile file)
         {
             ArgumentNullException.ThrowIfNull(file);
             SelectedConstructor = nameof(IFile);

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -252,6 +252,25 @@ namespace FastMoq.Tests
         [Theory]
         [InlineData("moq")]
         [InlineData("nsubstitute")]
+        public void AddFunctionContextInstanceServices_OnTrackedMock_ShouldNotReplaceGlobalServiceProvider(string providerName)
+        {
+            using var providerScope = PushProviderScope(providerName);
+            var mocker = new Mocker();
+            var globalProvider = mocker.CreateTypedServiceProvider(services => services.AddLogging());
+            var functionProvider = mocker.CreateFunctionContextInstanceServices(services => services.AddOptions());
+            var context = mocker.GetOrCreateMock<FunctionContext>();
+
+            mocker.AddServiceProvider(globalProvider, replace: true);
+
+            context.AddFunctionContextInstanceServices(functionProvider);
+
+            context.Instance.InstanceServices.Should().BeSameAs(functionProvider);
+            mocker.GetObject<IServiceProvider>().Should().BeSameAs(globalProvider);
+        }
+
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
         public async Task CreateHttpRequestData_ShouldCreateConfiguredRequestAndDefaultResponse(string providerName)
         {
             using var providerScope = PushProviderScope(providerName);

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -67,8 +67,9 @@ Package note:
 
 Analyzer note:
 
-- `FMOQ0013` warns when a test mocks `FunctionContext.InstanceServices` directly instead of using the typed helper path
-- the built-in code fix can rewrite the common `SetupGet(x => x.InstanceServices).Returns(provider)` and `SetupProperty(x => x.InstanceServices, provider)` patterns to `AddFunctionContextInstanceServices(provider, replace: true)` and add `using FastMoq.AzureFunctions.Extensions;` when needed
+- `FMOQ0013` warns on direct `FunctionContext.InstanceServices` mocking more broadly across `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` so those shims move toward the typed helper path
+- the built-in code fix is narrower: it rewrites the safe tracked-provider cases `Setup(x => x.InstanceServices).Returns(provider)`, `SetupGet(x => x.InstanceServices).Returns(provider)`, and `SetupProperty(x => x.InstanceServices, provider)` to `AddFunctionContextInstanceServices(provider, replace: true)` and adds `using FastMoq.AzureFunctions.Extensions;` when needed
+- `SetupSet(...)` is not part of this analyzer. When the real need is provider-neutral setter observation rather than Moq setter interception, prefer a fake or stub with [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1)
 - broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph
 
 If a suite already has a local Azure helper wrapper, re-point that wrapper to `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)` first and keep the existing call sites stable until the suite is green.

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -68,7 +68,7 @@ Package note:
 Analyzer note:
 
 - `FMOQ0013` warns on direct `FunctionContext.InstanceServices` mocking more broadly across `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` so those shims move toward the typed helper path
-- the built-in code fix is narrower: it rewrites the safe tracked-provider cases `Setup(x => x.InstanceServices).Returns(provider)`, `SetupGet(x => x.InstanceServices).Returns(provider)`, and `SetupProperty(x => x.InstanceServices, provider)` to `AddFunctionContextInstanceServices(provider, replace: true)` and adds `using FastMoq.AzureFunctions.Extensions;` when needed
+- the built-in code fix is narrower: it only appears when `FastMoq.AzureFunctions` is already referenced, and it rewrites the safe tracked-provider cases `Setup(x => x.InstanceServices).Returns(provider)`, `SetupGet(x => x.InstanceServices).Returns(provider)`, and `SetupProperty(x => x.InstanceServices, provider)` to `context.AddFunctionContextInstanceServices(provider)` and adds `using FastMoq.AzureFunctions.Extensions;` when needed
 - `SetupSet(...)` is not part of this analyzer. When the real need is provider-neutral setter observation rather than Moq setter interception, prefer a fake or stub with [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1)
 - broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph
 

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -65,6 +65,12 @@ Package note:
 - if the test project references `FastMoq.Core` directly, add `FastMoq.AzureFunctions` and import `FastMoq.AzureFunctions.Extensions` before using `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)`
 - the generic typed `IServiceProvider` helpers stay in `FastMoq.Core`
 
+Analyzer note:
+
+- `FMOQ0013` warns when a test mocks `FunctionContext.InstanceServices` directly instead of using the typed helper path
+- the built-in code fix can rewrite the common `SetupGet(x => x.InstanceServices).Returns(provider)` and `SetupProperty(x => x.InstanceServices, provider)` patterns to `AddFunctionContextInstanceServices(provider, replace: true)` and add `using FastMoq.AzureFunctions.Extensions;` when needed
+- broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph
+
 If a suite already has a local Azure helper wrapper, re-point that wrapper to `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)` first and keep the existing call sites stable until the suite is green.
 
 Avoid helpers that return one object such as `ILoggerFactory` for every `GetService(Type)` request. Those shims can let the suite keep running while hiding cast failures for typed services such as `IOptions<WorkerOptions>`.

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -173,7 +173,7 @@ Two practical rules help here:
 Analyzer notes:
 
 - `FMOQ0013` warns on raw `IServiceProvider` mock setup and pushes it toward the typed helper path
-- for Azure Functions worker tests, `FMOQ0013` also warns on direct `FunctionContext.InstanceServices` `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` usage, but the auto-fix is intentionally narrower and only appears for the safe provider-assignment shapes that can become `AddFunctionContextInstanceServices(provider, replace: true)`
+- for Azure Functions worker tests, `FMOQ0013` also warns on direct `FunctionContext.InstanceServices` `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` usage, but the auto-fix is intentionally narrower and only appears when `FastMoq.AzureFunctions` is already referenced for the safe provider-assignment shapes that can become `context.AddFunctionContextInstanceServices(provider)`
 - `FMOQ0014` warns on context-aware compatibility `AddType(...)` usage and pushes it toward `AddKnownType(...)`
 - `FMOQ0015` warns when same-type keyed constructor dependencies are accidentally collapsed into one unkeyed double
 

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -173,6 +173,7 @@ Two practical rules help here:
 Analyzer notes:
 
 - `FMOQ0013` warns on raw `IServiceProvider` mock setup and pushes it toward the typed helper path
+- for Azure Functions worker tests, `FMOQ0013` also warns on direct `FunctionContext.InstanceServices` `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` usage, but the auto-fix is intentionally narrower and only appears for the safe provider-assignment shapes that can become `AddFunctionContextInstanceServices(provider, replace: true)`
 - `FMOQ0014` warns on context-aware compatibility `AddType(...)` usage and pushes it toward `AddKnownType(...)`
 - `FMOQ0015` warns when same-type keyed constructor dependencies are accidentally collapsed into one unkeyed double
 


### PR DESCRIPTION
## Summary
Add a focused code fix for the Azure Functions/framework-helper migration path covered by `FMOQ0013`.

## What changed
- add a code fix for common `FunctionContext.InstanceServices` shim patterns that can safely move to `AddFunctionContextInstanceServices(provider, replace: true)`
- support both `SetupGet(x => x.InstanceServices).Returns(provider)` and Moq-native `AsMoq().SetupProperty(x => x.InstanceServices, provider)` shapes
- add missing `using FastMoq.AzureFunctions.Extensions;` when the fix is applied
- add regression tests for the new fix paths
- document the new analyzer-supported Azure Functions migration path in the framework-helper migration guide

## Why
The runtime Azure Functions helpers already existed, but the migration-assist layer still stopped at warning-only guidance for direct `FunctionContext.InstanceServices` shims. This closes the most stable, low-risk gap in that helper layer without overreaching into broader `IServiceProvider` graph rewrites.

## Validation
- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj --no-restore --filter "FullyQualifiedName~ServiceProviderShimAnalyzer_"`
- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj --no-restore`