### PR TITLE
Add provider-neutral SetupSet migration helper

### DIFF
--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -27,6 +27,7 @@ namespace FastMoq.Analyzers.Tests
             { new StrictCompatibilityAnalyzer(), DiagnosticDescriptors.AvoidStrictCompatibilityProperty },
             { new TimesSpecHelperBoundaryAnalyzer(), DiagnosticDescriptors.UseTimesSpecAtHelperBoundary },
             { new OptionsSetupAnalyzer(), DiagnosticDescriptors.PreferSetupOptionsHelper },
+            { new SetupSetAnalyzer(), DiagnosticDescriptors.PreferPropertySetterCaptureHelper },
             { new ProviderBootstrapAnalyzer(), DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi },
             { new NativeMockAuthoringAnalyzer(), DiagnosticDescriptors.PreferTypedProviderExtensions },
             { new WebHelperAuthoringAnalyzer(), DiagnosticDescriptors.PreferWebTestHelpers },
@@ -50,6 +51,7 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.AvoidStrictCompatibilityProperty, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.UseTimesSpecAtHelperBoundary, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferSetupOptionsHelper, DiagnosticSeverity.Info },
+            { DiagnosticDescriptors.PreferPropertySetterCaptureHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.PreferTypedProviderExtensions, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferWebTestHelpers, DiagnosticSeverity.Info },
@@ -649,6 +651,64 @@ class Sample
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task SetupSetAnalyzer_ShouldReportHelperSuggestion_ForSimpleInterfacePropertyCapture()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+public interface IOrderGateway
+{
+    string? Mode { get; set; }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var gateway = Mocks.GetOrCreateMock<IOrderGateway>();
+        gateway.AsMoq().SetupSet(x => x.Mode = It.IsAny<string?>());
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new SetupSetAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferPropertySetterCaptureHelper));
+
+            Assert.Equal(DiagnosticIds.PreferPropertySetterCaptureHelper, diagnostic.Id);
+            Assert.Contains("Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode)", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task SetupSetAnalyzer_ShouldReportFakePatternSuggestion_ForChainedSetupSetUsage()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+public interface IOrderGateway
+{
+    string? Mode { get; set; }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var gateway = Mocks.GetOrCreateMock<IOrderGateway>();
+        gateway.AsMoq().SetupSet(x => x.Mode = It.IsAny<string?>()).Verifiable();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new SetupSetAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferPropertySetterCaptureHelper));
+
+            Assert.Equal(DiagnosticIds.PreferPropertySetterCaptureHelper, diagnostic.Id);
+            Assert.Contains("PropertyValueCapture<string?>", diagnostic.GetMessage());
         }
 
         [Fact]

--- a/FastMoq.Analyzers/Analyzers/SetupSetAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/SetupSetAnalyzer.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class SetupSetAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PreferPropertySetterCaptureHelper);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax) context.Node;
+            if (!FastMoqAnalysisHelpers.TryBuildSetupSetGuidance(invocationExpression, context.SemanticModel, context.CancellationToken, out var guidance))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.PreferPropertySetterCaptureHelper,
+                FastMoqAnalysisHelpers.GetTargetNameLocation(invocationExpression.Expression),
+                guidance));
+        }
+    }
+}

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -114,6 +114,15 @@ namespace FastMoq.Analyzers
             isEnabledByDefault: true,
             description: "Prefer SetupOptions<T>(...) over repeated IOptions<T> AddType(...)/Options.Create(...) and Setup(x => x.Value).Returns(...) patterns when registering test options values.");
 
