### PR TITLE
Add provider-first property and scope migration helpers

### DIFF
--- a/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
@@ -41,11 +41,15 @@ namespace FastMoq.Analyzers.Tests
                 .ConfigureAwait(false);
         }
 
-        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false)
+        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null)
         {
             var document = CreateDocument(source, includeAzureFunctionsHelpers);
             var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
-            var diagnostic = diagnostics.Single(item => item.Id == diagnosticId);
+            var diagnostic = diagnostics
+                .Where(item => item.Id == diagnosticId)
+                .Where(item => diagnosticMessageContains is null || item.GetMessage().Contains(diagnosticMessageContains, StringComparison.Ordinal))
+                .OrderBy(item => item.Location.SourceSpan.Start)
+                .ElementAt(diagnosticOccurrence);
 
             var actions = new List<CodeAction>();
             var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
@@ -59,11 +63,15 @@ namespace FastMoq.Analyzers.Tests
             return changedRoot!.NormalizeWhitespace().ToFullString();
         }
 
-        public static async Task<ImmutableArray<string>> GetCodeFixTitlesAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false)
+        public static async Task<ImmutableArray<string>> GetCodeFixTitlesAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null)
         {
             var document = CreateDocument(source, includeAzureFunctionsHelpers);
             var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
-            var diagnostic = diagnostics.Single(item => item.Id == diagnosticId);
+            var diagnostic = diagnostics
+                .Where(item => item.Id == diagnosticId)
+                .Where(item => diagnosticMessageContains is null || item.GetMessage().Contains(diagnosticMessageContains, StringComparison.Ordinal))
+                .OrderBy(item => item.Location.SourceSpan.Start)
+                .ElementAt(diagnosticOccurrence);
 
             var actions = new List<CodeAction>();
             var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -827,6 +827,184 @@ class Sample
         }
 
         [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenScopeServiceProviderIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scope.SetupGet(x => x.ServiceProvider).Returns(provider);
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                diagnosticMessageContains: "SetupGet(x => x.ServiceProvider)");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        Mocks.AddServiceScope(provider);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenScopeServiceProviderUsesSetupProperty()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scope.AsMoq().SetupProperty(x => x.ServiceProvider, provider);
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                diagnosticMessageContains: "SetupProperty(x => x.ServiceProvider)");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        Mocks.AddServiceScope(provider);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenScopeSetupAlsoDrivesCreateScope()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scope.SetupGet(x => x.ServiceProvider).Returns(provider);
+        scopeFactory.Setup(x => x.CreateScope()).Returns(scope.Instance);
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                diagnosticMessageContains: "SetupGet(x => x.ServiceProvider)");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        Mocks.AddServiceScope(provider);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenCreateScopeReturnsTrackedScopeWithConfiguredProvider()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(scope.Instance);
+        scope.SetupGet(x => x.ServiceProvider).Returns(provider);
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                diagnosticMessageContains: "Setup(x => x.CreateScope())");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        Mocks.AddServiceScope(provider);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenServiceScopeIsMockedDirectly()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -626,6 +626,42 @@ class Sample
         }
 
         [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenServiceProviderIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var serviceProvider = Mocks.GetOrCreateMock<IServiceProvider>();
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var serviceProvider = Mocks.CreateTypedServiceProvider();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenServiceScopeFactoryIsMockedDirectly()
         {
             const string SOURCE = @"
@@ -644,6 +680,42 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
             Assert.Contains("GetOrCreateMock<IServiceScopeFactory>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenServiceScopeFactoryIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scopeFactory = Mocks.CreateTypedServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
         }
 
         [Fact]
@@ -666,6 +738,44 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers && item.GetMessage().Contains("AddType<IServiceScopeFactory>(GetRequiredService<IServiceScopeFactory>())")));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
             Assert.Contains("AddType<IServiceScopeFactory>(GetRequiredService<IServiceScopeFactory>())", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenScopeFactoryIsExtractedFromProvider()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        Mocks.AddType<IServiceScopeFactory>(provider.GetRequiredService<IServiceScopeFactory>());
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        Mocks.AddServiceProvider(provider);
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
         }
 
         [Fact]
@@ -714,6 +824,42 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers && item.GetMessage().Contains("SetupGet(x => x.ServiceProvider)")));
             Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
             Assert.Contains("SetupGet(x => x.ServiceProvider)", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenServiceScopeIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scope = Mocks.CreateTypedServiceScope();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -1005,6 +1005,41 @@ class Sample
         }
 
         [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldNotOfferCreateScopeFix_WhenOnlyNestedLocalFunctionHasMatchingProviderSetup()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(scope.Instance);
+
+        void Configure(Mocker Mocks, IServiceProvider provider)
+        {
+            var scope = Mocks.GetOrCreateMock<IServiceScope>();
+            scope.SetupGet(x => x.ServiceProvider).Returns(provider);
+        }
+    }
+}";
+
+            var titles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new ServiceProviderShimAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.PreferTypedServiceProviderHelpers,
+                diagnosticMessageContains: "Setup(x => x.CreateScope())");
+
+            Assert.Empty(titles);
+        }
+
+        [Fact]
         public async Task ServiceProviderShimAnalyzer_ShouldReportAndFix_WhenServiceScopeIsMockedDirectly()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -28,6 +28,7 @@ namespace FastMoq.Analyzers.Tests
             { new TimesSpecHelperBoundaryAnalyzer(), DiagnosticDescriptors.UseTimesSpecAtHelperBoundary },
             { new OptionsSetupAnalyzer(), DiagnosticDescriptors.PreferSetupOptionsHelper },
             { new SetupSetAnalyzer(), DiagnosticDescriptors.PreferPropertySetterCaptureHelper },
+            { new SetupAllPropertiesAnalyzer(), DiagnosticDescriptors.PreferPropertyStateHelper },
             { new ProviderBootstrapAnalyzer(), DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi },
             { new NativeMockAuthoringAnalyzer(), DiagnosticDescriptors.PreferTypedProviderExtensions },
             { new WebHelperAuthoringAnalyzer(), DiagnosticDescriptors.PreferWebTestHelpers },
@@ -52,6 +53,7 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.UseTimesSpecAtHelperBoundary, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferSetupOptionsHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferPropertySetterCaptureHelper, DiagnosticSeverity.Info },
+            { DiagnosticDescriptors.PreferPropertyStateHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.PreferTypedProviderExtensions, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferWebTestHelpers, DiagnosticSeverity.Info },
@@ -624,6 +626,97 @@ class Sample
         }
 
         [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenServiceScopeFactoryIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+            Assert.Contains("GetOrCreateMock<IServiceScopeFactory>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenScopeFactoryIsExtractedFromProvider()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        Mocks.AddType<IServiceScopeFactory>(provider.GetRequiredService<IServiceScopeFactory>());
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers && item.GetMessage().Contains("AddType<IServiceScopeFactory>(GetRequiredService<IServiceScopeFactory>())")));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+            Assert.Contains("AddType<IServiceScopeFactory>(GetRequiredService<IServiceScopeFactory>())", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenScopeFactoryCreateScopeIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var scopeFactory = Mocks.GetOrCreateMock<IServiceScopeFactory>();
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(scope.Instance);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers && item.GetMessage().Contains("Setup(x => x.CreateScope())")));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+            Assert.Contains("Setup(x => x.CreateScope())", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenScopeServiceProviderIsMockedDirectly()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.DependencyInjection;
+
+class Sample
+{
+    void Execute(Mocker Mocks, IServiceProvider provider)
+    {
+        var scope = Mocks.GetOrCreateMock<IServiceScope>();
+        scope.SetupGet(x => x.ServiceProvider).Returns(provider);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ServiceProviderShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferTypedServiceProviderHelpers && item.GetMessage().Contains("SetupGet(x => x.ServiceProvider)")));
+            Assert.Equal(DiagnosticIds.PreferTypedServiceProviderHelpers, diagnostic.Id);
+            Assert.Contains("SetupGet(x => x.ServiceProvider)", diagnostic.GetMessage());
+        }
+
+        [Fact]
         public async Task ServiceProviderShimAnalyzer_ShouldReport_WhenFunctionContextInstanceServicesIsMockedDirectly()
         {
             const string SOURCE = @"
@@ -709,6 +802,62 @@ class Sample
 
             Assert.Equal(DiagnosticIds.PreferPropertySetterCaptureHelper, diagnostic.Id);
             Assert.Contains("PropertyValueCapture<string?>", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task SetupAllPropertiesAnalyzer_ShouldReportPropertyStateSuggestion_ForSimpleInterfaceUsage()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+public interface IOrderGateway
+{
+    string? Mode { get; set; }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var gateway = Mocks.GetOrCreateMock<IOrderGateway>();
+        gateway.AsMoq().SetupAllProperties();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new SetupAllPropertiesAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferPropertyStateHelper));
+
+            Assert.Equal(DiagnosticIds.PreferPropertyStateHelper, diagnostic.Id);
+            Assert.Contains("AddPropertyState<IOrderGateway>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task SetupAllPropertiesAnalyzer_ShouldReportFakeSuggestion_ForClassUsage()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+public class OrderGateway
+{
+    public virtual string? Mode { get; set; }
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var gateway = Mocks.GetOrCreateMock<OrderGateway>();
+        gateway.AsMoq().SetupAllProperties();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new SetupAllPropertiesAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferPropertyStateHelper));
+
+            Assert.Equal(DiagnosticIds.PreferPropertyStateHelper, diagnostic.Id);
+            Assert.Contains("concrete fake or stub registered with AddType(...)", diagnostic.GetMessage());
         }
 
         [Fact]

--- a/FastMoq.Analyzers/Analyzers/SetupAllPropertiesAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/SetupAllPropertiesAnalyzer.cs
@@ -6,9 +6,9 @@ using System.Collections.Immutable;
 namespace FastMoq.Analyzers.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ServiceProviderShimAnalyzer : DiagnosticAnalyzer
+    public sealed class SetupAllPropertiesAnalyzer : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PreferTypedServiceProviderHelpers);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PreferPropertyStateHelper);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -20,22 +20,15 @@ namespace FastMoq.Analyzers.Analyzers
         private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
             var invocationExpression = (InvocationExpressionSyntax) context.Node;
-            if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var method) ||
-                method is null)
-            {
-                return;
-            }
-
-            if (!FastMoqAnalysisHelpers.TryGetTypedServiceProviderHelperSuggestion(invocationExpression, context.SemanticModel, context.CancellationToken, out var currentApi) &&
-                !FastMoqAnalysisHelpers.TryGetFunctionContextInstanceServicesHelperSuggestion(invocationExpression, context.SemanticModel, context.CancellationToken, out currentApi))
+            if (!FastMoqAnalysisHelpers.TryBuildSetupAllPropertiesGuidance(invocationExpression, context.SemanticModel, context.CancellationToken, out var guidance))
             {
                 return;
             }
 
             context.ReportDiagnostic(Diagnostic.Create(
-                DiagnosticDescriptors.PreferTypedServiceProviderHelpers,
+                DiagnosticDescriptors.PreferPropertyStateHelper,
                 FastMoqAnalysisHelpers.GetTargetNameLocation(invocationExpression.Expression),
-                currentApi));
+                guidance));
         }
     }
 }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -123,7 +123,7 @@ namespace FastMoq.Analyzers.CodeFixes
                             return;
                         }
 
-                        if (FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _, out _))
+                        if (FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperEdit(invocationExpression, semanticModel, context.CancellationToken, out _, out _, out _, out _))
                         {
                             context.RegisterCodeFix(
                                 CodeAction.Create(
@@ -375,14 +375,44 @@ namespace FastMoq.Analyzers.CodeFixes
                 return document;
             }
 
-            if (!FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperReplacement(invocationExpression, semanticModel, cancellationToken, out var targetInvocation, out var replacementText, out var requiredNamespaces))
+            if (!FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperEdit(invocationExpression, semanticModel, cancellationToken, out var targetInvocation, out var replacementText, out var requiredNamespaces, out var linkedInvocationToRemove))
             {
                 return document;
             }
 
+            var targetAnnotation = new SyntaxAnnotation();
+            var removalNode = linkedInvocationToRemove?.FirstAncestorOrSelf<ExpressionStatementSyntax>() as SyntaxNode ?? linkedInvocationToRemove;
+            var removalAnnotation = removalNode is null ? null : new SyntaxAnnotation();
+            var nodesToAnnotate = new List<SyntaxNode>
+            {
+                targetInvocation,
+            };
+            if (removalNode is not null)
+            {
+                nodesToAnnotate.Add(removalNode);
+            }
+
+            var updatedRoot = root.ReplaceNodes(
+                nodesToAnnotate,
+                (originalNode, rewrittenNode) =>
+                {
+                    if (originalNode == targetInvocation)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(targetAnnotation);
+                    }
+
+                    return rewrittenNode.WithAdditionalAnnotations(removalAnnotation!);
+                });
+            if (removalAnnotation is not null)
+            {
+                var annotatedRemovalNode = updatedRoot.GetAnnotatedNodes(removalAnnotation).Single();
+                updatedRoot = updatedRoot.RemoveNode(annotatedRemovalNode, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
+            }
+
+            var annotatedTargetInvocation = updatedRoot.GetAnnotatedNodes(targetAnnotation).Single();
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
-                .WithTriviaFrom(targetInvocation);
-            var updatedRoot = root.ReplaceNode(targetInvocation, replacementExpression);
+                .WithTriviaFrom(annotatedTargetInvocation);
+            updatedRoot = updatedRoot.ReplaceNode(annotatedTargetInvocation, replacementExpression);
             updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, requiredNamespaces);
             return document.WithSyntaxRoot(updatedRoot);
         }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -117,19 +118,32 @@ namespace FastMoq.Analyzers.CodeFixes
                         }
 
                         var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-                        if (semanticModel is null ||
-                            !FastMoqAnalysisHelpers.HasFunctionContextInstanceServicesMockHelper(semanticModel) ||
-                            !FastMoqAnalysisHelpers.TryBuildFunctionContextInstanceServicesReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _))
+                        if (semanticModel is null)
                         {
                             return;
                         }
 