+        public static readonly DiagnosticDescriptor PreferPropertySetterCaptureHelper = new(
+            DiagnosticIds.PreferPropertySetterCaptureHelper,
+            "Prefer provider-neutral property setter capture",
+            "Prefer '{0}' instead of 'SetupSet(...)' when the test only needs setter observation or value capture",
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Prefer AddPropertySetterCapture<TService, TValue>(...) for simple interface-property setter capture flows, or a fake plus PropertyValueCapture<TValue> when the test needs a broader replacement than Moq-specific SetupSet(...).");
+
         public static readonly DiagnosticDescriptor SelectProviderBeforeProviderSpecificApi = new(
             DiagnosticIds.SelectProviderBeforeProviderSpecificApi,
             "Select a provider before using provider-specific FastMoq APIs",

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -21,5 +21,6 @@ namespace FastMoq.Analyzers
         public const string AvoidLegacyRequiredMockRetrieval = "FMOQ0017";
         public const string AvoidLegacyMockCreationAndLifecycleApis = "FMOQ0018";
         public const string PreferSetupOptionsHelper = "FMOQ0019";
+        public const string PreferPropertySetterCaptureHelper = "FMOQ0020";
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -457,6 +457,31 @@ namespace FastMoq.Analyzers
                 TryBuildSetupOptionsAddTypeReplacement(invocationExpression, semanticModel, cancellationToken, out replacement);
         }
 
+        public static bool TryBuildSetupSetGuidance(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string guidance)
+        {
+            guidance = string.Empty;
+
+            if (!TryGetSetupSetProperty(invocationExpression, semanticModel, cancellationToken, out var origin, out var property, out var lambdaExpression))
+            {
+                return false;
+            }
+
+            var propertyTypeName = GetMinimalTypeName(property.Type, semanticModel, invocationExpression.SpanStart);
+            if (origin.ServiceType.TypeKind == TypeKind.Interface &&
+                invocationExpression.Parent is not MemberAccessExpressionSyntax &&
+                property.SetMethod is not null &&
+                TryBuildSetupSetPropertySelector(lambdaExpression, out var propertySelector))
+            {
+                var mockerExpression = origin.MockerExpression.WithoutTrivia().ToString();
+                var serviceTypeName = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
+                guidance = $"{mockerExpression}.AddPropertySetterCapture<{serviceTypeName}, {propertyTypeName}>({propertySelector})";
+                return true;
+            }
+
+            guidance = $"a fake or stub plus PropertyValueCapture<{propertyTypeName}>";
+            return true;
+        }
+
         public static bool TryBuildFunctionContextInstanceServicesReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
         {
             if (!HasFunctionContextInstanceServicesMockHelper(semanticModel))
@@ -662,6 +687,67 @@ namespace FastMoq.Analyzers
                     method.Parameters.Length == 2 &&
                     method.Parameters[0].Type.ToDisplayString() == "FastMoq.Providers.IFastMock" &&
                     method.Parameters[1].Type.ToDisplayString() == SERVICE_PROVIDER_TYPE);
+        }
+
+        private static bool TryGetSetupSetProperty(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out TrackedMockOrigin origin, out IPropertySymbol property, out LambdaExpressionSyntax lambdaExpression)
+        {
+            origin = default;
+            property = null!;
+            lambdaExpression = null!;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name != "SetupSet" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !TryResolveTrackedMockOrigin(memberAccess.Expression, semanticModel, cancellationToken, out origin) ||
+                invocationExpression.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateExpression is not LambdaExpressionSyntax candidateLambda ||
+                candidateLambda.Body is not AssignmentExpressionSyntax assignmentExpression ||
+                assignmentExpression.Left is not MemberAccessExpressionSyntax propertyAccess ||
+                !TryGetPropertySymbol(propertyAccess, semanticModel, cancellationToken, out var candidateProperty) ||
+                candidateProperty is null)
+            {
+                return false;
+            }
+
+            property = candidateProperty;
+            lambdaExpression = candidateLambda;
+            return true;
+        }
+
+        private static bool TryBuildSetupSetPropertySelector(LambdaExpressionSyntax lambdaExpression, out string selector)
+        {
+            selector = string.Empty;
+            if (lambdaExpression.Body is not AssignmentExpressionSyntax assignmentExpression ||
+                assignmentExpression.Left is not MemberAccessExpressionSyntax propertyAccess)
+            {
+                return false;
+            }
+
+            var parameterName = lambdaExpression switch
+            {
+                SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Parameter.Identifier.ValueText,
+                ParenthesizedLambdaExpressionSyntax parenthesizedLambda when parenthesizedLambda.ParameterList.Parameters.Count == 1 => parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText,
+                _ => string.Empty,
+            };
+
+            if (string.IsNullOrWhiteSpace(parameterName))
+            {
+                return false;
+            }
+
+            selector = $"{parameterName} => {propertyAccess.WithoutTrivia()}";
+            return true;
         }
 
         private static bool TryBuildFunctionContextInstanceServicesReturnsReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)

--- a/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
+++ b/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
@@ -20,12 +20,16 @@ namespace FastMoq.Extensions
         /// <example>
         /// <code language="csharp"><![CDATA[
         /// var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
+        /// CreateComponent();
         ///
         /// await Component.RunAsync();
         ///
         /// modeCapture.Value.Should().Be("fast");
         /// ]]></code>
         /// </example>
+        /// <remarks>
+        /// When you use this helper from a <c>MockerTestBase&lt;TComponent&gt;</c>-based test, add the capture during the setup phase or call <c>CreateComponent()</c> after the registration change so the component is rebuilt against the proxy-wrapped dependency.
+        /// </remarks>
         public static PropertyValueCapture<TValue> AddPropertySetterCapture<TService, TValue>(this Mocker mocker, Expression<Func<TService, TValue>> propertyExpression, bool replace = true)
             where TService : class
         {
@@ -45,6 +49,9 @@ namespace FastMoq.Extensions
         /// <param name="capture">The capture that should record assigned values.</param>
         /// <param name="replace">True to replace an existing registration for <typeparamref name="TService" />. Defaults to <see langword="true" /> because the helper intentionally swaps in a capture proxy.</param>
         /// <returns>The supplied <paramref name="capture" />.</returns>
+        /// <remarks>
+        /// When you use this helper from a <c>MockerTestBase&lt;TComponent&gt;</c>-based test, add the capture during the setup phase or call <c>CreateComponent()</c> after the registration change so the component is rebuilt against the proxy-wrapped dependency.
+        /// </remarks>
         public static PropertyValueCapture<TValue> AddPropertySetterCapture<TService, TValue>(this Mocker mocker, Expression<Func<TService, TValue>> propertyExpression, PropertyValueCapture<TValue> capture, bool replace = true)
             where TService : class
         {

--- a/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
+++ b/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
@@ -1,0 +1,158 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FastMoq.Extensions
+{
+    /// <summary>
+    /// Provides first-party helpers for capturing interface property assignments without relying on provider-specific <c>SetupSet(...)</c> behavior.
+    /// </summary>
+    public static class PropertySetterCaptureExtensions
+    {
+        /// <summary>
+        /// Replaces the current interface registration with a proxy that captures assignments to the selected property while forwarding unrelated members to the previously resolved instance.
+        /// </summary>
+        /// <typeparam name="TService">The interface type to wrap.</typeparam>
+        /// <typeparam name="TValue">The property value type.</typeparam>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="propertyExpression">The interface property whose setter should be captured.</param>
+        /// <param name="replace">True to replace an existing registration for <typeparamref name="TService" />. Defaults to <see langword="true" /> because the helper intentionally swaps in a capture proxy.</param>
+        /// <returns>A <see cref="PropertyValueCapture{TValue}" /> that records the assigned values.</returns>
+        /// <example>
+        /// <code language="csharp"><![CDATA[
+        /// var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
+        ///
+        /// await Component.RunAsync();
+        ///
+        /// modeCapture.Value.Should().Be("fast");
+        /// ]]></code>
+        /// </example>
+        public static PropertyValueCapture<TValue> AddPropertySetterCapture<TService, TValue>(this Mocker mocker, Expression<Func<TService, TValue>> propertyExpression, bool replace = true)
+            where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(propertyExpression);
+
+            return mocker.AddPropertySetterCapture(propertyExpression, new PropertyValueCapture<TValue>(), replace);
+        }
+
+        /// <summary>
+        /// Replaces the current interface registration with a proxy that records assignments to the selected property into the supplied capture instance while forwarding unrelated members to the previously resolved instance.
+        /// </summary>
+        /// <typeparam name="TService">The interface type to wrap.</typeparam>
+        /// <typeparam name="TValue">The property value type.</typeparam>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="propertyExpression">The interface property whose setter should be captured.</param>
+        /// <param name="capture">The capture that should record assigned values.</param>
+        /// <param name="replace">True to replace an existing registration for <typeparamref name="TService" />. Defaults to <see langword="true" /> because the helper intentionally swaps in a capture proxy.</param>
+        /// <returns>The supplied <paramref name="capture" />.</returns>
+        public static PropertyValueCapture<TValue> AddPropertySetterCapture<TService, TValue>(this Mocker mocker, Expression<Func<TService, TValue>> propertyExpression, PropertyValueCapture<TValue> capture, bool replace = true)
+            where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(propertyExpression);
+            ArgumentNullException.ThrowIfNull(capture);
+
+            var serviceType = typeof(TService);
+            if (!serviceType.IsInterface)
+            {
+                throw new NotSupportedException($"{nameof(AddPropertySetterCapture)} currently supports interface types only. Use a fake or stub plus {nameof(PropertyValueCapture<TValue>)} for {serviceType.Name}.");
+            }
+
+            var propertyInfo = propertyExpression.GetPropertyInfo();
+            if (propertyInfo.SetMethod is null)
+            {
+                throw new ArgumentException($"Property '{propertyInfo.Name}' must have a setter.", nameof(propertyExpression));
+            }
+
+            var currentInstance = mocker.GetObject<TService>() ?? throw new InvalidOperationException($"Unable to resolve an instance for {serviceType.Name} before adding a setter capture.");
+            if (currentInstance is PropertySetterCaptureProxy<TService> existingProxy)
+            {
+                existingProxy.AddCapture(propertyInfo, capture);
+                return capture;
+            }
+
+            var proxy = DispatchProxy.Create<TService, PropertySetterCaptureProxy<TService>>();
+            var proxyController = (PropertySetterCaptureProxy<TService>) (object) proxy;
+            proxyController.Initialize(currentInstance);
+            proxyController.AddCapture(propertyInfo, capture);
+
+            mocker.AddType<TService>(proxy, replace);
+            return capture;
+        }
+    }
+
+    internal class PropertySetterCaptureProxy<TService> : DispatchProxy where TService : class
+    {
+        private readonly Dictionary<MethodInfo, Func<object?[]?, object?>> _handlers = [];
+
+        private TService? _inner;
+
+        public void Initialize(TService inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            _inner = inner;
+        }
+
+        public void AddCapture<TValue>(PropertyInfo propertyInfo, PropertyValueCapture<TValue> capture)
+        {
+            ArgumentNullException.ThrowIfNull(propertyInfo);
+            ArgumentNullException.ThrowIfNull(capture);
+
+            if (propertyInfo.GetMethod is MethodInfo getter)
+            {
+                _handlers[getter] = _ =>
+                {
+                    if (capture.HasValue)
+                    {
+                        return capture.Value;
+                    }
+
+                    return _inner is null ? default(TValue) : propertyInfo.GetValue(_inner);
+                };
+            }
+
+            if (propertyInfo.SetMethod is MethodInfo setter)
+            {
+                _handlers[setter] = arguments =>
+                {
+                    var assignedValue = arguments is not null && arguments.Length > 0
+                        ? (TValue) arguments[0]!
+                        : default!;
+
+                    capture.Record(assignedValue);
+
+                    if (_inner is not null)
+                    {
+                        propertyInfo.SetValue(_inner, assignedValue);
+                    }
+
+                    return null;
+                };
+            }
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            ArgumentNullException.ThrowIfNull(targetMethod);
+
+            if (_handlers.TryGetValue(targetMethod, out var handler))
+            {
+                return handler(args);
+            }
+
+            if (_inner is null)
+            {
+                throw new InvalidOperationException($"{nameof(PropertySetterCaptureProxy<TService>)} has not been initialized.");
+            }
+
+            try
+            {
+                return targetMethod.Invoke(_inner, args);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                throw ex.InnerException;
+            }
+        }
+    }
+}