-                        context.RegisterCodeFix(
-                            CodeAction.Create(
-                                "Use AddFunctionContextInstanceServices(...)",
-                                cancellationToken => ReplaceFunctionContextInstanceServicesInvocationAsync(document, invocationExpression, cancellationToken),
-                                nameof(DiagnosticIds.PreferTypedServiceProviderHelpers)),
-                            diagnostic);
+                        if (FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _, out _))
+                        {
+                            context.RegisterCodeFix(
+                                CodeAction.Create(
+                                    "Use typed service-provider helper",
+                                    cancellationToken => ReplaceTypedServiceProviderHelperInvocationAsync(document, invocationExpression, cancellationToken),
+                                    nameof(DiagnosticIds.PreferTypedServiceProviderHelpers) + ".typed"),
+                                diagnostic);
+                        }
+
+                        if (FastMoqAnalysisHelpers.HasFunctionContextInstanceServicesMockHelper(semanticModel) &&
+                            FastMoqAnalysisHelpers.TryBuildFunctionContextInstanceServicesReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _))
+                        {
+                            context.RegisterCodeFix(
+                                CodeAction.Create(
+                                    "Use AddFunctionContextInstanceServices(...)",
+                                    cancellationToken => ReplaceFunctionContextInstanceServicesInvocationAsync(document, invocationExpression, cancellationToken),
+                                    nameof(DiagnosticIds.PreferTypedServiceProviderHelpers) + ".functions"),
+                                diagnostic);
+                        }
+
                         break;
                     }
 
@@ -352,6 +366,27 @@ namespace FastMoq.Analyzers.CodeFixes
             return document.WithSyntaxRoot(updatedRoot);
         }
 
+        private static async Task<Document> ReplaceTypedServiceProviderHelperInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return document;
+            }
+
+            if (!FastMoqAnalysisHelpers.TryBuildTypedServiceProviderHelperReplacement(invocationExpression, semanticModel, cancellationToken, out var targetInvocation, out var replacementText, out var requiredNamespaces))
+            {
+                return document;
+            }
+
+            var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
+                .WithTriviaFrom(targetInvocation);
+            var updatedRoot = root.ReplaceNode(targetInvocation, replacementExpression);
+            updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, requiredNamespaces);
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
         private static async Task<Document> ReplaceGetMockAsync(Document document, MemberAccessExpressionSyntax memberAccess, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -373,6 +408,16 @@ namespace FastMoq.Analyzers.CodeFixes
             if (root is CompilationUnitSyntax compilationUnit && !compilationUnit.Usings.Any(@using => @using.Name?.ToString() == namespaceName))
             {
                 return compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+            }
+
+            return root;
+        }
+
+        private static SyntaxNode AddUsingDirectivesIfMissing(SyntaxNode root, IReadOnlyList<string> namespaceNames)
+        {
+            foreach (var namespaceName in namespaceNames)
+            {
+                root = AddUsingDirectiveIfMissing(root, namespaceName);
             }
 
             return root;

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -123,6 +123,15 @@ namespace FastMoq.Analyzers
             isEnabledByDefault: true,
             description: "Prefer AddPropertySetterCapture<TService, TValue>(...) for simple interface-property setter capture flows, or a fake plus PropertyValueCapture<TValue> when the test needs a broader replacement than Moq-specific SetupSet(...).");
 
+        public static readonly DiagnosticDescriptor PreferPropertyStateHelper = new(
+            DiagnosticIds.PreferPropertyStateHelper,
+            "Prefer provider-neutral property state",
+            "Prefer '{0}' instead of 'SetupAllProperties()' when the test only needs lightweight property state",
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Prefer AddPropertyState<TService>(...) for simple interface-property state flows, or a concrete fake registered with AddType(...) when the old Moq setup relied on broader class or provider-specific property behavior.");
+
         public static readonly DiagnosticDescriptor SelectProviderBeforeProviderSpecificApi = new(
             DiagnosticIds.SelectProviderBeforeProviderSpecificApi,
             "Select a provider before using provider-specific FastMoq APIs",
@@ -166,7 +175,7 @@ namespace FastMoq.Analyzers
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Mocking IServiceProvider directly or manually wiring FunctionContext.InstanceServices often creates one-object-for-all-types shims. Prefer CreateTypedServiceProvider(...), AddServiceProvider(...), CreateFunctionContextInstanceServices(...), or AddFunctionContextInstanceServices(...) so framework code resolves services by requested type.");
+            description: "Mocking IServiceProvider, IServiceScopeFactory, or IServiceScope directly often creates one-object-for-all-types shims. Prefer CreateTypedServiceProvider(...), CreateTypedServiceScope(...), AddServiceProvider(...), AddServiceScope(...), CreateFunctionContextInstanceServices(...), or AddFunctionContextInstanceServices(...) so framework code resolves services by requested type.");
 
         public static readonly DiagnosticDescriptor PreferKnownTypeRegistrations = new(
             DiagnosticIds.PreferKnownTypeRegistrations,

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -22,5 +22,6 @@ namespace FastMoq.Analyzers
         public const string AvoidLegacyMockCreationAndLifecycleApis = "FMOQ0018";
         public const string PreferSetupOptionsHelper = "FMOQ0019";
         public const string PreferPropertySetterCaptureHelper = "FMOQ0020";
+        public const string PreferPropertyStateHelper = "FMOQ0021";
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -688,6 +689,22 @@ namespace FastMoq.Analyzers
             return TryBuildScopeExtractionReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces);
         }
 
+        public static bool TryBuildTypedServiceProviderHelperEdit(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces, out InvocationExpressionSyntax? linkedInvocationToRemove)
+        {
+            linkedInvocationToRemove = null;
+            if (TryBuildTypedServiceProviderHelperReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces))
+            {
+                return true;
+            }
+
+            if (TryBuildScopeServiceProviderSetupReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces, out linkedInvocationToRemove))
+            {
+                return true;
+            }
+
+            return TryBuildScopeFactoryCreateScopeReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces, out linkedInvocationToRemove);
+        }
+
         public static bool TryGetFunctionContextInstanceServicesHelperSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string currentApi)
         {
             currentApi = string.Empty;
@@ -958,6 +975,222 @@ namespace FastMoq.Analyzers
                 default:
                     return false;
             }