--- a/FastMoq.TestingExample/README.md
+++ b/FastMoq.TestingExample/README.md
@@ -5,6 +5,7 @@ This project is the smallest repo-local place to see FastMoq patterns in executa
 ## Real-world examples
 
 - `OrderProcessingServiceExamples` shows a business workflow with repository, inventory, payment, and logger dependencies.
+- `OrderSubmissionServiceExamples` shows provider-neutral property setter capture with `AddPropertySetterCapture<TService, TValue>(...)`.
 - `CustomerImportServiceExamples` shows the built-in `IFileSystem` support with `MockFileSystem` plus parser and repository collaborators.
 - `InvoiceReminderServiceScenarioExamples` shows the fluent `Scenario.With(...).When(...).Then(...).Verify(...)` style.
 - `OptionalParameterResolutionExamples` shows the explicit optional-parameter model through `ComponentCreationFlags` and `InvocationOptions`.

--- a/FastMoq.TestingExample/RealWorldExampleServices.cs
+++ b/FastMoq.TestingExample/RealWorldExampleServices.cs
@@ -59,6 +59,13 @@ namespace FastMoq.TestingExample
         Task SaveAsync(OrderRecord order, CancellationToken cancellationToken = default);
     }
 
+    public interface IOrderSubmissionChannel
+    {
+        string? Mode { get; set; }
+
+        Task SubmitAsync(string orderId, CancellationToken cancellationToken = default);
+    }
+
     public sealed class OrderProcessingService
     {
         private readonly IInventoryGateway _inventoryGateway;
@@ -103,6 +110,24 @@ namespace FastMoq.TestingExample
             await _orderRepository.SaveAsync(order, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("Placed order {OrderId} for {CustomerId}", order.OrderId, order.CustomerId);
             return OrderPlacementResult.Placed(order.OrderId);
+        }
+    }
+
+    public sealed class OrderSubmissionService
+    {
+        private readonly IOrderSubmissionChannel _submissionChannel;
+
+        public OrderSubmissionService(IOrderSubmissionChannel submissionChannel)
+        {
+            _submissionChannel = submissionChannel;
+        }
+
+        public async Task SubmitAsync(string orderId, bool expedited, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+
+            _submissionChannel.Mode = expedited ? "fast" : "standard";
+            await _submissionChannel.SubmitAsync(orderId, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/FastMoq.TestingExample/RealWorldExampleTests.cs
+++ b/FastMoq.TestingExample/RealWorldExampleTests.cs
@@ -86,6 +86,26 @@ namespace FastMoq.TestingExample
         }
     }
 
+    public class OrderSubmissionServiceExamples : MockerTestBase<OrderSubmissionService>
+    {
+        [Fact]
+        public async Task SubmitAsync_ShouldCaptureAssignedMode_WithAddPropertySetterCapture()
+        {
+            var submissionChannel = Mocks.GetOrCreateMock<IOrderSubmissionChannel>();
+            submissionChannel
+                .Setup(x => x.SubmitAsync("order-42", CancellationToken.None))
+                .Returns(Task.CompletedTask);
+
+            var modeCapture = Mocks.AddPropertySetterCapture<IOrderSubmissionChannel, string?>(x => x.Mode);
+            CreateComponent();
+
+            await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+
+            modeCapture.Value.Should().Be("fast");
+            Mocks.Verify<IOrderSubmissionChannel>(x => x.SubmitAsync("order-42", CancellationToken.None), TimesSpec.Once);
+        }
+    }
+
     public class CustomerImportServiceExamples : MockerTestBase<CustomerImportService>
     {
         [Fact]

--- a/FastMoq.Tests/PropertySetterCaptureTests.cs
+++ b/FastMoq.Tests/PropertySetterCaptureTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using FastMoq.Extensions;
 using FastMoq.Providers;
 
@@ -56,6 +57,19 @@ namespace FastMoq.Tests
                 .WithMessage("*interface types only*");
         }
 
+        [Fact]
+        public void AddPropertySetterCapture_ShouldSupportMockerTestBase_WhenComponentIsRecreated()
+        {
+            using var testBase = new PropertySetterCaptureComponentTestBase();
+
+            var modeCapture = testBase.AddModeCapture();
+
+            testBase.Submit("alpha", expedited: true);
+
+            modeCapture.Value.Should().Be("fast");
+            testBase.VerifyPublished("alpha");
+        }
+
         public interface IPropertySetterCaptureGateway
         {
             string? Mode { get; set; }
@@ -82,6 +96,42 @@ namespace FastMoq.Tests
         private sealed class PropertySetterCaptureConcreteTarget
         {
             public string? Mode { get; set; }
+        }
+
+        private sealed class PropertySetterCaptureComponent
+        {
+            private readonly IPropertySetterCaptureGateway _gateway;
+
+            public PropertySetterCaptureComponent(IPropertySetterCaptureGateway gateway)
+            {
+                _gateway = gateway;
+            }
+
+            public void Submit(string value, bool expedited)
+            {
+                _gateway.Mode = expedited ? "fast" : "standard";
+                _gateway.Publish(value);
+            }
+        }
+
+        private sealed class PropertySetterCaptureComponentTestBase : MockerTestBase<PropertySetterCaptureComponent>
+        {
+            public PropertyValueCapture<string?> AddModeCapture()
+            {
+                var capture = Mocks.AddPropertySetterCapture<IPropertySetterCaptureGateway, string?>(x => x.Mode);
+                CreateComponent();
+                return capture;
+            }
+
+            public void Submit(string value, bool expedited)
+            {
+                Component.Submit(value, expedited);
+            }
+
+            public void VerifyPublished(string value)
+            {
+                Mocks.Verify<IPropertySetterCaptureGateway>(x => x.Publish(value), TimesSpec.Once);
+            }
         }
     }
 }