+        }
+
+        private static bool TryBuildScopeServiceProviderSetupReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces, out InvocationExpressionSyntax? linkedInvocationToRemove)
+        {
+            linkedInvocationToRemove = null;
+            targetInvocation = null!;
+            replacement = string.Empty;
+            requiredNamespaces = Array.Empty<string>();
+
+            if (!TryGetScopeServiceProviderSetup(invocationExpression, semanticModel, cancellationToken, out var scopeOrigin, out var providerExpression, out var replacementTarget))
+            {
+                return false;
+            }
+
+            targetInvocation = replacementTarget;
+            replacement = $"{scopeOrigin.MockerExpression.WithoutTrivia()}.AddServiceScope({providerExpression.WithoutTrivia()})";
+            requiredNamespaces = ["FastMoq.Extensions"];
+
+            if (TryFindMatchingScopeFactoryCreateScopeSetup(replacementTarget, scopeOrigin, semanticModel, cancellationToken, out var matchingInvocation))
+            {
+                linkedInvocationToRemove = matchingInvocation;
+            }
+
+            return true;
+        }
+
+        private static bool TryBuildScopeFactoryCreateScopeReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces, out InvocationExpressionSyntax? linkedInvocationToRemove)
+        {
+            linkedInvocationToRemove = null;
+            targetInvocation = null!;
+            replacement = string.Empty;
+            requiredNamespaces = Array.Empty<string>();
+
+            if (!TryGetScopeFactoryCreateScopeSetup(invocationExpression, semanticModel, cancellationToken, out var scopeFactoryOrigin, out var scopeOrigin, out var replacementTarget) ||
+                !TryFindMatchingScopeServiceProviderSetup(replacementTarget, scopeOrigin, semanticModel, cancellationToken, out var matchingInvocation, out var providerExpression))
+            {
+                return false;
+            }
+
+            targetInvocation = replacementTarget;
+            replacement = $"{scopeFactoryOrigin.MockerExpression.WithoutTrivia()}.AddServiceScope({providerExpression.WithoutTrivia()})";
+            requiredNamespaces = ["FastMoq.Extensions"];
+            linkedInvocationToRemove = matchingInvocation;
+            return true;
+        }
+
+        private static bool TryGetScopeServiceProviderSetup(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out TrackedMockOrigin origin, out ExpressionSyntax providerExpression, out InvocationExpressionSyntax targetInvocation)
+        {
+            origin = default;
+            providerExpression = null!;
+            targetInvocation = null!;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name is not "Setup" and not "SetupGet" and not "SetupProperty" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||
+                !TryResolveTrackedMockOrigin(memberAccessExpression.Expression, semanticModel, cancellationToken, out origin) ||
+                origin.ServiceType.ToDisplayString() != SERVICE_SCOPE_TYPE ||
+                invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateExpression is not LambdaExpressionSyntax scopeLambda ||
+                scopeLambda.Body is not MemberAccessExpressionSyntax propertyAccess ||
+                propertyAccess.Name.Identifier.ValueText != "ServiceProvider")
+            {
+                return false;
+            }
+
+            if (method.Name == "SetupProperty")
+            {
+                if (invocationExpression.ArgumentList.Arguments.Count != 2)
+                {
+                    return false;
+                }
+
+                providerExpression = invocationExpression.ArgumentList.Arguments[1].Expression;
+                targetInvocation = invocationExpression;
+                return true;
+            }
+
+            if (invocationExpression.Parent is not MemberAccessExpressionSyntax returnsAccess ||
+                returnsAccess.Parent is not InvocationExpressionSyntax returnsInvocation ||
+                !TryGetMethodSymbol(returnsInvocation, semanticModel, cancellationToken, out var returnsMethod) ||
+                returnsMethod is null)
+            {
+                return false;
+            }
+
+            returnsMethod = returnsMethod.ReducedFrom ?? returnsMethod;
+            if (returnsMethod.Name != "Returns" ||
+                returnsInvocation.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            providerExpression = returnsInvocation.ArgumentList.Arguments[0].Expression;
+            targetInvocation = returnsInvocation;
+            return true;
+        }
+
+        private static bool TryGetScopeFactoryCreateScopeSetup(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out TrackedMockOrigin scopeFactoryOrigin, out TrackedMockOrigin scopeOrigin, out InvocationExpressionSyntax targetInvocation)
+        {
+            scopeFactoryOrigin = default;
+            scopeOrigin = default;
+            targetInvocation = null!;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name is not "Setup" and not "SetupGet" and not "SetupProperty" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||
+                !TryResolveTrackedMockOrigin(memberAccessExpression.Expression, semanticModel, cancellationToken, out scopeFactoryOrigin) ||
+                scopeFactoryOrigin.ServiceType.ToDisplayString() != SERVICE_SCOPE_FACTORY_TYPE ||
+                invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateExpression is not LambdaExpressionSyntax scopeFactoryLambda ||
+                scopeFactoryLambda.Body is not InvocationExpressionSyntax createScopeInvocation ||
+                createScopeInvocation.Expression is not MemberAccessExpressionSyntax createScopeAccess ||
+                createScopeAccess.Name.Identifier.ValueText != "CreateScope" ||
+                invocationExpression.Parent is not MemberAccessExpressionSyntax returnsAccess ||
+                returnsAccess.Parent is not InvocationExpressionSyntax returnsInvocation ||
+                !TryGetMethodSymbol(returnsInvocation, semanticModel, cancellationToken, out var returnsMethod) ||
+                returnsMethod is null)
+            {
+                return false;
+            }
+
+            returnsMethod = returnsMethod.ReducedFrom ?? returnsMethod;
+            if (returnsMethod.Name != "Returns" ||
+                returnsInvocation.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            var returnedScopeExpression = Unwrap(returnsInvocation.ArgumentList.Arguments[0].Expression);
+            if (returnedScopeExpression is not MemberAccessExpressionSyntax returnedScopeAccess ||
+                returnedScopeAccess.Name.Identifier.ValueText != "Instance" ||
+                !TryResolveTrackedMockOrigin(returnedScopeAccess.Expression, semanticModel, cancellationToken, out scopeOrigin) ||
+                scopeOrigin.ServiceType.ToDisplayString() != SERVICE_SCOPE_TYPE)
+            {
+                return false;
+            }
+
+            targetInvocation = returnsInvocation;
+            return true;
+        }
+
+        private static bool TryFindMatchingScopeServiceProviderSetup(SyntaxNode referenceNode, TrackedMockOrigin scopeOrigin, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax matchingInvocation, out ExpressionSyntax providerExpression)
+        {
+            matchingInvocation = null!;
+            providerExpression = null!;
+
+            var searchRoot = referenceNode.FirstAncestorOrSelf<BlockSyntax>() ?? referenceNode.SyntaxTree.GetRoot(cancellationToken);
+            foreach (var candidateInvocation in searchRoot.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (candidateInvocation.Span == referenceNode.Span)
+                {
+                    continue;
+                }
+
+                if (TryGetScopeServiceProviderSetup(candidateInvocation, semanticModel, cancellationToken, out var candidateOrigin, out var candidateProviderExpression, out var candidateTargetInvocation) &&
+                    AreSameTrackedMockOrigin(scopeOrigin, candidateOrigin))
+                {
+                    matchingInvocation = candidateTargetInvocation;
+                    providerExpression = candidateProviderExpression;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryFindMatchingScopeFactoryCreateScopeSetup(SyntaxNode referenceNode, TrackedMockOrigin scopeOrigin, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax matchingInvocation)
+        {
+            matchingInvocation = null!;
+
+            var searchRoot = referenceNode.FirstAncestorOrSelf<BlockSyntax>() ?? referenceNode.SyntaxTree.GetRoot(cancellationToken);
+            foreach (var candidateInvocation in searchRoot.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (candidateInvocation.Span == referenceNode.Span)
+                {
+                    continue;
+                }
+
+                if (TryGetScopeFactoryCreateScopeSetup(candidateInvocation, semanticModel, cancellationToken, out _, out var candidateScopeOrigin, out var candidateTargetInvocation) &&
+                    AreSameTrackedMockOrigin(scopeOrigin, candidateScopeOrigin))
+                {
+                    matchingInvocation = candidateTargetInvocation;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool AreSameTrackedMockOrigin(TrackedMockOrigin left, TrackedMockOrigin right)
+        {
+            return SymbolEqualityComparer.Default.Equals(left.ServiceType, right.ServiceType) &&
+                   SyntaxFactory.AreEquivalent(Unwrap(left.TrackedMockExpression), Unwrap(right.TrackedMockExpression)) &&
+                   SyntaxFactory.AreEquivalent(Unwrap(left.MockerExpression), Unwrap(right.MockerExpression));
         }
 
         private static bool TryGetServiceProviderLookupTarget(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string serviceTypeName, out string lookupApi)

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -48,6 +48,8 @@ namespace FastMoq.Analyzers
         private const string FUNCTION_CONTEXT_TYPE = "Microsoft.Azure.Functions.Worker.FunctionContext";
         private const string FUNCTION_CONTEXT_INSTANCE_SERVICES_PROPERTY = "InstanceServices";
         private const string SERVICE_PROVIDER_TYPE = "System.IServiceProvider";
+        private const string SERVICE_SCOPE_FACTORY_TYPE = "Microsoft.Extensions.DependencyInjection.IServiceScopeFactory";
+        private const string SERVICE_SCOPE_TYPE = "Microsoft.Extensions.DependencyInjection.IServiceScope";
 
         private static readonly HashSet<string> DisallowedMixedRetrievalMembers = new(StringComparer.Ordinal)
         {
@@ -482,6 +484,44 @@ namespace FastMoq.Analyzers
             return true;
         }
 
+        public static bool TryBuildSetupAllPropertiesGuidance(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string guidance)
+        {
+            guidance = string.Empty;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name != "SetupAllProperties" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                return false;
+            }
+
+            var receiverType = semanticModel.GetTypeInfo(memberAccessExpression.Expression, cancellationToken).Type as INamedTypeSymbol;
+            if (receiverType is null ||
+                receiverType.Name != "Mock" ||
+                receiverType.ContainingNamespace.ToDisplayString() != "Moq" ||
+                receiverType.TypeArguments.Length != 1)
+            {
+                return false;
+            }
+
+            var serviceType = receiverType.TypeArguments[0];
+            var serviceTypeName = GetMinimalTypeName(serviceType, semanticModel, invocationExpression.SpanStart);
+            if (serviceType.TypeKind == TypeKind.Interface && invocationExpression.Parent is not MemberAccessExpressionSyntax)
+            {
+                guidance = $"AddPropertyState<{serviceTypeName}>()";
+                return true;
+            }
+
+            guidance = "a concrete fake or stub registered with AddType(...)";
+            return true;
+        }
+
         public static bool TryBuildFunctionContextInstanceServicesReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement)
         {
             if (!HasFunctionContextInstanceServicesMockHelper(semanticModel))
@@ -615,25 +655,27 @@ namespace FastMoq.Analyzers
             return false;
         }
 
-        public static bool TryGetTypedServiceProviderHelperSuggestion(IMethodSymbol method, out string currentApi)
+        public static bool TryGetTypedServiceProviderHelperSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string currentApi)
         {
-            method = method.ReducedFrom ?? method;
             currentApi = string.Empty;
 
-            if (!IsFastMoqMockerMethod(method, "GetOrCreateMock") &&
-                !IsFastMoqMockerMethod(method, "GetMock") &&
-                !IsFastMoqMockerMethod(method, "GetRequiredMock"))
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
             {
                 return false;
             }
 
-            if (method.TypeArguments.Length != 1 || method.TypeArguments[0].ToDisplayString() != SERVICE_PROVIDER_TYPE)
+            if (TryGetTrackedServiceGraphShimSuggestion(method, out currentApi))
             {
-                return false;
+                return true;
             }
 
-            currentApi = $"{method.Name}<IServiceProvider>()";
-            return true;
+            if (TryGetScopeExtractionLookupSuggestion(invocationExpression, semanticModel, cancellationToken, out currentApi))
+            {
+                return true;
+            }
+
+            return TryGetScopeShimSetupSuggestion(invocationExpression, semanticModel, cancellationToken, method, out currentApi);
         }
 
         public static bool TryGetFunctionContextInstanceServicesHelperSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string currentApi)
@@ -687,6 +729,165 @@ namespace FastMoq.Analyzers
                     method.Parameters.Length == 2 &&
                     method.Parameters[0].Type.ToDisplayString() == "FastMoq.Providers.IFastMock" &&
                     method.Parameters[1].Type.ToDisplayString() == SERVICE_PROVIDER_TYPE);
+        }
+
+        private static bool TryGetTrackedServiceGraphShimSuggestion(IMethodSymbol method, out string currentApi)
+        {
+            method = method.ReducedFrom ?? method;
+            currentApi = string.Empty;
+
+            if (!IsFastMoqMockerMethod(method, "GetOrCreateMock") &&
+                !IsFastMoqMockerMethod(method, "GetMock") &&
+                !IsFastMoqMockerMethod(method, "GetRequiredMock"))
+            {
+                return false;
+            }
+
+            if (method.TypeArguments.Length != 1 || !TryGetTypedServiceGraphShimTypeDisplay(method.TypeArguments[0], out var serviceTypeName))
+            {
+                return false;
+            }
+
+            currentApi = $"{method.Name}<{serviceTypeName}>()";
+            return true;
+        }
+
+        private static bool TryGetScopeExtractionAddTypeSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, IMethodSymbol method, out string currentApi)
+        {
+            currentApi = string.Empty;
+            method = method.ReducedFrom ?? method;
+            if (!IsFastMoqMockerAddTypeMethod(method) || invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            if (method.TypeArguments.Length == 0 || !TryGetTypedServiceGraphShimTypeDisplay(method.TypeArguments[0], out var addedTypeName))
+            {
+                return false;
+            }
+
+            var firstArgument = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (firstArgument is not InvocationExpressionSyntax lookupInvocation ||
+                !TryGetServiceProviderLookupTarget(lookupInvocation, semanticModel, cancellationToken, out var lookupTypeName, out var lookupApi) ||
+                lookupTypeName != addedTypeName)
+            {
+                return false;
+            }
+
+            currentApi = $"AddType<{addedTypeName}>({lookupApi})";
+            return true;
+        }
+
+        private static bool TryGetScopeExtractionLookupSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string currentApi)
+        {
+            currentApi = string.Empty;
+            if (!TryGetServiceProviderLookupTarget(invocationExpression, semanticModel, cancellationToken, out var serviceTypeName, out var lookupApi) ||
+                invocationExpression.Parent is not ArgumentSyntax argumentSyntax ||
+                argumentSyntax.Parent is not ArgumentListSyntax argumentListSyntax ||
+                argumentListSyntax.Parent is not InvocationExpressionSyntax outerInvocation ||
+                !TryGetMethodSymbol(outerInvocation, semanticModel, cancellationToken, out var outerMethod) ||
+                outerMethod is null)
+            {
+                return false;
+            }
+
+            outerMethod = outerMethod.ReducedFrom ?? outerMethod;
+            if (!IsFastMoqMockerAddTypeMethod(outerMethod))
+            {
+                return false;
+            }
+
+            currentApi = $"AddType<{serviceTypeName}>({lookupApi})";
+            return true;
+        }
+
+        private static bool TryGetScopeShimSetupSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, IMethodSymbol method, out string currentApi)
+        {
+            currentApi = string.Empty;
+            method = method.ReducedFrom ?? method;
+            if (method.Name is not "Setup" and not "SetupGet" and not "SetupProperty")
+            {
+                return false;
+            }
+
+            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||
+                !TryResolveTrackedMockOrigin(memberAccessExpression.Expression, semanticModel, cancellationToken, out var origin) ||
+                invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (origin.ServiceType.ToDisplayString() == SERVICE_SCOPE_FACTORY_TYPE &&
+                candidateExpression is LambdaExpressionSyntax scopeFactoryLambda &&
+                scopeFactoryLambda.Body is InvocationExpressionSyntax createScopeInvocation &&
+                createScopeInvocation.Expression is MemberAccessExpressionSyntax createScopeAccess &&
+                createScopeAccess.Name.Identifier.ValueText == "CreateScope")
+            {
+                currentApi = "Setup(x => x.CreateScope())";
+                return true;
+            }
+
+            if (origin.ServiceType.ToDisplayString() == SERVICE_SCOPE_TYPE &&
+                candidateExpression is LambdaExpressionSyntax scopeLambda &&
+                scopeLambda.Body is MemberAccessExpressionSyntax propertyAccess &&
+                propertyAccess.Name.Identifier.ValueText == "ServiceProvider")
+            {
+                currentApi = $"{method.Name}(x => x.ServiceProvider)";
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetServiceProviderLookupTarget(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string serviceTypeName, out string lookupApi)
+        {
+            serviceTypeName = string.Empty;
+            lookupApi = string.Empty;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) || method is null)
+            {
+                return false;
+            }
+
+            var comparisonMethod = method.ReducedFrom ?? method;
+            if (comparisonMethod.Name is not "GetRequiredService" and not "GetService")
+            {
+                return false;
+            }
+
+            if (method.TypeArguments.Length != 1 || !TryGetTypedServiceGraphShimTypeDisplay(method.TypeArguments[0], out serviceTypeName))
+            {
+                return false;
+            }
+
+            lookupApi = $"{method.Name}<{serviceTypeName}>()";
+            return true;
+        }
+
+        private static bool TryGetTypedServiceGraphShimTypeDisplay(ITypeSymbol typeSymbol, out string serviceTypeName)
+        {
+            var metadataName = typeSymbol.ToDisplayString();
+            if (metadataName == SERVICE_PROVIDER_TYPE)
+            {
+                serviceTypeName = "IServiceProvider";
+                return true;
+            }
+
+            if (metadataName == SERVICE_SCOPE_FACTORY_TYPE)
+            {
+                serviceTypeName = "IServiceScopeFactory";
+                return true;
+            }
+
+            if (metadataName == SERVICE_SCOPE_TYPE)
+            {
+                serviceTypeName = "IServiceScope";
+                return true;
+            }
+
+            serviceTypeName = string.Empty;
+            return false;
         }
 
         private static bool TryGetSetupSetProperty(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out TrackedMockOrigin origin, out IPropertySymbol property, out LambdaExpressionSyntax lambdaExpression)

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -678,6 +678,16 @@ namespace FastMoq.Analyzers
             return TryGetScopeShimSetupSuggestion(invocationExpression, semanticModel, cancellationToken, method, out currentApi);
         }
 
+        public static bool TryBuildTypedServiceProviderHelperReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces)
+        {
+            if (TryBuildTrackedServiceGraphShimReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces))
+            {
+                return true;
+            }
+
+            return TryBuildScopeExtractionReplacement(invocationExpression, semanticModel, cancellationToken, out targetInvocation, out replacement, out requiredNamespaces);
+        }
+
         public static bool TryGetFunctionContextInstanceServicesHelperSuggestion(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string currentApi)
         {
             currentApi = string.Empty;
@@ -838,6 +848,116 @@ namespace FastMoq.Analyzers
             }
 
             return false;