--- a/FastMoq.Tests/PropertySetterCaptureTests.cs
+++ b/FastMoq.Tests/PropertySetterCaptureTests.cs
@@ -1,0 +1,87 @@
+using System;
+using FastMoq.Extensions;
+using FastMoq.Providers;
+
+namespace FastMoq.Tests
+{
+    public class PropertySetterCaptureTests
+    {
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
+        public void AddPropertySetterCapture_ShouldCaptureAssignments_AndForwardOtherMembers(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            _ = mocker.GetOrCreateMock<IPropertySetterCaptureGateway>();
+            var modeCapture = mocker.AddPropertySetterCapture<IPropertySetterCaptureGateway, string?>(x => x.Mode);
+
+            var gateway = mocker.GetObject<IPropertySetterCaptureGateway>();
+            gateway.Should().NotBeNull();
+
+            gateway!.Mode = "fast";
+            gateway.Publish("alpha");
+
+            modeCapture.HasValue.Should().BeTrue();
+            modeCapture.Value.Should().Be("fast");
+            gateway.Mode.Should().Be("fast");
+            mocker.Verify<IPropertySetterCaptureGateway>(x => x.Publish("alpha"), TimesSpec.Once);
+        }
+
+        [Fact]
+        public void AddPropertySetterCapture_ShouldForwardSetterToExistingConcreteRegistration()
+        {
+            var mocker = new Mocker();
+            mocker.AddType<IPropertySetterCaptureGateway>(new PropertySetterCaptureGatewayFake());
+
+            var modeCapture = mocker.AddPropertySetterCapture<IPropertySetterCaptureGateway, string?>(x => x.Mode);
+            var gateway = mocker.GetObject<IPropertySetterCaptureGateway>();
+
+            gateway.Should().NotBeNull();
+            gateway!.Mode = "beta";
+
+            modeCapture.Value.Should().Be("beta");
+            gateway.ReadMode().Should().Be("beta");
+        }
+
+        [Fact]
+        public void AddPropertySetterCapture_ShouldRejectNonInterfaceTypes()
+        {
+            var mocker = new Mocker();
+
+            Action action = () => mocker.AddPropertySetterCapture<PropertySetterCaptureConcreteTarget, string?>(x => x.Mode);
+
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("*interface types only*");
+        }
+
+        public interface IPropertySetterCaptureGateway
+        {
+            string? Mode { get; set; }
+
+            void Publish(string value);
+
+            string? ReadMode();
+        }
+
+        private sealed class PropertySetterCaptureGatewayFake : IPropertySetterCaptureGateway
+        {
+            public string? Mode { get; set; }
+
+            public void Publish(string value)
+            {
+            }
+
+            public string? ReadMode()
+            {
+                return Mode;
+            }
+        }
+
+        private sealed class PropertySetterCaptureConcreteTarget
+        {
+            public string? Mode { get; set; }
+        }
+    }
+}