+        }
+
+        private static bool TryBuildTrackedServiceGraphShimReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces)
+        {
+            targetInvocation = null!;
+            replacement = string.Empty;
+            requiredNamespaces = Array.Empty<string>();
+
+            if (invocationExpression.Parent is MemberAccessExpressionSyntax ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (!IsFastMoqMockerMethod(method, "GetOrCreateMock") &&
+                !IsFastMoqMockerMethod(method, "GetMock") &&
+                !IsFastMoqMockerMethod(method, "GetRequiredMock"))
+            {
+                return false;
+            }
+
+            if (method.TypeArguments.Length != 1 || invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                return false;
+            }
+
+            var mockerExpression = memberAccessExpression.Expression.WithoutTrivia().ToString();
+            switch (method.TypeArguments[0].ToDisplayString())
+            {
+                case SERVICE_PROVIDER_TYPE:
+                    targetInvocation = invocationExpression;
+                    replacement = $"{mockerExpression}.CreateTypedServiceProvider()";
+                    requiredNamespaces = ["FastMoq.Extensions"];
+                    return true;
+
+                case SERVICE_SCOPE_FACTORY_TYPE:
+                    targetInvocation = invocationExpression;
+                    replacement = $"{mockerExpression}.CreateTypedServiceProvider().GetRequiredService<IServiceScopeFactory>()";
+                    requiredNamespaces = ["FastMoq.Extensions", "Microsoft.Extensions.DependencyInjection"];
+                    return true;
+
+                case SERVICE_SCOPE_TYPE:
+                    targetInvocation = invocationExpression;
+                    replacement = $"{mockerExpression}.CreateTypedServiceScope()";
+                    requiredNamespaces = ["FastMoq.Extensions"];
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static bool TryBuildScopeExtractionReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax targetInvocation, out string replacement, out IReadOnlyList<string> requiredNamespaces)
+        {
+            targetInvocation = null!;
+            replacement = string.Empty;
+            requiredNamespaces = Array.Empty<string>();
+
+            if (!TryGetServiceProviderLookupTarget(invocationExpression, semanticModel, cancellationToken, out var serviceTypeName, out _) ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax lookupAccess ||
+                invocationExpression.Parent is not ArgumentSyntax argumentSyntax ||
+                argumentSyntax.Parent is not ArgumentListSyntax argumentListSyntax ||
+                argumentListSyntax.Parent is not InvocationExpressionSyntax outerInvocation ||
+                !TryGetMethodSymbol(outerInvocation, semanticModel, cancellationToken, out var outerMethod) ||
+                outerMethod is null)
+            {
+                return false;
+            }
+
+            outerMethod = outerMethod.ReducedFrom ?? outerMethod;
+            if (!IsFastMoqMockerAddTypeMethod(outerMethod) ||
+                outerInvocation.Expression is not MemberAccessExpressionSyntax outerAccess ||
+                outerInvocation.ArgumentList.Arguments.Count == 0 ||
+                outerInvocation.ArgumentList.Arguments.Count > 2)
+            {
+                return false;
+            }
+
+            if (outerInvocation.ArgumentList.Arguments.Count == 2 &&
+                (outerMethod.Parameters.Length < 2 || outerMethod.Parameters[1].Type.SpecialType != SpecialType.System_Boolean))
+            {
+                return false;
+            }
+
+            var mockerExpression = outerAccess.Expression.WithoutTrivia().ToString();
+            var receiverExpression = lookupAccess.Expression.WithoutTrivia().ToString();
+            var trailingArguments = outerInvocation.ArgumentList.Arguments.Count == 2
+                ? $", {outerInvocation.ArgumentList.Arguments[1].WithoutTrivia()}"
+                : string.Empty;
+
+            switch (serviceTypeName)
+            {
+                case "IServiceProvider":
+                case "IServiceScopeFactory":
+                    targetInvocation = outerInvocation;
+                    replacement = $"{mockerExpression}.AddServiceProvider({receiverExpression}{trailingArguments})";
+                    requiredNamespaces = ["FastMoq.Extensions"];
+                    return true;
+
+                case "IServiceScope":
+                    targetInvocation = outerInvocation;
+                    replacement = $"{mockerExpression}.AddServiceScope({invocationExpression.WithoutTrivia()}{trailingArguments})";
+                    requiredNamespaces = ["FastMoq.Extensions"];
+                    return true;
+
+                default:
+                    return false;
+            }
         }
 
         private static bool TryGetServiceProviderLookupTarget(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string serviceTypeName, out string lookupApi)

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -1143,8 +1143,7 @@ namespace FastMoq.Analyzers
             matchingInvocation = null!;
             providerExpression = null!;
 
-            var searchRoot = referenceNode.FirstAncestorOrSelf<BlockSyntax>() ?? referenceNode.SyntaxTree.GetRoot(cancellationToken);
-            foreach (var candidateInvocation in searchRoot.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            foreach (var candidateInvocation in EnumerateCurrentBlockInvocations(referenceNode))
             {
                 if (candidateInvocation.Span == referenceNode.Span)
                 {
@@ -1167,8 +1166,7 @@ namespace FastMoq.Analyzers
         {
             matchingInvocation = null!;
 
-            var searchRoot = referenceNode.FirstAncestorOrSelf<BlockSyntax>() ?? referenceNode.SyntaxTree.GetRoot(cancellationToken);
-            foreach (var candidateInvocation in searchRoot.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            foreach (var candidateInvocation in EnumerateCurrentBlockInvocations(referenceNode))
             {
                 if (candidateInvocation.Span == referenceNode.Span)
                 {
@@ -1191,6 +1189,29 @@ namespace FastMoq.Analyzers
             return SymbolEqualityComparer.Default.Equals(left.ServiceType, right.ServiceType) &&
                    SyntaxFactory.AreEquivalent(Unwrap(left.TrackedMockExpression), Unwrap(right.TrackedMockExpression)) &&
                    SyntaxFactory.AreEquivalent(Unwrap(left.MockerExpression), Unwrap(right.MockerExpression));
+        }
+
+        private static IEnumerable<InvocationExpressionSyntax> EnumerateCurrentBlockInvocations(SyntaxNode referenceNode)
+        {
+            if (referenceNode.FirstAncestorOrSelf<BlockSyntax>() is not BlockSyntax block)
+            {
+                yield break;
+            }
+
+            foreach (var statement in block.Statements)
+            {
+                if (statement is LocalFunctionStatementSyntax)
+                {
+                    continue;
+                }
+
+                foreach (var invocation in statement
+                    .DescendantNodesAndSelf(static node => node is not BlockSyntax and not AnonymousFunctionExpressionSyntax and not LocalFunctionStatementSyntax)
+                    .OfType<InvocationExpressionSyntax>())
+                {
+                    yield return invocation;
+                }
+            }
         }
 
         private static bool TryGetServiceProviderLookupTarget(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string serviceTypeName, out string lookupApi)

--- a/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
+++ b/FastMoq.Core/Extensions/PropertySetterCaptureExtensions.cs
@@ -72,94 +72,19 @@ namespace FastMoq.Extensions
             }
 
             var currentInstance = mocker.GetObject<TService>() ?? throw new InvalidOperationException($"Unable to resolve an instance for {serviceType.Name} before adding a setter capture.");
-            if (currentInstance is PropertySetterCaptureProxy<TService> existingProxy)
+            if (currentInstance is PropertyStateProxy<TService> existingProxy)
             {
                 existingProxy.AddCapture(propertyInfo, capture);
                 return capture;
             }
 
-            var proxy = DispatchProxy.Create<TService, PropertySetterCaptureProxy<TService>>();
-            var proxyController = (PropertySetterCaptureProxy<TService>) (object) proxy;
+            var proxy = DispatchProxy.Create<TService, PropertyStateProxy<TService>>();
+            var proxyController = (PropertyStateProxy<TService>) (object) proxy;
             proxyController.Initialize(currentInstance);
             proxyController.AddCapture(propertyInfo, capture);
 
             mocker.AddType<TService>(proxy, replace);
             return capture;
-        }
-    }
-
-    internal class PropertySetterCaptureProxy<TService> : DispatchProxy where TService : class
-    {
-        private readonly Dictionary<MethodInfo, Func<object?[]?, object?>> _handlers = [];
-
-        private TService? _inner;
-
-        public void Initialize(TService inner)
-        {
-            ArgumentNullException.ThrowIfNull(inner);
-            _inner = inner;
-        }
-
-        public void AddCapture<TValue>(PropertyInfo propertyInfo, PropertyValueCapture<TValue> capture)
-        {
-            ArgumentNullException.ThrowIfNull(propertyInfo);
-            ArgumentNullException.ThrowIfNull(capture);
-
-            if (propertyInfo.GetMethod is MethodInfo getter)
-            {
-                _handlers[getter] = _ =>
-                {
-                    if (capture.HasValue)
-                    {
-                        return capture.Value;
-                    }
-
-                    return _inner is null ? default(TValue) : propertyInfo.GetValue(_inner);
-                };
-            }
-
-            if (propertyInfo.SetMethod is MethodInfo setter)
-            {
-                _handlers[setter] = arguments =>
-                {
-                    var assignedValue = arguments is not null && arguments.Length > 0
-                        ? (TValue) arguments[0]!
-                        : default!;
-
-                    capture.Record(assignedValue);
-
-                    if (_inner is not null)
-                    {
-                        propertyInfo.SetValue(_inner, assignedValue);
-                    }
-
-                    return null;
-                };
-            }
-        }
-
-        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
-        {
-            ArgumentNullException.ThrowIfNull(targetMethod);
-
-            if (_handlers.TryGetValue(targetMethod, out var handler))
-            {
-                return handler(args);
-            }
-
-            if (_inner is null)
-            {
-                throw new InvalidOperationException($"{nameof(PropertySetterCaptureProxy<TService>)} has not been initialized.");
-            }
-
-            try
-            {
-                return targetMethod.Invoke(_inner, args);
-            }
-            catch (TargetInvocationException ex) when (ex.InnerException is not null)
-            {
-                throw ex.InnerException;
-            }
         }
     }
 }

--- a/FastMoq.Core/Extensions/PropertyStateExtensions.cs
+++ b/FastMoq.Core/Extensions/PropertyStateExtensions.cs
@@ -1,0 +1,227 @@
+using System.Reflection;
+
+namespace FastMoq.Extensions
+{
+    /// <summary>
+    /// Provides first-party helpers for lightweight stateful interface properties without relying on provider-specific <c>SetupAllProperties()</c> behavior.
+    /// </summary>
+    public static class PropertyStateExtensions
+    {
+        /// <summary>
+        /// Replaces the current interface registration with a proxy that preserves assignments for all readable and writable non-indexer properties while forwarding unrelated members to the previously resolved instance.
+        /// </summary>
+        /// <typeparam name="TService">The interface type to wrap.</typeparam>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="replace">True to replace an existing registration for <typeparamref name="TService" />. Defaults to <see langword="true" /> because the helper intentionally swaps in a property-state proxy.</param>
+        /// <returns>The proxy-backed instance now registered for <typeparamref name="TService" />.</returns>
+        /// <example>
+        /// <code language="csharp"><![CDATA[
+        /// var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>();
+        /// CreateComponent();
+        ///
+        /// await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+        ///
+        /// channel.Mode.Should().Be("fast");
+        /// ]]></code>
+        /// </example>
+        /// <remarks>
+        /// When you use this helper from a <c>MockerTestBase&lt;TComponent&gt;</c>-based test, add the helper during the setup phase or call <c>CreateComponent()</c> after the registration change so the component is rebuilt against the proxy-wrapped dependency.
+        /// </remarks>
+        public static TService AddPropertyState<TService>(this Mocker mocker, bool replace = true)
+            where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            var serviceType = typeof(TService);
+            if (!serviceType.IsInterface)
+            {
+                throw new NotSupportedException($"{nameof(AddPropertyState)} currently supports interface types only. Use a fake or stub plus {nameof(Mocker.AddType)}(...) for {serviceType.Name}.");
+            }
+
+            var currentInstance = mocker.GetObject<TService>() ?? throw new InvalidOperationException($"Unable to resolve an instance for {serviceType.Name} before adding property state.");
+            if (currentInstance is PropertyStateProxy<TService> existingProxy)
+            {
+                existingProxy.EnableAutomaticPropertyState();
+                return currentInstance;
+            }
+
+            var proxy = DispatchProxy.Create<TService, PropertyStateProxy<TService>>();
+            var proxyController = (PropertyStateProxy<TService>) (object) proxy;
+            proxyController.Initialize(currentInstance);
+            proxyController.EnableAutomaticPropertyState();
+
+            mocker.AddType<TService>(proxy, replace);
+            return proxy;
+        }
+    }
+
+    internal class PropertyStateProxy<TService> : DispatchProxy where TService : class
+    {
+        private readonly Dictionary<MethodInfo, PropertyStateRegistration> _propertyRegistrations = [];
+
+        private TService? _inner;
+
+        public void Initialize(TService inner)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            _inner = inner;
+        }
+
+        public void EnableAutomaticPropertyState()
+        {
+            foreach (var propertyInfo in typeof(TService).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (propertyInfo.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
+                if (propertyInfo.GetMethod is null || propertyInfo.SetMethod is null)
+                {
+                    continue;
+                }
+
+                EnsurePropertyRegistration(propertyInfo);
+            }
+        }
+
+        public void AddCapture<TValue>(PropertyInfo propertyInfo, PropertyValueCapture<TValue> capture)
+        {
+            ArgumentNullException.ThrowIfNull(propertyInfo);
+            ArgumentNullException.ThrowIfNull(capture);
+
+            var registration = EnsurePropertyRegistration(propertyInfo);
+            registration.AddObserver(value => capture.Record(ConvertAssignedValue<TValue>(value)));
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            ArgumentNullException.ThrowIfNull(targetMethod);
+
+            if (_propertyRegistrations.TryGetValue(targetMethod, out var registration))
+            {
+                return registration.Invoke(_inner, targetMethod, args);
+            }
+
+            if (_inner is null)
+            {
+                throw new InvalidOperationException($"{nameof(PropertyStateProxy<TService>)} has not been initialized.");
+            }
+
+            try
+            {
+                return targetMethod.Invoke(_inner, args);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                throw ex.InnerException;
+            }
+        }
+
+        private PropertyStateRegistration EnsurePropertyRegistration(PropertyInfo propertyInfo)
+        {
+            ArgumentNullException.ThrowIfNull(propertyInfo);
+
+            if (propertyInfo.SetMethod is null)
+            {
+                throw new ArgumentException($"Property '{propertyInfo.Name}' must have a setter.", nameof(propertyInfo));
+            }
+
+            if (propertyInfo.GetMethod is null)
+            {
+                throw new ArgumentException($"Property '{propertyInfo.Name}' must have a getter.", nameof(propertyInfo));
+            }
+
+            if (_propertyRegistrations.TryGetValue(propertyInfo.GetMethod, out var existingRegistration))
+            {
+                return existingRegistration;
+            }
+
+            var registration = new PropertyStateRegistration(propertyInfo);
+            _propertyRegistrations[propertyInfo.GetMethod] = registration;
+            _propertyRegistrations[propertyInfo.SetMethod] = registration;
+            return registration;
+        }
+
+        private static TValue ConvertAssignedValue<TValue>(object? value)
+        {
+            if (value is null)
+            {
+                return default!;
+            }
+
+            return (TValue) value;
+        }
+
+        private sealed class PropertyStateRegistration
+        {
+            private readonly List<Action<object?>> _observers = [];
+
+            public PropertyStateRegistration(PropertyInfo propertyInfo)
+            {
+                PropertyInfo = propertyInfo;
+            }
+
+            public PropertyInfo PropertyInfo { get; }
+
+            public bool HasAssignedValue { get; private set; }
+
+            public object? AssignedValue { get; private set; }
+
+            public void AddObserver(Action<object?> observer)
+            {
+                ArgumentNullException.ThrowIfNull(observer);
+                _observers.Add(observer);
+            }
+
+            public object? Invoke(object? inner, MethodInfo targetMethod, object?[]? args)
+            {
+                if (targetMethod == PropertyInfo.GetMethod)
+                {
+                    if (HasAssignedValue)
+                    {
+                        return AssignedValue;
+                    }
+
+                    if (inner is null)
+                    {
+                        return GetDefaultValue();
+                    }
+
+                    return PropertyInfo.GetValue(inner);
+                }
+
+                if (targetMethod == PropertyInfo.SetMethod)
+                {
+                    var assignedValue = args is not null && args.Length > 0
+                        ? args[0]
+                        : GetDefaultValue();
+
+                    AssignedValue = assignedValue;
+                    HasAssignedValue = true;
+
+                    foreach (var observer in _observers)
+                    {
+                        observer(assignedValue);
+                    }
+
+                    if (inner is not null)
+                    {
+                        PropertyInfo.SetValue(inner, assignedValue);
+                    }
+
+                    return null;
+                }
+
+                throw new InvalidOperationException($"Method '{targetMethod.Name}' is not registered for property state on '{PropertyInfo.Name}'.");
+            }
+
+            private object? GetDefaultValue()
+            {
+                return PropertyInfo.PropertyType.IsValueType
+                    ? Activator.CreateInstance(PropertyInfo.PropertyType)
+                    : null;
+            }
+        }
+    }
+}

--- a/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
+++ b/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
@@ -12,6 +12,7 @@ namespace FastMoq.Extensions
         /// </summary>
         /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
         /// <param name="configureServices">Optional service registrations to apply before the provider is built.</param>
+        /// <param name="includeMockerFallback">True to fall back to the current <see cref="Mocker" /> for unregistered class and interface resolutions.</param>
         /// <returns>A real service provider that resolves services by requested type.</returns>
         /// <example>
         /// <code language="csharp"><![CDATA[
@@ -22,13 +23,39 @@ namespace FastMoq.Extensions
         /// });
         /// ]]></code>
         /// </example>
-        public static IServiceProvider CreateTypedServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices = null)
+        public static IServiceProvider CreateTypedServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices = null, bool includeMockerFallback = false)
         {
             ArgumentNullException.ThrowIfNull(mocker);
 
             var services = new ServiceCollection();
             configureServices?.Invoke(services);
-            return services.BuildServiceProvider();
+            var serviceProvider = services.BuildServiceProvider();
+            if (!includeMockerFallback)
+            {
+                return serviceProvider;
+            }
+
+            return new MockerBackedServiceProvider(mocker, serviceProvider);
+        }
+
+        /// <summary>
+        /// Creates a typed <see cref="IServiceScope" /> from the supplied service registrations.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="configureServices">Optional service registrations to apply before the scope is built.</param>
+        /// <param name="includeMockerFallback">True to fall back to the current <see cref="Mocker" /> for unregistered class and interface resolutions.</param>
+        /// <returns>A real service scope whose <see cref="IServiceScope.ServiceProvider" /> resolves services by requested type.</returns>
+        public static IServiceScope CreateTypedServiceScope(this Mocker mocker, Action<IServiceCollection>? configureServices = null, bool includeMockerFallback = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            var serviceProvider = mocker.CreateTypedServiceProvider(configureServices, includeMockerFallback);
+            if (serviceProvider.GetService(typeof(IServiceScopeFactory)) is not IServiceScopeFactory scopeFactory)
+            {
+                throw new InvalidOperationException("The typed service provider did not expose an IServiceScopeFactory.");
+            }
+
+            return scopeFactory.CreateScope();
         }
 
         /// <summary>
@@ -59,17 +86,248 @@ namespace FastMoq.Extensions
         }
 
         /// <summary>