--- a/docs/getting-started/provider-capabilities.md
+++ b/docs/getting-started/provider-capabilities.md
@@ -58,7 +58,7 @@ When that happens, use this rule:
 | `VerifyLogger(...)` | Prefer `VerifyLogged(...)`. For a first-party registration story, use `AddLoggerFactory()` to register callback-backed `ILoggerFactory`, `ILogger`, and `ILogger<T>` services directly on `Mocker`, or use `CreateLoggerFactory()` when you want to plug the same capture-backed factory into a typed `IServiceProvider` recipe. | When you are intentionally preserving older Moq-shaped logger assertions with minimal churn. |
 | `Protected()` for `HttpMessageHandler` | Prefer `WhenHttpRequest(...)` or `WhenHttpRequestJson(...)` for HTTP behavior. | When the test really depends on direct protected-member interception rather than request/response behavior. |
 | `Protected()` for arbitrary protected members | Prefer testing through a public seam, extracted collaborator, or concrete fake. | When the implementation cannot reasonably be reshaped and protected-member interception is the behavior under test. |
-| `SetupSet(...)` | Prefer a fake or stub registered with `AddType(...)` that captures assigned values, usually with `PropertyValueCapture<TValue>`, or verify the observable downstream behavior instead of the setter interception itself. | When the setter interception is the important behavior and introducing a fake would create more churn than value. |
+| `SetupSet(...)` | For simple interface-property cases, prefer `AddPropertySetterCapture<TService, TValue>(...)`. For broader collaborator behavior, prefer a fake or stub registered with `AddType(...)` that captures assigned values, usually with `PropertyValueCapture<TValue>`, or verify the observable downstream behavior instead of the setter interception itself. | When the setter interception is the important behavior and introducing a helper-backed replacement or fake would create more churn than value. |
 | `SetupAllProperties()` | Prefer a concrete fake or lightweight test double with real property state. For ordinary collaborator behavior, use `AddType(...)` or a purpose-built fake instead of expecting provider-managed property backing. | When you specifically want mocking-library-managed property backing without creating a custom fake. |
 | `CallBase` / partial mock behavior | Prefer a real instance or `AddType(...)` factory for the concrete collaborator. | When the test intentionally relies on partial mocking rather than a real implementation or fake. |
 | `out` / `ref` verification with `It.Ref<T>.IsAny` | Prefer wrapping the dependency behind a simpler interface, or assert on the public result / side effect instead of the raw `out` / `ref` interaction. | When the API shape is fixed and the `out` / `ref` interaction itself is important to the test. |
@@ -128,7 +128,17 @@ Mocks.GetOrCreateMock<IOrderGateway>()
     .SetupSet(x => x.Mode = It.IsAny<string>());
 ```
 
-For `SetupSet(...)`-heavy tests, the preferred first-party answer is usually a small fake plus [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1):
+For simple `SetupSet(...)` cases on interface properties, the preferred first-party answer is `AddPropertySetterCapture<TService, TValue>(...)`:
+
+```csharp
+var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
+
+Component.Run();
+
+modeCapture.Value.Should().Be("fast");
+```
+
+If the collaborator needs more behavior than one captured property, or the target is not an interface, fall back to a fake plus [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1):
 
 ```csharp
 var modeCapture = new PropertyValueCapture<string?>();
@@ -148,7 +158,7 @@ sealed class OrderGatewayStub(PropertyValueCapture<string?> capture) : IOrderGat
 }
 ```
 
-That pattern stays portable across providers, makes the arranged state explicit, and avoids tying the test to Moq-only setter interception when the important behavior is the assigned value.
+That combination keeps the test portable across providers, makes the arranged state explicit, and avoids tying the test to Moq-only setter interception when the important behavior is the assigned value.
 
 Repo-backed references:
 

--- a/docs/getting-started/provider-capabilities.md
+++ b/docs/getting-started/provider-capabilities.md
@@ -132,11 +132,14 @@ For simple `SetupSet(...)` cases on interface properties, the preferred first-pa
 
 ```csharp
 var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