+        /// Registers a typed <see cref="IServiceScope" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="serviceScope">The scope to register.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddServiceScope(this Mocker mocker, IServiceScope serviceScope, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(serviceScope);
+
+            mocker.AddType<IServiceScope>(serviceScope, replace);
+            return mocker.AddServiceProvider(serviceScope.ServiceProvider, replace);
+        }
+
+        /// <summary>
         /// Builds and registers a typed <see cref="IServiceProvider" /> for the current <see cref="Mocker" /> instance.
         /// </summary>
         /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
         /// <param name="configureServices">Optional service registrations to apply before the provider is built.</param>
         /// <param name="replace">True to replace an existing registration.</param>
+        /// <param name="includeMockerFallback">True to fall back to the current <see cref="Mocker" /> for unregistered class and interface resolutions.</param>
         /// <returns>The current <see cref="Mocker" /> instance.</returns>
-        public static Mocker AddServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices, bool replace = false)
+        public static Mocker AddServiceProvider(this Mocker mocker, Action<IServiceCollection>? configureServices, bool replace = false, bool includeMockerFallback = false)
         {
             ArgumentNullException.ThrowIfNull(mocker);
 
-            return mocker.AddServiceProvider(mocker.CreateTypedServiceProvider(configureServices), replace);
+            return mocker.AddServiceProvider(mocker.CreateTypedServiceProvider(configureServices, includeMockerFallback), replace);
+        }
+
+        /// <summary>
+        /// Builds and registers a typed <see cref="IServiceScope" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="configureServices">Optional service registrations to apply before the scope is built.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <param name="includeMockerFallback">True to fall back to the current <see cref="Mocker" /> for unregistered class and interface resolutions.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddServiceScope(this Mocker mocker, Action<IServiceCollection>? configureServices, bool replace = false, bool includeMockerFallback = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            return mocker.AddServiceScope(mocker.CreateTypedServiceScope(configureServices, includeMockerFallback), replace);
+        }
+    }
+
+    internal sealed class MockerBackedServiceProvider : IServiceProvider, IServiceScopeFactory, IServiceProviderIsService, IDisposable, IAsyncDisposable
+    {
+        private readonly IServiceProviderIsService? _innerServiceProviderIsService;
+        private readonly Mocker _mocker;
+        private readonly ServiceProvider _serviceProvider;
+
+        public MockerBackedServiceProvider(Mocker mocker, ServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            _mocker = mocker;
+            _serviceProvider = serviceProvider;
+            _innerServiceProviderIsService = serviceProvider.GetService<IServiceProviderIsService>();
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            ArgumentNullException.ThrowIfNull(serviceType);
+
+            if (serviceType == typeof(IServiceProvider))
+            {
+                return this;
+            }
+
+            if (serviceType == typeof(IServiceScopeFactory))
+            {
+                return this;
+            }
+
+            if (serviceType == typeof(IServiceProviderIsService))
+            {
+                return this;
+            }
+
+            var resolved = _serviceProvider.GetService(serviceType);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+
+            return CanResolveFromMocker(serviceType)
+                ? _mocker.GetObject(serviceType)
+                : null;
+        }
+
+        public IServiceScope CreateScope()
+        {
+            var innerScope = _serviceProvider.CreateScope();
+            return new MockerBackedServiceScope(_mocker, innerScope, this);
+        }
+
+        public bool IsService(Type serviceType)
+        {
+            ArgumentNullException.ThrowIfNull(serviceType);
+
+            if (IsBuiltInService(serviceType))
+            {
+                return true;
+            }
+
+            if (_innerServiceProviderIsService?.IsService(serviceType) == true)
+            {
+                return true;
+            }
+
+            return _mocker.Contains(serviceType) || _mocker.HasTypeRegistration(serviceType) || CanResolveFromMocker(serviceType);
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return _serviceProvider.DisposeAsync();
+        }
+
+        private static bool CanResolveFromMocker(Type serviceType)
+        {
+            return serviceType.IsInterface || !serviceType.IsSealed && serviceType.IsClass;
+        }
+
+        private static bool IsBuiltInService(Type serviceType)
+        {
+            return serviceType == typeof(IServiceProvider) ||
+                   serviceType == typeof(IServiceScopeFactory) ||
+                   serviceType == typeof(IServiceProviderIsService);
+        }
+    }
+
+    internal sealed class MockerBackedServiceScope : IServiceScope, IAsyncDisposable
+    {
+        private readonly IServiceScope _innerScope;
+
+        public MockerBackedServiceScope(Mocker mocker, IServiceScope innerScope, IServiceScopeFactory scopeFactory)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(innerScope);
+            ArgumentNullException.ThrowIfNull(scopeFactory);
+
+            _innerScope = innerScope;
+            ServiceProvider = new MockerBackedScopedServiceProvider(mocker, innerScope.ServiceProvider, scopeFactory);
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public void Dispose()
+        {
+            _innerScope.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (_innerScope is IAsyncDisposable asyncDisposable)
+            {
+                return asyncDisposable.DisposeAsync();
+            }
+
+            _innerScope.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    internal sealed class MockerBackedScopedServiceProvider : IServiceProvider, IServiceProviderIsService
+    {
+        private readonly IServiceProviderIsService? _innerServiceProviderIsService;
+        private readonly Mocker _mocker;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        public MockerBackedScopedServiceProvider(Mocker mocker, IServiceProvider serviceProvider, IServiceScopeFactory scopeFactory)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+            ArgumentNullException.ThrowIfNull(scopeFactory);
+
+            _mocker = mocker;
+            _serviceProvider = serviceProvider;
+            _scopeFactory = scopeFactory;
+            _innerServiceProviderIsService = serviceProvider.GetService(typeof(IServiceProviderIsService)) as IServiceProviderIsService;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            ArgumentNullException.ThrowIfNull(serviceType);
+
+            if (serviceType == typeof(IServiceProvider))
+            {
+                return this;
+            }
+
+            if (serviceType == typeof(IServiceScopeFactory))
+            {
+                return _scopeFactory;
+            }
+
+            if (serviceType == typeof(IServiceProviderIsService))
+            {
+                return this;
+            }
+
+            var resolved = _serviceProvider.GetService(serviceType);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+
+            return CanResolveFromMocker(serviceType)
+                ? _mocker.GetObject(serviceType)
+                : null;
+        }
+
+        public bool IsService(Type serviceType)
+        {
+            ArgumentNullException.ThrowIfNull(serviceType);
+
+            if (serviceType == typeof(IServiceProvider) ||
+                serviceType == typeof(IServiceScopeFactory) ||
+                serviceType == typeof(IServiceProviderIsService))
+            {
+                return true;
+            }
+
+            if (_innerServiceProviderIsService?.IsService(serviceType) == true)
+            {
+                return true;
+            }
+
+            return _mocker.Contains(serviceType) || _mocker.HasTypeRegistration(serviceType) || CanResolveFromMocker(serviceType);
+        }
+
+        private static bool CanResolveFromMocker(Type serviceType)
+        {
+            return serviceType.IsInterface || !serviceType.IsSealed && serviceType.IsClass;
         }
     }
 }

--- a/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
+++ b/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
@@ -111,6 +111,31 @@ namespace FastMoq.Extensions
         }
 
         /// <summary>
+        /// Registers a fixed <see cref="IServiceScope" /> backed by the supplied <see cref="IServiceProvider" /> for the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="serviceProvider">The provider to expose through the registered scope.</param>
+        /// <param name="replace">True to replace an existing registration.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker AddServiceScope(this Mocker mocker, IServiceProvider serviceProvider, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            var serviceScope = new FixedServiceScope(serviceProvider);
+            mocker.AddType<IServiceProvider>(serviceProvider, replace);
+            mocker.AddType<IServiceScope>(serviceScope, replace);
+            mocker.AddType<IServiceScopeFactory>(new FixedServiceScopeFactory(serviceScope), replace);
+
+            if (serviceProvider.GetService(typeof(IServiceProviderIsService)) is IServiceProviderIsService serviceProviderIsService)
+            {
+                mocker.AddType<IServiceProviderIsService>(serviceProviderIsService, replace);
+            }
+
+            return mocker;
+        }
+
+        /// <summary>
         /// Builds and registers a typed <see cref="IServiceProvider" /> for the current <see cref="Mocker" /> instance.
         /// </summary>
         /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
@@ -238,6 +263,44 @@ namespace FastMoq.Extensions
                     ownedDisposable.Dispose();
                 }
             }