+CreateComponent();
 
 Component.Run();
 
 modeCapture.Value.Should().Be("fast");
 ```
+
+When the component under test comes from `MockerTestBase<TComponent>`, call `CreateComponent()` after adding the capture unless you registered it in the test base setup path before component creation.
 
 If the collaborator needs more behavior than one captured property, or the target is not an interface, fall back to a fake plus [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1):
 

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -230,4 +230,4 @@ Cases that do not translate cleanly:
 
 When a test depends on those features, either keep it on the Moq provider or replace the collaborator with a fake or stub through `AddType(...)`.
 
-For simple interface-property `SetupSet(...)` cases, the preferred non-Moq migration target is `AddPropertySetterCapture<TService, TValue>(...)`. When the collaborator needs broader behavior, or the target is not an interface, fall back to a fake that records assignments through `PropertyValueCapture<TValue>`.
+For simple interface-property `SetupSet(...)` cases, the preferred non-Moq migration target is `AddPropertySetterCapture<TService, TValue>(...)`. When the component under test is already created through `MockerTestBase<TComponent>`, add the capture before construction or call `CreateComponent()` after the registration change. When the collaborator needs broader behavior, or the target is not an interface, fall back to a fake that records assignments through `PropertyValueCapture<TValue>`.

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -230,4 +230,4 @@ Cases that do not translate cleanly:
 
 When a test depends on those features, either keep it on the Moq provider or replace the collaborator with a fake or stub through `AddType(...)`.
 
-For `SetupSet(...)`-heavy tests, the preferred non-Moq migration target is usually a fake that records assignments through `PropertyValueCapture<TValue>`.
+For simple interface-property `SetupSet(...)` cases, the preferred non-Moq migration target is `AddPropertySetterCapture<TService, TValue>(...)`. When the collaborator needs broader behavior, or the target is not an interface, fall back to a fake that records assignments through `PropertyValueCapture<TValue>`.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -33,8 +33,16 @@ Planned work includes:
 
 - Additional provider-neutral guidance for framework-heavy suites that combine typed `IServiceProvider` helpers with keyed services, scoped resolution, or framework-owned service graphs.
 - Azure Functions follow-up helpers beyond the shipped `FunctionContext.InstanceServices`, `CreateHttpRequestData(...)`, and `CreateHttpResponseData(...)` support.
-- A clearer first-party path for common `SetupSet(...)`-heavy tests where the real need is setter observation or value capture.
+- A clearer first-party path for common `SetupAllProperties()`-heavy tests where the real need is lightweight stateful property backing rather than mocking-library-managed auto-properties.
 - Focused migration guidance and examples for compatibility-only APIs that remain temporary rather than long-term patterns.
+
+Other gaps worth adding next, in priority order:
+
+1. A clearer first-party `SetupAllProperties()` replacement.
+2. Better typed `IServiceProvider` helper support for scoped and framework-owned graphs.
+3. Analyzer guidance for manual scope and `IServiceScopeFactory` shims.
+4. Azure Functions follow-up helpers beyond `InstanceServices`, request, and response.
+5. More examples and sample-backed docs for property-capture migration.
 
 ### Documentation and examples
 

--- a/docs/samples/testing-examples.md
+++ b/docs/samples/testing-examples.md
@@ -109,11 +109,14 @@ Provider-neutral shape:
 
 ```csharp
 var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
+CreateComponent();
 
 await Component.RunAsync();
 
 modeCapture.Value.Should().Be("fast");
 ```
+
+When the component already exists because the test derives from `MockerTestBase<TComponent>`, that `CreateComponent()` call is what rebinds the constructor dependency to the proxy-backed registration.
 
 If the collaborator needs more than one captured property or is not an interface, keep using the fake-plus-`PropertyValueCapture<TValue>` pattern instead.
 

--- a/docs/samples/testing-examples.md
+++ b/docs/samples/testing-examples.md
@@ -94,7 +94,7 @@ That is the main migration pattern: replace `Setup(...)` with direct substitute 
 
 ### Side-by-side: `SetupSet(...)` migration versus provider-neutral capture
 
-When a test only needs to observe which value was assigned to a property, prefer a fake plus `PropertyValueCapture<TValue>` over keeping the test tied to Moq setter interception.
+When a test only needs to observe which value was assigned to a property, prefer `AddPropertySetterCapture<TService, TValue>(...)` for simple interface-property cases, or a fake plus `PropertyValueCapture<TValue>` when the collaborator needs broader behavior.
 
 Moq-specific shape:
 
@@ -108,13 +108,14 @@ gateway.AsMoq().SetupSet(x => x.Mode = It.IsAny<string>());
 Provider-neutral shape:
 
 ```csharp
-var modeCapture = new PropertyValueCapture<string?>();
-Mocks.AddType<IOrderGateway>(_ => new OrderGatewayStub(modeCapture));
+var modeCapture = Mocks.AddPropertySetterCapture<IOrderGateway, string?>(x => x.Mode);
 
 await Component.RunAsync();
 
 modeCapture.Value.Should().Be("fast");
 ```
+
+If the collaborator needs more than one captured property or is not an interface, keep using the fake-plus-`PropertyValueCapture<TValue>` pattern instead.
 
 That migration keeps the test portable across providers and usually makes the asserted behavior clearer.
 


### PR DESCRIPTION
## Summary
- add a first-party `AddPropertySetterCapture<TService, TValue>(...)` helper for simple interface property setter-capture migrations
- add `FMOQ0020` guidance for Moq `SetupSet(...)`, pointing simple cases at the new helper and broader cases at fake-plus-`PropertyValueCapture<TValue>` patterns
- document the new migration path and refine the roadmap priorities for the next gaps worth adding

## Validation
- `dotnet test .\\FastMoq.Tests\\FastMoq.Tests.csproj --filter "FullyQualifiedName~PropertySetterCaptureTests" -v minimal`
- `dotnet test .\\FastMoq.Analyzers.Tests\\FastMoq.Analyzers.Tests.csproj -v minimal`