+        }
+    }
+
+    internal sealed class FixedServiceScope : IServiceScope, IAsyncDisposable
+    {
+        public FixedServiceScope(IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            ServiceProvider = serviceProvider;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    internal sealed class FixedServiceScopeFactory : IServiceScopeFactory
+    {
+        private readonly IServiceScope _scope;
+
+        public FixedServiceScopeFactory(IServiceScope scope)
+        {
+            ArgumentNullException.ThrowIfNull(scope);
+
+            _scope = scope;
+        }
+
+        public IServiceScope CreateScope()
+        {
+            return _scope;
         }
     }
 

--- a/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
+++ b/FastMoq.Core/Extensions/ServiceProviderTestExtensions.cs
@@ -52,10 +52,19 @@ namespace FastMoq.Extensions
             var serviceProvider = mocker.CreateTypedServiceProvider(configureServices, includeMockerFallback);
             if (serviceProvider.GetService(typeof(IServiceScopeFactory)) is not IServiceScopeFactory scopeFactory)
             {
+                DisposeCreatedRegistration(serviceProvider);
                 throw new InvalidOperationException("The typed service provider did not expose an IServiceScopeFactory.");
             }
 
-            return scopeFactory.CreateScope();
+            try
+            {
+                return new OwnedServiceScope(scopeFactory.CreateScope(), serviceProvider);
+            }
+            catch
+            {
+                DisposeCreatedRegistration(serviceProvider);
+                throw;
+            }
         }
 
         /// <summary>
@@ -113,7 +122,18 @@ namespace FastMoq.Extensions
         {
             ArgumentNullException.ThrowIfNull(mocker);
 
-            return mocker.AddServiceProvider(mocker.CreateTypedServiceProvider(configureServices, includeMockerFallback), replace);
+            var serviceProvider = mocker.CreateTypedServiceProvider(configureServices, includeMockerFallback);
+            try
+            {
+                mocker.AddServiceProvider(serviceProvider, replace);
+                mocker.TrackOwnedRegistration(serviceProvider);
+                return mocker;
+            }
+            catch
+            {
+                DisposeCreatedRegistration(serviceProvider);
+                throw;
+            }
         }
 
         /// <summary>
@@ -128,7 +148,96 @@ namespace FastMoq.Extensions
         {
             ArgumentNullException.ThrowIfNull(mocker);
 
-            return mocker.AddServiceScope(mocker.CreateTypedServiceScope(configureServices, includeMockerFallback), replace);
+            var serviceScope = mocker.CreateTypedServiceScope(configureServices, includeMockerFallback);
+            try
+            {
+                mocker.AddServiceScope(serviceScope, replace);
+                mocker.TrackOwnedRegistration(serviceScope);
+                return mocker;
+            }
+            catch
+            {
+                DisposeCreatedRegistration(serviceScope);
+                throw;
+            }
+        }
+
+        private static void DisposeCreatedRegistration(object createdRegistration)
+        {
+            ArgumentNullException.ThrowIfNull(createdRegistration);
+
+            if (createdRegistration is IDisposable disposable)
+            {
+                disposable.Dispose();
+                return;
+            }
+
+            if (createdRegistration is IAsyncDisposable asyncDisposable)
+            {
+                asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+    }
+
+    internal sealed class OwnedServiceScope : IServiceScope, IAsyncDisposable
+    {
+        private readonly object _owner;
+        private readonly IServiceScope _scope;
+
+        public OwnedServiceScope(IServiceScope scope, object owner)
+        {
+            ArgumentNullException.ThrowIfNull(scope);
+            ArgumentNullException.ThrowIfNull(owner);
+
+            _scope = scope;
+            _owner = owner;
+        }
+
+        public IServiceProvider ServiceProvider => _scope.ServiceProvider;
+
+        public void Dispose()
+        {
+            try
+            {
+                _scope.Dispose();
+            }
+            finally
+            {
+                if (_owner is IDisposable ownedDisposable)
+                {
+                    ownedDisposable.Dispose();
+                }
+                else if (_owner is IAsyncDisposable ownedAsyncDisposable)
+                {
+                    ownedAsyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                if (_scope is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    _scope.Dispose();
+                }
+            }
+            finally
+            {
+                if (_owner is IAsyncDisposable ownedAsyncDisposable)
+                {
+                    await ownedAsyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else if (_owner is IDisposable ownedDisposable)
+                {
+                    ownedDisposable.Dispose();
+                }
+            }
         }
     }
 

--- a/FastMoq.Core/Mocker.Disposal.cs
+++ b/FastMoq.Core/Mocker.Disposal.cs
@@ -1,0 +1,116 @@
+namespace FastMoq
+{
+    /// <summary>
+    /// Adds disposal support for helper-owned registrations created by a <see cref="Mocker" /> instance.
+    /// </summary>
+    public partial class Mocker
+    {
+        private readonly List<object> _ownedRegistrations = [];
+
+        private bool _disposed;
+
+        internal void TrackOwnedRegistration(object ownedRegistration)
+        {
+            ArgumentNullException.ThrowIfNull(ownedRegistration);
+
+            _ownedRegistrations.Add(ownedRegistration);
+        }
+
+        /// <summary>
+        /// Releases helper-owned disposable registrations created by this <see cref="Mocker" /> instance.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Asynchronously releases helper-owned disposable registrations created by this <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <returns>A task that completes when owned registrations are disposed.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases managed resources owned by this <see cref="Mocker" /> instance.
+        /// Derived types overriding this method should call the base implementation.
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> when called from <see cref="Dispose()" />; otherwise, <see langword="false" />.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                foreach (var ownedRegistration in Enumerable.Reverse(_ownedRegistrations))
+                {
+                    DisposeOwnedRegistration(ownedRegistration);
+                }
+
+                _ownedRegistrations.Clear();
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Asynchronously releases resources owned by this <see cref="Mocker" /> instance.
+        /// Derived types overriding this method should call the base implementation.
+        /// </summary>
+        /// <returns>A task that completes when asynchronous cleanup has finished.</returns>
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            foreach (var ownedRegistration in Enumerable.Reverse(_ownedRegistrations))
+            {
+                await DisposeOwnedRegistrationAsync(ownedRegistration).ConfigureAwait(false);
+            }
+
+            _ownedRegistrations.Clear();
+            _disposed = true;
+        }
+
+        private static void DisposeOwnedRegistration(object ownedRegistration)
+        {
+            ArgumentNullException.ThrowIfNull(ownedRegistration);
+
+            if (ownedRegistration is IDisposable disposable)
+            {
+                disposable.Dispose();
+                return;
+            }
+
+            if (ownedRegistration is IAsyncDisposable asyncDisposable)
+            {
+                asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        private static async ValueTask DisposeOwnedRegistrationAsync(object ownedRegistration)
+        {
+            ArgumentNullException.ThrowIfNull(ownedRegistration);
+
+            if (ownedRegistration is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            if (ownedRegistration is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -59,7 +59,7 @@ namespace FastMoq
     /// resolvedFileSystem.Should().BeSameAs(fileSystem);
     /// ]]></code>
     /// </example>
-    public partial class Mocker
+    public partial class Mocker : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Name of the legacy Moq setup-all-properties method used by compatibility helpers.

--- a/FastMoq.Core/MockerTestBase.cs
+++ b/FastMoq.Core/MockerTestBase.cs
@@ -225,7 +225,7 @@ namespace FastMoq
             {
                 if (disposing)
                 {
-                    // Dispose managed state (managed objects)
+                    Mocks.Dispose();
                 }
 
                 // Free unmanaged resources (unmanaged objects) and override finalizer

--- a/FastMoq.TestingExample/RealWorldExampleServices.cs
+++ b/FastMoq.TestingExample/RealWorldExampleServices.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
@@ -128,6 +129,27 @@ namespace FastMoq.TestingExample
 
             _submissionChannel.Mode = expedited ? "fast" : "standard";
             await _submissionChannel.SubmitAsync(orderId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public sealed class ScopedWidgetContext
+    {
+        public Guid ScopeId { get; } = Guid.NewGuid();
+    }
+
+    public sealed class WidgetScopeRunner
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public WidgetScopeRunner(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Guid RunScope()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            return scope.ServiceProvider.GetRequiredService<ScopedWidgetContext>().ScopeId;
         }
     }
 

--- a/FastMoq.TestingExample/RealWorldExampleTests.cs
+++ b/FastMoq.TestingExample/RealWorldExampleTests.cs
@@ -2,6 +2,7 @@ using FastMoq.Extensions;
 using FastMoq.Providers;
 using FastMoq.Providers.MoqProvider;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
@@ -89,6 +90,23 @@ namespace FastMoq.TestingExample
     public class OrderSubmissionServiceExamples : MockerTestBase<OrderSubmissionService>
     {
         [Fact]
+        public async Task SubmitAsync_ShouldPreserveAssignedMode_WithAddPropertyState()
+        {
+            var submissionChannel = Mocks.GetOrCreateMock<IOrderSubmissionChannel>();
+            submissionChannel
+                .Setup(x => x.SubmitAsync("order-42", CancellationToken.None))
+                .Returns(Task.CompletedTask);
+
+            var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>();
+            CreateComponent();
+
+            await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+
+            channel.Mode.Should().Be("fast");
+            Mocks.Verify<IOrderSubmissionChannel>(x => x.SubmitAsync("order-42", CancellationToken.None), TimesSpec.Once);
+        }
+
+        [Fact]
         public async Task SubmitAsync_ShouldCaptureAssignedMode_WithAddPropertySetterCapture()
         {
             var submissionChannel = Mocks.GetOrCreateMock<IOrderSubmissionChannel>();
@@ -103,6 +121,23 @@ namespace FastMoq.TestingExample
 
             modeCapture.Value.Should().Be("fast");
             Mocks.Verify<IOrderSubmissionChannel>(x => x.SubmitAsync("order-42", CancellationToken.None), TimesSpec.Once);
+        }
+    }
+
+    public class WidgetScopeRunnerExamples : MockerTestBase<WidgetScopeRunner>
+    {
+        [Fact]
+        public void RunScope_ShouldResolveScopedGraph_WithTypedServiceProviderHelper()
+        {
+            Mocks.AddServiceProvider(services => services.AddScoped<ScopedWidgetContext>(), replace: true, includeMockerFallback: true);
+            CreateComponent();
+
+            var first = Component.RunScope();
+            var second = Component.RunScope();
+
+            first.Should().NotBe(Guid.Empty);
+            second.Should().NotBe(Guid.Empty);
+            first.Should().NotBe(second);
         }
     }
 

--- a/FastMoq.Tests/MockerDisposalTests.cs
+++ b/FastMoq.Tests/MockerDisposalTests.cs
@@ -1,0 +1,52 @@
+using System.Threading.Tasks;
+
+namespace FastMoq.Tests
+{
+    public class MockerDisposalTests
+    {
+        [Fact]
+        public void Dispose_ShouldInvokeVirtualDisposeHook()
+        {
+            var mocker = new DisposalProbeMocker();
+
+            mocker.Dispose();
+
+            mocker.DisposeCallCount.Should().Be(1);
+            mocker.LastDisposeDisposing.Should().BeTrue();
+            mocker.DisposeAsyncCoreCallCount.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_ShouldInvokeVirtualDisposeAsyncHook()
+        {
+            var mocker = new DisposalProbeMocker();
+
+            await mocker.DisposeAsync();
+
+            mocker.DisposeAsyncCoreCallCount.Should().Be(1);
+            mocker.DisposeCallCount.Should().Be(0);
+        }
+
+        private sealed class DisposalProbeMocker : Mocker
+        {
+            public int DisposeCallCount { get; private set; }
+
+            public int DisposeAsyncCoreCallCount { get; private set; }
+
+            public bool? LastDisposeDisposing { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCallCount++;
+                LastDisposeDisposing = disposing;
+                base.Dispose(disposing);
+            }
+
+            protected override async ValueTask DisposeAsyncCore()
+            {
+                DisposeAsyncCoreCallCount++;
+                await base.DisposeAsyncCore().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/FastMoq.Tests/PropertySetterCaptureTests.cs
+++ b/FastMoq.Tests/PropertySetterCaptureTests.cs
@@ -10,6 +10,24 @@ namespace FastMoq.Tests
         [Theory]
         [InlineData("moq")]
         [InlineData("nsubstitute")]
+        public void AddPropertyState_ShouldPreserveAssignments_AndForwardOtherMembers(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            _ = mocker.GetOrCreateMock<IPropertySetterCaptureGateway>();
+            var gateway = mocker.AddPropertyState<IPropertySetterCaptureGateway>();
+
+            gateway.Mode = "fast";
+            gateway.Publish("alpha");
+
+            gateway.Mode.Should().Be("fast");
+            mocker.Verify<IPropertySetterCaptureGateway>(x => x.Publish("alpha"), TimesSpec.Once);
+        }
+
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
         public void AddPropertySetterCapture_ShouldCaptureAssignments_AndForwardOtherMembers(string providerName)
         {
             using var providerScope = MockingProviderRegistry.Push(providerName);
@@ -70,6 +88,30 @@ namespace FastMoq.Tests
             testBase.VerifyPublished("alpha");
         }
 
+        [Fact]
+        public void AddPropertyState_ShouldRejectNonInterfaceTypes()
+        {
+            var mocker = new Mocker();
+
+            Action action = () => mocker.AddPropertyState<PropertySetterCaptureConcreteTarget>();
+
+            action.Should().Throw<NotSupportedException>()
+                .WithMessage("*interface types only*");
+        }
+
+        [Fact]
+        public void AddPropertyState_ShouldSupportMockerTestBase_WhenComponentIsRecreated()
+        {
+            using var testBase = new PropertySetterCaptureComponentTestBase();
+
+            var gateway = testBase.AddModeState();
+
+            testBase.Submit("alpha", expedited: true);
+
+            gateway.Mode.Should().Be("fast");
+            testBase.VerifyPublished("alpha");
+        }
+
         public interface IPropertySetterCaptureGateway
         {
             string? Mode { get; set; }
@@ -116,6 +158,13 @@ namespace FastMoq.Tests
 
         private sealed class PropertySetterCaptureComponentTestBase : MockerTestBase<PropertySetterCaptureComponent>
         {
+            public IPropertySetterCaptureGateway AddModeState()
+            {
+                var gateway = Mocks.AddPropertyState<IPropertySetterCaptureGateway>();
+                CreateComponent();
+                return gateway;
+            }
+
             public PropertyValueCapture<string?> AddModeCapture()
             {
                 var capture = Mocks.AddPropertySetterCapture<IPropertySetterCaptureGateway, string?>(x => x.Mode);

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -106,6 +106,20 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void CreateTypedServiceScope_ShouldDisposeOwnedRootProvider_WhenScopeIsDisposed()
+        {
+            var mocker = new Mocker();
+            DisposableProbe? probe;
+
+            var scope = mocker.CreateTypedServiceScope(services => services.AddSingleton<DisposableProbe>());
+            probe = scope.ServiceProvider.GetRequiredService<DisposableProbe>();
+
+            scope.Dispose();
+
+            probe.IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
         public void AddServiceProvider_ShouldRegisterTypedProviderAndScopeFactory()
         {
             var mocker = new Mocker();
@@ -129,6 +143,48 @@ namespace FastMoq.Tests
             mocker.GetObject<IServiceScope>().Should().BeSameAs(scope);
             mocker.GetObject<IServiceProvider>().Should().BeSameAs(scope.ServiceProvider);
             mocker.GetObject<IServiceProvider>()!.GetRequiredService<ScopedProbe>().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddServiceProvider_ShouldDisposeOwnedProvider_WhenMockerIsDisposed()
+        {
+            DisposableProbe? probe;
+
+            using (var mocker = new Mocker())
+            {
+                mocker.AddServiceProvider(services => services.AddSingleton<DisposableProbe>(), replace: true);
+                probe = mocker.GetObject<IServiceProvider>()!.GetRequiredService<DisposableProbe>();
+            }
+
+            probe!.IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddServiceScope_ShouldDisposeOwnedScope_WhenMockerIsDisposed()
+        {
+            DisposableProbe? probe;
+
+            using (var mocker = new Mocker())
+            {
+                mocker.AddServiceScope(services => services.AddSingleton<DisposableProbe>(), replace: true);
+                probe = mocker.GetObject<IServiceProvider>()!.GetRequiredService<DisposableProbe>();
+            }
+
+            probe!.IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task AddServiceProvider_ShouldDisposeOwnedProvider_WhenMockerIsDisposedAsync()
+        {
+            DisposableProbe? probe;
+
+            var mocker = new Mocker();
+            mocker.AddServiceProvider(services => services.AddSingleton<DisposableProbe>(), replace: true);
+            probe = mocker.GetObject<IServiceProvider>()!.GetRequiredService<DisposableProbe>();
+
+            await mocker.DisposeAsync();
+
+            probe!.IsDisposed.Should().BeTrue();
         }
 
         [Fact]
@@ -534,6 +590,16 @@ namespace FastMoq.Tests
         private sealed class ScopedProbe
         {
             public Guid Id { get; } = Guid.NewGuid();
+        }
+
+        private sealed class DisposableProbe : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
         }
 
         private sealed class SampleOptions

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -36,6 +36,76 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void CreateTypedServiceProvider_ShouldFallbackToMockerResolution_WhenEnabled()
+        {
+            var mocker = new Mocker();
+            mocker.SetupOptions(new SampleOptions
+            {
+                Name = "fallback",
+                RetryCount = 7,
+            });
+
+            var provider = mocker.CreateTypedServiceProvider(includeMockerFallback: true);
+            var options = provider.GetService(typeof(IOptions<SampleOptions>)) as IOptions<SampleOptions>;
+
+            options.Should().NotBeNull();
+            options!.Value.Name.Should().Be("fallback");
+            options.Value.RetryCount.Should().Be(7);
+        }
+
+        [Fact]
+        public void CreateTypedServiceProvider_ShouldResolveExplicitSealedRegistrations_WhenFallbackIsEnabled()
+        {
+            var mocker = new Mocker();
+            var expectedUri = new Uri("https://fallback.fastmoq/");
+            mocker.AddType(expectedUri, replace: true);
+
+            var provider = mocker.CreateTypedServiceProvider(includeMockerFallback: true);
+
+            provider.GetService(typeof(Uri)).Should().BeSameAs(expectedUri);
+        }
+
+        [Fact]
+        public void CreateTypedServiceProvider_ShouldReturnNull_ForUnknownValueTypeServices_WhenFallbackIsEnabled()
+        {
+            var mocker = new Mocker();
+            var provider = mocker.CreateTypedServiceProvider(includeMockerFallback: true);
+
+            provider.GetService(typeof(int)).Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateTypedServiceScope_ShouldResolveScopedServicesByType()
+        {
+            var mocker = new Mocker();
+
+            using var scope = mocker.CreateTypedServiceScope(services => services.AddScoped<ScopedProbe>());
+
+            var first = scope.ServiceProvider.GetRequiredService<ScopedProbe>();
+            var second = scope.ServiceProvider.GetRequiredService<ScopedProbe>();
+
+            first.Should().BeSameAs(second);
+        }
+
+        [Fact]
+        public void CreateTypedServiceScope_ShouldFallbackToMockerResolution_WhenEnabled()
+        {
+            var mocker = new Mocker();
+            mocker.SetupOptions(new SampleOptions
+            {
+                Name = "scoped-fallback",
+                RetryCount = 3,
+            });
+
+            using var scope = mocker.CreateTypedServiceScope(includeMockerFallback: true);
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptions<SampleOptions>>();
+
+            options.Value.Name.Should().Be("scoped-fallback");
+            options.Value.RetryCount.Should().Be(3);
+        }
+
+        [Fact]
         public void AddServiceProvider_ShouldRegisterTypedProviderAndScopeFactory()
         {
             var mocker = new Mocker();
@@ -46,6 +116,19 @@ namespace FastMoq.Tests
             mocker.GetObject<IServiceProvider>().Should().BeSameAs(provider);
             mocker.GetObject<IServiceScopeFactory>().Should().NotBeNull();
             mocker.GetObject<IServiceProviderIsService>().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddServiceScope_ShouldRegisterTypedScopeAndScopeOwnedProvider()
+        {
+            var mocker = new Mocker();
+            using var scope = mocker.CreateTypedServiceScope(services => services.AddScoped<ScopedProbe>());
+
+            mocker.AddServiceScope(scope);
+
+            mocker.GetObject<IServiceScope>().Should().BeSameAs(scope);
+            mocker.GetObject<IServiceProvider>().Should().BeSameAs(scope.ServiceProvider);
+            mocker.GetObject<IServiceProvider>()!.GetRequiredService<ScopedProbe>().Should().NotBeNull();
         }
 
         [Fact]
@@ -446,6 +529,11 @@ namespace FastMoq.Tests
             public int Count { get; set; }
 
             public string? Name { get; set; }
+        }
+
+        private sealed class ScopedProbe
+        {
+            public Guid Id { get; } = Guid.NewGuid();
         }
 
         private sealed class SampleOptions

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -146,6 +146,24 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void AddServiceScope_ShouldRegisterProviderBackedScopeAndFixedScopeFactory()
+        {
+            var mocker = new Mocker();
+            var provider = mocker.CreateTypedServiceProvider(services => services.AddScoped<ScopedProbe>());
+
+            mocker.AddServiceScope(provider, replace: true);
+
+            var scope = mocker.GetObject<IServiceScope>();
+            var scopeFactory = mocker.GetObject<IServiceScopeFactory>();
+
+            scope.Should().NotBeNull();
+            scope!.ServiceProvider.Should().BeSameAs(provider);
+            scopeFactory.Should().NotBeNull();
+            scopeFactory!.CreateScope().Should().BeSameAs(scope);
+            mocker.GetObject<IServiceProvider>().Should().BeSameAs(provider);
+        }
+
+        [Fact]
         public void AddServiceProvider_ShouldDisposeOwnedProvider_WhenMockerIsDisposed()
         {
             DisposableProbe? probe;

--- a/docs/getting-started/provider-capabilities.md
+++ b/docs/getting-started/provider-capabilities.md
@@ -59,7 +59,7 @@ When that happens, use this rule:
 | `Protected()` for `HttpMessageHandler` | Prefer `WhenHttpRequest(...)` or `WhenHttpRequestJson(...)` for HTTP behavior. | When the test really depends on direct protected-member interception rather than request/response behavior. |
 | `Protected()` for arbitrary protected members | Prefer testing through a public seam, extracted collaborator, or concrete fake. | When the implementation cannot reasonably be reshaped and protected-member interception is the behavior under test. |
 | `SetupSet(...)` | For simple interface-property cases, prefer `AddPropertySetterCapture<TService, TValue>(...)`. For broader collaborator behavior, prefer a fake or stub registered with `AddType(...)` that captures assigned values, usually with `PropertyValueCapture<TValue>`, or verify the observable downstream behavior instead of the setter interception itself. | When the setter interception is the important behavior and introducing a helper-backed replacement or fake would create more churn than value. |
-| `SetupAllProperties()` | Prefer a concrete fake or lightweight test double with real property state. For ordinary collaborator behavior, use `AddType(...)` or a purpose-built fake instead of expecting provider-managed property backing. | When you specifically want mocking-library-managed property backing without creating a custom fake. |
+| `SetupAllProperties()` | For simple interface-property state, prefer `AddPropertyState<TService>(...)`. For broader collaborator behavior or class targets, prefer a concrete fake or lightweight test double with real property state via `AddType(...)`. | When you specifically want mocking-library-managed property backing without creating a custom fake. |
 | `CallBase` / partial mock behavior | Prefer a real instance or `AddType(...)` factory for the concrete collaborator. | When the test intentionally relies on partial mocking rather than a real implementation or fake. |
 | `out` / `ref` verification with `It.Ref<T>.IsAny` | Prefer wrapping the dependency behind a simpler interface, or assert on the public result / side effect instead of the raw `out` / `ref` interaction. | When the API shape is fixed and the `out` / `ref` interaction itself is important to the test. |
 
@@ -141,6 +141,19 @@ modeCapture.Value.Should().Be("fast");
 
 When the component under test comes from `MockerTestBase<TComponent>`, call `CreateComponent()` after adding the capture unless you registered it in the test base setup path before component creation.
 
+For simple `SetupAllProperties()` cases on interface collaborators, the preferred first-party answer is `AddPropertyState<TService>(...)`:
+
+```csharp
+var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>();
+CreateComponent();
+
+await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+
+channel.Mode.Should().Be("fast");
+```
+
+That keeps the important part of the test explicit: the collaborator needs real property state, not Moq-specific property plumbing.
+
 If the collaborator needs more behavior than one captured property, or the target is not an interface, fall back to a fake plus [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1):
 
 ```csharp
@@ -218,7 +231,7 @@ Quick Moq-to-NSubstitute translation rules:
 - `SetupSequence(...)` becomes `Returns(value1, value2, ...)`
 - `SetupGet(...)` becomes a direct property `Returns(...)`
 
-If a migrated test still needs `SetupSet(...)`, `Protected()`, `SetupAllProperties()`, or `CallBase`, that test should usually stay on Moq or move to a fake rather than trying to force an NSubstitute equivalent. `PropertyValueCapture<TValue>` is the default FastMoq answer when the test only needs to observe property assignments rather than exercise Moq itself.
+If a migrated test still needs `Protected()` or `CallBase`, that test should usually stay on Moq or move to a fake rather than trying to force an NSubstitute equivalent. For simple interface-property cases, prefer `AddPropertySetterCapture<TService, TValue>(...)` or `AddPropertyState<TService>(...)` before keeping `SetupSet(...)` or `SetupAllProperties()` purely for habit. `PropertyValueCapture<TValue>` remains the default FastMoq answer when the test only needs to observe property assignments rather than exercise Moq itself.
 
 Repo-backed references:
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -11,7 +11,7 @@ Use these rules first:
 3. Use [Mocks.GetOrCreateMock&lt;T&gt;()](xref:FastMoq.Mocker.GetOrCreateMock``1(FastMoq.MockRequestOptions)) when you want the normal FastMoq tracked mock path for a dependency.
 4. Use [AddType(...)](xref:FastMoq.Mocker.AddType``1(System.Func{FastMoq.Mocker,``0},System.Boolean,System.Object[])) when you need to replace FastMoq's default resolution with a specific concrete type, factory, or fixed instance.
 5. Use `CreateInstanceByType(...)` when direct `Mocker` usage must pick an exact constructor signature. Do not treat `GetObject<T>()` as the explicit constructor-selection API.
-6. Use `CreateTypedServiceProvider(...)` and `AddServiceProvider(...)` when framework code expects a typed `IServiceProvider` rather than a one-object-for-all-types shim.
+6. Use `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, and `AddServiceScope(...)` when framework code expects typed service-provider or service-scope behavior rather than a one-object-for-all-types shim.
 7. If the constructor uses the same abstraction more than once under different DI service keys, use keyed mocks, keyed registrations, or explicit constructor injection for tests where dependency selection matters.
 8. Use [AddKnownType(...)](xref:FastMoq.Mocker.AddKnownType(FastMoq.KnownTypeRegistration,System.Boolean)) when a framework-style type needs special resolution or post-processing behavior.
 9. Use [GetMockDbContext&lt;TContext&gt;()](xref:FastMoq.DbContextMockerExtensions.GetMockDbContext``1(FastMoq.Mocker)) when testing EF Core contexts. Do not hand-roll DbContext setup unless you need behavior outside FastMoq's helper.
@@ -75,6 +75,14 @@ var instanceServices = Mocks.CreateTypedServiceProvider(services =>
 });
 ```
 
+If framework-owned resolution should fall back to the current `Mocker` for unregistered collaborators, opt in explicitly:
+
+```csharp
+var instanceServices = Mocks.CreateTypedServiceProvider(
+    services => services.AddLogging(),
+    includeMockerFallback: true);
+```
+
 Use `AddServiceProvider(...)` when the system under test resolves `IServiceProvider` or `IServiceScopeFactory` from the current [Mocker](xref:FastMoq.Mocker):
 
 ```csharp
@@ -86,6 +94,28 @@ Mocks.AddServiceProvider(services =>
 ```
 
 `AddServiceProvider(...)` registers the typed provider itself and, when the built container exposes them, also registers `IServiceScopeFactory` and `IServiceProviderIsService` for the current `Mocker`.
+
+Use `CreateTypedServiceScope(...)` when the test needs an actual scope instance or wants to verify scoped lifetimes directly:
+
+```csharp
+using var scope = Mocks.CreateTypedServiceScope(services =>
+{
+    services.AddScoped<ScopedWidgetContext>();
+});
+
+var scopedService = scope.ServiceProvider.GetRequiredService<ScopedWidgetContext>();
+```
+
+Use `AddServiceScope(...)` when the current `Mocker` should expose a scope and its scope-owned provider:
+
+```csharp
+using var scope = Mocks.CreateTypedServiceScope(services =>
+{
+    services.AddScoped<ScopedWidgetContext>();
+});
+
+Mocks.AddServiceScope(scope, replace: true);
+```
 
 If a constructor takes `IServiceScopeFactory`, prefer this shape:
 
@@ -105,6 +135,8 @@ var scopeFactory = Mocks.GetRequiredObject<IServiceScopeFactory>();
 ```
 
 instead of building a provider manually and registering only `provider.GetRequiredService<IServiceScopeFactory>()`. Keeping the full typed provider registered makes constructor injection, nested framework resolution, and service-scope behavior stay aligned.
+
+When framework code should resolve a mix of real DI registrations and normal FastMoq collaborators, use `includeMockerFallback: true` on `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, or `AddServiceScope(...)`.
 
 For Azure-oriented tests that also need configuration defaults, prefer `CreateAzureServiceProvider(...)` or `AddAzureServiceProvider(...)` from `FastMoq.Azure.DependencyInjection` instead of repeating `AddLogging()`, `AddOptions()`, and `IConfiguration` setup in every test.
 
@@ -145,12 +177,13 @@ Use `ReadBodyAsStringAsync(...)` and `ReadBodyAsJsonAsync<T>(...)` when you want
 Package note:
 
 - `CreateTypedServiceProvider(...)` and `AddServiceProvider(...)` remain part of `FastMoq.Core`
+- `CreateTypedServiceScope(...)` and `AddServiceScope(...)` remain part of `FastMoq.Core`
 - direct `FastMoq.Core` consumers should add `FastMoq.AzureFunctions` and import `FastMoq.AzureFunctions.Extensions` before using `CreateFunctionContextInstanceServices(...)`, `AddFunctionContextInstanceServices(...)`, `CreateHttpRequestData(...)`, or `CreateHttpResponseData(...)`
 - the aggregate `FastMoq` package includes the Azure Functions helper package already
 
 Analyzer note:
 
-- `FMOQ0013` warns on direct `GetOrCreateMock<IServiceProvider>()`, `GetMock<IServiceProvider>()`, and `GetRequiredMock<IServiceProvider>()` setup so those shims migrate toward the typed helper path.
+- `FMOQ0013` warns on direct `GetOrCreateMock<IServiceProvider>()`, `GetMock<IServiceProvider>()`, `GetRequiredMock<IServiceProvider>()`, `IServiceScopeFactory` or `IServiceScope` shims, and manual scope-factory extraction so those patterns migrate toward the typed helper path.
 
 ## Construction APIs
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -117,6 +117,19 @@ using var scope = Mocks.CreateTypedServiceScope(services =>
 Mocks.AddServiceScope(scope, replace: true);
 ```
 
+If a helper already has a real provider and only needs a fixed scope plus a matching scope factory, use the provider-backed overload:
+
+```csharp
+var provider = Mocks.CreateTypedServiceProvider(services =>
+{
+    services.AddScoped<ScopedWidgetContext>();
+});
+
+Mocks.AddServiceScope(provider, replace: true);
+```
+
+That overload exposes the supplied `IServiceProvider`, a fixed `IServiceScope`, and an `IServiceScopeFactory` that returns that registered scope, which maps well to older `scope.SetupGet(x => x.ServiceProvider)` and `scopeFactory.Setup(x => x.CreateScope())` shim patterns.
+
 If a constructor takes `IServiceScopeFactory`, prefer this shape:
 
 ```csharp

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -766,7 +766,7 @@ For practical fallback patterns when you do not want to stay on Moq, see [Provid
 
 ### `IMemoryCache` and `ICacheEntry`
 
-Property-setter and cache-entry tests are still a common Moq-only pocket because they often rely on `SetupSet(...)` or `SetupAllProperties()`.
+Property-setter and cache-entry tests are still a common Moq-only pocket because they often rely on `SetupSet(...)` or `SetupAllProperties()`. For ordinary interface collaborators, FastMoq now has first-party answers in `AddPropertySetterCapture<TService, TValue>(...)` and `AddPropertyState<TService>(...)`, but `ICacheEntry` tests often still need the broader Moq shape.
 
 ```csharp
 var cacheEntry = Mocks.GetMock<ICacheEntry>();
@@ -852,7 +852,18 @@ cacheEntry.SetupAllProperties();
 cacheEntry.SetupSet(x => x.Value = It.IsAny<object>());
 ```
 
-That is still a valid v4 migration outcome because the test depends on Moq-only setter behavior.
+That is still a valid v4 migration outcome because the test depends on broader Moq-only cache-entry behavior.
+
+For simpler interface collaborators where the real need is property state rather than cache-entry semantics, prefer the first-party helper instead:
+
+```csharp
+var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>();
+CreateComponent();
+
+await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+
+channel.Mode.Should().Be("fast");
+```
 
 ### Known-type extensibility
 

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -102,7 +102,7 @@ That migration is usually the highest-leverage cleanup in suites that centralize
 
 Analyzer note:
 
-- `FMOQ0013` warns on direct FastMoq `IServiceProvider` mock setup so those helpers move toward `CreateTypedServiceProvider(...)` or `AddServiceProvider(...)`.
+- `FMOQ0013` warns on direct FastMoq `IServiceProvider`, `IServiceScopeFactory`, and `IServiceScope` shim setup, plus manual scope-factory extraction, so those helpers move toward `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, or `AddServiceScope(...)`.
 
 If the same helper layer also hand-rolls `IOptions<T>` setup, move that boilerplate at the same time:
 

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -70,7 +70,7 @@ Analyzer note:
 - `FMOQ0013` warns on direct `FunctionContext.InstanceServices` mocking more broadly across `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` so those shims move toward the typed helper path
 - the built-in code fix is narrower: it only appears when `FastMoq.AzureFunctions` is already referenced, and it rewrites the safe tracked-provider cases `Setup(x => x.InstanceServices).Returns(provider)`, `SetupGet(x => x.InstanceServices).Returns(provider)`, and `SetupProperty(x => x.InstanceServices, provider)` to `context.AddFunctionContextInstanceServices(provider)` and adds `using FastMoq.AzureFunctions.Extensions;` when needed
 - `SetupSet(...)` is not part of this analyzer. When the real need is provider-neutral setter observation rather than Moq setter interception, prefer a fake or stub with [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1)
-- broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph, but the built-in `FMOQ0013` fix now also handles the direct tracked-shim cases `GetOrCreateMock<IServiceProvider>()`, `GetOrCreateMock<IServiceScopeFactory>()`, `GetOrCreateMock<IServiceScope>()`, and manual scope-factory extraction such as `AddType<IServiceScopeFactory>(provider.GetRequiredService<IServiceScopeFactory>())`
+- broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph, but the built-in `FMOQ0013` fix now also handles the direct tracked-shim cases `GetOrCreateMock<IServiceProvider>()`, `GetOrCreateMock<IServiceScopeFactory>()`, `GetOrCreateMock<IServiceScope>()`, manual scope-factory extraction such as `AddType<IServiceScopeFactory>(provider.GetRequiredService<IServiceScopeFactory>())`, direct `IServiceScope.ServiceProvider` setup, and the paired `CreateScope()` pattern when the returned tracked scope also exposes a concrete provider in the same helper block
 
 If a suite already has a local Azure helper wrapper, re-point that wrapper to `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)` first and keep the existing call sites stable until the suite is green.
 
@@ -103,7 +103,7 @@ That migration is usually the highest-leverage cleanup in suites that centralize
 Analyzer note:
 
 - `FMOQ0013` warns on direct FastMoq `IServiceProvider`, `IServiceScopeFactory`, and `IServiceScope` shim setup, plus manual scope-factory extraction, so those helpers move toward `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, or `AddServiceScope(...)`.
-- the built-in fix covers the direct tracked-provider and tracked-scope cases plus manual scope-factory extraction, and adds `using FastMoq.Extensions;` when needed. More entangled shim setups such as custom `CreateScope()` plumbing or partially mocked scopes still need manual migration.
+- the built-in fix covers the direct tracked-provider and tracked-scope cases, manual scope-factory extraction, direct `IServiceScope.ServiceProvider` setup, and the paired `CreateScope()` case when `FMOQ0013` can recover the provider expression from the same helper block. It adds `using FastMoq.Extensions;` when needed. More entangled shim setups still need manual migration.
 
 If the same helper layer also hand-rolls `IOptions<T>` setup, move that boilerplate at the same time:
 

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -70,7 +70,7 @@ Analyzer note:
 - `FMOQ0013` warns on direct `FunctionContext.InstanceServices` mocking more broadly across `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` so those shims move toward the typed helper path
 - the built-in code fix is narrower: it only appears when `FastMoq.AzureFunctions` is already referenced, and it rewrites the safe tracked-provider cases `Setup(x => x.InstanceServices).Returns(provider)`, `SetupGet(x => x.InstanceServices).Returns(provider)`, and `SetupProperty(x => x.InstanceServices, provider)` to `context.AddFunctionContextInstanceServices(provider)` and adds `using FastMoq.AzureFunctions.Extensions;` when needed
 - `SetupSet(...)` is not part of this analyzer. When the real need is provider-neutral setter observation rather than Moq setter interception, prefer a fake or stub with [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1)
-- broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph
+- broader `IServiceProvider` shim warnings still stay warning-only when the right replacement depends on the suite's real service graph, but the built-in `FMOQ0013` fix now also handles the direct tracked-shim cases `GetOrCreateMock<IServiceProvider>()`, `GetOrCreateMock<IServiceScopeFactory>()`, `GetOrCreateMock<IServiceScope>()`, and manual scope-factory extraction such as `AddType<IServiceScopeFactory>(provider.GetRequiredService<IServiceScopeFactory>())`
 
 If a suite already has a local Azure helper wrapper, re-point that wrapper to `CreateFunctionContextInstanceServices(...)` or `AddFunctionContextInstanceServices(...)` first and keep the existing call sites stable until the suite is green.
 
@@ -103,6 +103,7 @@ That migration is usually the highest-leverage cleanup in suites that centralize
 Analyzer note:
 
 - `FMOQ0013` warns on direct FastMoq `IServiceProvider`, `IServiceScopeFactory`, and `IServiceScope` shim setup, plus manual scope-factory extraction, so those helpers move toward `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, or `AddServiceScope(...)`.
+- the built-in fix covers the direct tracked-provider and tracked-scope cases plus manual scope-factory extraction, and adds `using FastMoq.Extensions;` when needed. More entangled shim setups such as custom `CreateScope()` plumbing or partially mocked scopes still need manual migration.
 
 If the same helper layer also hand-rolls `IOptions<T>` setup, move that boilerplate at the same time:
 

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -163,7 +163,7 @@ Treat these APIs as temporary migration tools, not as the target style for new h
 | `MockOptional` | `OptionalParameterResolutionMode.ResolveViaMocker` or explicit `InvocationOptions` / `InstanceCreationFlags` |
 | `Strict` bundle toggles | `Mocker.Policy.DefaultStrictMockCreation` and explicit built-in resolution flags |
 | context-aware `AddType(...)` overloads | `AddKnownType(...)` |
-| mocked `IServiceProvider` shims | `CreateTypedServiceProvider(...)`, `AddServiceProvider(...)`, and `AddFunctionContextInstanceServices(...)` with `FastMoq.AzureFunctions` installed for the `FunctionContext` helper path |
+| mocked `IServiceProvider` / `IServiceScopeFactory` / `IServiceScope` shims | `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, `AddServiceScope(...)`, and `AddFunctionContextInstanceServices(...)` with `FastMoq.AzureFunctions` installed for the `FunctionContext` helper path |
 
 Two practical rules help here:
 
@@ -172,7 +172,7 @@ Two practical rules help here:
 
 Analyzer notes:
 
-- `FMOQ0013` warns on raw `IServiceProvider` mock setup and pushes it toward the typed helper path
+- `FMOQ0013` warns on raw `IServiceProvider`, `IServiceScopeFactory`, and `IServiceScope` shims, plus manual scope-factory extraction, and pushes them toward the typed helper path
 - for Azure Functions worker tests, `FMOQ0013` also warns on direct `FunctionContext.InstanceServices` `Setup(...)`, `SetupGet(...)`, and `SetupProperty(...)` usage, but the auto-fix is intentionally narrower and only appears when `FastMoq.AzureFunctions` is already referenced for the safe provider-assignment shapes that can become `context.AddFunctionContextInstanceServices(provider)`
 - `FMOQ0014` warns on context-aware compatibility `AddType(...)` usage and pushes it toward `AddKnownType(...)`
 - `FMOQ0015` warns when same-type keyed constructor dependencies are accidentally collapsed into one unkeyed double
@@ -230,4 +230,4 @@ Cases that do not translate cleanly:
 
 When a test depends on those features, either keep it on the Moq provider or replace the collaborator with a fake or stub through `AddType(...)`.
 
-For simple interface-property `SetupSet(...)` cases, the preferred non-Moq migration target is `AddPropertySetterCapture<TService, TValue>(...)`. When the component under test is already created through `MockerTestBase<TComponent>`, add the capture before construction or call `CreateComponent()` after the registration change. When the collaborator needs broader behavior, or the target is not an interface, fall back to a fake that records assignments through `PropertyValueCapture<TValue>`.
+For simple interface-property `SetupSet(...)` cases, the preferred non-Moq migration target is `AddPropertySetterCapture<TService, TValue>(...)`. For simple interface-property `SetupAllProperties()` cases, prefer `AddPropertyState<TService>(...)`. When the component under test is already created through `MockerTestBase<TComponent>`, add the helper before construction or call `CreateComponent()` after the registration change. When the collaborator needs broader behavior, or the target is not an interface, fall back to a fake that records assignments through `PropertyValueCapture<TValue>` or exposes real property state directly.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -31,18 +31,22 @@ v4 also includes helper and migration work where common testing scenarios still 
 
 Planned work includes:
 
-- Additional provider-neutral guidance for framework-heavy suites that combine typed `IServiceProvider` helpers with keyed services, scoped resolution, or framework-owned service graphs.
+- Additional provider-neutral guidance for framework-heavy suites that combine typed `IServiceProvider` helpers with keyed services or framework-owned service graphs beyond the current scope-aware helper path.
 - Azure Functions follow-up helpers beyond the shipped `FunctionContext.InstanceServices`, `CreateHttpRequestData(...)`, and `CreateHttpResponseData(...)` support.
-- A clearer first-party path for common `SetupAllProperties()`-heavy tests where the real need is lightweight stateful property backing rather than mocking-library-managed auto-properties.
 - Focused migration guidance and examples for compatibility-only APIs that remain temporary rather than long-term patterns.
+
+Recently added in the current v4 line:
+
+- `AddPropertyState<TService>(...)` for common interface-based `SetupAllProperties()` migration cases where the real need is lightweight stateful property backing.
+- `CreateTypedServiceScope(...)` and `AddServiceScope(...)` for typed scope setup, plus optional `includeMockerFallback: true` bridging when framework-owned resolution should fall back to normal `Mocker` behavior.
+- `FMOQ0013` coverage for manual `IServiceScopeFactory` and `IServiceScope` shims, alongside the existing typed `IServiceProvider` guidance.
+- `FMOQ0021` guidance for Moq `SetupAllProperties()` cases that should move toward `AddPropertyState<TService>(...)` or a concrete fake.
 
 Other gaps worth adding next, in priority order:
 
-1. A clearer first-party `SetupAllProperties()` replacement.
-2. Better typed `IServiceProvider` helper support for scoped and framework-owned graphs.
-3. Analyzer guidance for manual scope and `IServiceScopeFactory` shims.
-4. Azure Functions follow-up helpers beyond `InstanceServices`, request, and response.
-5. More examples and sample-backed docs for property-capture migration.
+1. Azure Functions follow-up helpers beyond `InstanceServices`, request, and response.
+2. More examples and sample-backed docs for property-capture and property-state migration.
+3. Additional keyed-service guidance for framework-owned DI graphs.
 
 ### Documentation and examples
 


### PR DESCRIPTION
## Summary
- add provider-first property state and property setter capture helpers as a migration path away from simple `SetupAllProperties()` and setter-interception patterns
- expand typed `IServiceProvider` and `IServiceScope` helper coverage, including owned lifetime tracking, provider-backed scope registration, and the corresponding disposal model updates on `Mocker`
- extend analyzer migration support with `FMOQ0021` plus broader `FMOQ0013` detection and code fixes for typed provider, scope, and context-sensitive scope-factory migration cases
- add runtime tests, analyzer/code-fix tests, sample coverage, and updated migration/testing docs for the new helper surfaces

## Validation
- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj --no-restore`
- `dotnet test .\FastMoq.Tests\FastMoq.Tests.csproj --no-restore`