### PR TITLE
Clean up example warning sites and add Moq coverage

### DIFF
--- a/FastMoq.Core/Extensions/PropertyStateExtensions.cs
+++ b/FastMoq.Core/Extensions/PropertyStateExtensions.cs
@@ -25,9 +25,40 @@ namespace FastMoq.Extensions
         /// ]]></code>
         /// </example>
         /// <remarks>
+        /// This overload preserves the original write-through behavior by using <see cref="PropertyStateMode.WriteThrough" />.
+        ///
         /// When you use this helper from a <c>MockerTestBase&lt;TComponent&gt;</c>-based test, add the helper during the setup phase or call <c>CreateComponent()</c> after the registration change so the component is rebuilt against the proxy-wrapped dependency.
         /// </remarks>
         public static TService AddPropertyState<TService>(this Mocker mocker, bool replace = true)
+            where TService : class
+        {
+            return mocker.AddPropertyState<TService>(PropertyStateMode.WriteThrough, replace);
+        }
+
+        /// <summary>
+        /// Replaces the current interface registration with a proxy that preserves assignments for all readable and writable non-indexer properties while forwarding unrelated members to the previously resolved instance.
+        /// </summary>
+        /// <typeparam name="TService">The interface type to wrap.</typeparam>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="mode">Controls whether property assignments also write through to the wrapped inner instance or stay on the proxy only.</param>
+        /// <param name="replace">True to replace an existing registration for <typeparamref name="TService" />. Defaults to <see langword="true" /> because the helper intentionally swaps in a property-state proxy.</param>
+        /// <returns>The proxy-backed instance now registered for <typeparamref name="TService" />.</returns>
+        /// <example>
+        /// <code language="csharp"><![CDATA[
+        /// var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>(PropertyStateMode.ProxyOnly);
+        /// CreateComponent();
+        ///
+        /// await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+        ///
+        /// channel.Mode.Should().Be("fast");
+        /// ]]></code>
+        /// </example>
+        /// <remarks>
+        /// Use <see cref="PropertyStateMode.ProxyOnly" /> when the test needs detached property state on the proxy registration without mutating the previously wrapped instance.
+        ///
+        /// When you use this helper from a <c>MockerTestBase&lt;TComponent&gt;</c>-based test, add the helper during the setup phase or call <c>CreateComponent()</c> after the registration change so the component is rebuilt against the proxy-wrapped dependency.
+        /// </remarks>
+        public static TService AddPropertyState<TService>(this Mocker mocker, PropertyStateMode mode, bool replace = true)
             where TService : class
         {
             ArgumentNullException.ThrowIfNull(mocker);
@@ -41,6 +72,7 @@ namespace FastMoq.Extensions
             var currentInstance = mocker.GetObject<TService>() ?? throw new InvalidOperationException($"Unable to resolve an instance for {serviceType.Name} before adding property state.");
             if (currentInstance is PropertyStateProxy<TService> existingProxy)
             {
+                existingProxy.SetPropertyStateMode(mode);
                 existingProxy.EnableAutomaticPropertyState();
                 return currentInstance;
             }
@@ -48,6 +80,7 @@ namespace FastMoq.Extensions
             var proxy = DispatchProxy.Create<TService, PropertyStateProxy<TService>>();
             var proxyController = (PropertyStateProxy<TService>) (object) proxy;
             proxyController.Initialize(currentInstance);
+            proxyController.SetPropertyStateMode(mode);
             proxyController.EnableAutomaticPropertyState();
 
             mocker.AddType<TService>(proxy, replace);
@@ -60,6 +93,7 @@ namespace FastMoq.Extensions
         private readonly Dictionary<MethodInfo, PropertyStateRegistration> _propertyRegistrations = [];
 
         private TService? _inner;
+        private PropertyStateMode _propertyStateMode = PropertyStateMode.WriteThrough;
 
         public void Initialize(TService inner)
         {
@@ -85,6 +119,11 @@ namespace FastMoq.Extensions
             }
         }
 
+        public void SetPropertyStateMode(PropertyStateMode propertyStateMode)
+        {
+            _propertyStateMode = propertyStateMode;
+        }
+
         public void AddCapture<TValue>(PropertyInfo propertyInfo, PropertyValueCapture<TValue> capture)
         {
             ArgumentNullException.ThrowIfNull(propertyInfo);
@@ -100,7 +139,7 @@ namespace FastMoq.Extensions
 
             if (_propertyRegistrations.TryGetValue(targetMethod, out var registration))
             {
-                return registration.Invoke(_inner, targetMethod, args);
+                return registration.Invoke(_inner, targetMethod, args, _propertyStateMode == PropertyStateMode.WriteThrough);
             }
 
             if (_inner is null)
@@ -174,7 +213,7 @@ namespace FastMoq.Extensions
                 _observers.Add(observer);
             }
 
-            public object? Invoke(object? inner, MethodInfo targetMethod, object?[]? args)
+            public object? Invoke(object? inner, MethodInfo targetMethod, object?[]? args, bool writeThroughToInner)
             {
                 if (targetMethod == PropertyInfo.GetMethod)
                 {
@@ -205,7 +244,7 @@ namespace FastMoq.Extensions
                         observer(assignedValue);
                     }
 
-                    if (inner is not null)
+                    if (writeThroughToInner && inner is not null)
                     {
                         PropertyInfo.SetValue(inner, assignedValue);
                     }

--- a/FastMoq.Core/PropertyStateMode.cs
+++ b/FastMoq.Core/PropertyStateMode.cs
@@ -1,0 +1,20 @@
+namespace FastMoq
+{
+    /// <summary>
+    /// Controls whether <c>AddPropertyState&lt;TService&gt;(...)</c> keeps assigned values on the proxy only or also writes them through to the wrapped inner instance.
+    /// </summary>
+    public enum PropertyStateMode
+    {
+        /// <summary>
+        /// Preserve the proxy-backed property value and also assign the same value to the wrapped inner instance.
+        /// This keeps the original <c>AddPropertyState&lt;TService&gt;(...)</c> behavior.
+        /// </summary>
+        WriteThrough = 0,
+
+        /// <summary>
+        /// Preserve the proxy-backed property value without mutating the wrapped inner instance.
+        /// Non-property members still forward to the wrapped instance.
+        /// </summary>
+        ProxyOnly = 1,
+    }
+}

--- a/FastMoq.TestingExample/ExampleTests.cs
+++ b/FastMoq.TestingExample/ExampleTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using FastMoq.Extensions;
+using FastMoq.Providers;
 using FastMoq.Providers.MoqProvider;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
@@ -75,7 +75,7 @@ namespace FastMoq.TestingExample
         #region Fields
 
         private static bool testEventCalled;
-        private static Mock<IFileSystem> fileSystemMock = default!;
+        private static IFastMock<IFileSystem> fileSystemMock = default!;
 
         #endregion
 
@@ -85,7 +85,7 @@ namespace FastMoq.TestingExample
         [Fact]
         public void Test1()
         {
-            Component.FileSystem.Should().Be(fileSystemMock.Object);
+            Component.FileSystem.Should().Be(fileSystemMock.Instance);
             Component.FileSystem.Should().NotBeNull();
             Component.FileSystem.File.Should().NotBeNull();
             Component.FileSystem.Directory.Should().BeNull();
@@ -102,11 +102,11 @@ namespace FastMoq.TestingExample
 
         private static void SetupMocks(Mocker mocks)
         {
-            fileSystemMock = new Mock<IFileSystem>();
             var iFile = new FileSystem().File;
             mocks.Behavior.Enabled |= MockFeatures.FailOnUnconfigured;
+            fileSystemMock = mocks.GetOrCreateMock<IFileSystem>();
             fileSystemMock.Setup(x => x.File).Returns(iFile);
-            mocks.AddType<IFileSystem>(fileSystemMock.Object, replace: true);
+            fileSystemMock.Setup(x => x.Directory).Returns((IDirectory)null!);
         }
     }
 

--- a/FastMoq.TestingExample/ProviderSelectionExampleTests.cs
+++ b/FastMoq.TestingExample/ProviderSelectionExampleTests.cs
@@ -15,14 +15,16 @@ namespace FastMoq.TestingExample
         }
 
         [Fact]
-        public void AppWideDefaultProvider_ShouldEnableMoqCompatibilitySurface()
+        public void AppWideDefaultProvider_ShouldEnableTrackedMoqAuthoringSurface()
         {
-            Mocks.GetMock<IProviderSelectionDependency>()
+            var dependency = Mocks.GetOrCreateMock<IProviderSelectionDependency>();
+
+            dependency
                 .Setup(x => x.GetValue())
                 .Returns("configured via moq");
 
             Component.GetValue().Should().Be("configured via moq");
-            Mocks.GetMock<IProviderSelectionDependency>()
+            dependency.AsMoq()
                 .Verify(x => x.GetValue(), Times.Once);
         }
     }

--- a/FastMoq.Tests/MoqProviderExtensionTests.cs
+++ b/FastMoq.Tests/MoqProviderExtensionTests.cs
@@ -134,6 +134,26 @@ namespace FastMoq.Tests
             dependency.Instance.GetValue().Should().Be("second");
         }
 
+        [Theory]
+        [InlineData("reflection")]
+        [InlineData("nsubstitute")]
+        public void MoqAuthoringShortcuts_ShouldThrowClearProviderMismatch_WhenProviderIsNotMoq(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var dependency = mocker.GetOrCreateMock<ProviderTests.IProviderDependency>();
+            var valueDependency = mocker.GetOrCreateMock<IProviderValueDependency>();
+            var propertyDependency = mocker.GetOrCreateMock<IProviderPropertyDependency>();
+            var handler = mocker.GetOrCreateMock<ProtectedShortcutDependency>();
+
+            AssertRequiresMoqProvider(() => dependency.Setup(x => x.Run("alpha")), providerName);
+            AssertRequiresMoqProvider(() => valueDependency.Setup(x => x.GetValue()), providerName);
+            AssertRequiresMoqProvider(() => propertyDependency.SetupGet(x => x.Value), providerName);
+            AssertRequiresMoqProvider(() => valueDependency.SetupSequence(x => x.GetValue()), providerName);
+            AssertRequiresMoqProvider(() => handler.Protected(), providerName);
+        }
+
         [Fact]
         public async Task ProtectedShortcut_ShouldExposeMoqProtectedApi_ForTrackedMock()
         {
@@ -210,6 +230,26 @@ namespace FastMoq.Tests
             logger.VerifyLogger(LogLevel.Error, "processing failed", exception, eventId: 9, times: 1);
         }
 
+        [Theory]
+        [InlineData("reflection")]
+        [InlineData("nsubstitute")]
+        public void MoqLoggerCompatibilityShortcuts_ShouldThrowClearProviderMismatch_WhenProviderIsNotMoq(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var logger = mocker.GetOrCreateMock<ILogger>();
+            var genericLogger = mocker.GetOrCreateMock<ILogger<NullLogger>>();
+            var exception = new InvalidOperationException("boom");
+
+            AssertRequiresMoqProvider(() => logger.VerifyLogger(LogLevel.Information, "processed order", times: 1), providerName);
+            AssertRequiresMoqProvider(() => genericLogger.VerifyLogger(LogLevel.Information, "processed order", times: 1), providerName);
+            AssertRequiresMoqProvider(() => logger.VerifyLogger(LogLevel.Error, "processed order", exception, eventId: 7, times: 1), providerName);
+            AssertRequiresMoqProvider(() => genericLogger.VerifyLogger(LogLevel.Error, "processed order", exception, eventId: 9, times: 1), providerName);
+            AssertRequiresMoqProvider(() => logger.SetupLoggerCallback((_, _, _, _) => { }), providerName);
+            AssertRequiresMoqProvider(() => genericLogger.SetupLoggerCallback((_, _, _, _) => { }), providerName);
+        }
+
         [Fact]
         public void SetupLoggerCallbackShortcut_ShouldCaptureEntries_WithoutCallingAsMoq()
         {
@@ -262,6 +302,19 @@ namespace FastMoq.Tests
         public interface IProviderPropertyDependency
         {
             string Value { get; }
+        }
+
+        public class ProtectedShortcutDependency
+        {
+            public virtual string Run() => "ok";
+        }
+
+        private static void AssertRequiresMoqProvider(Action action, string providerName)
+        {
+            var exception = action.Should().Throw<NotSupportedException>().Which;
+            exception.Message.Should().Contain("requires the 'moq' provider");
+            exception.Message.Should().Contain($"active provider is '{providerName}'");
+            exception.Message.Should().Contain("MockingProviderRegistry.Push(\"moq\")");
         }
     }
 }

--- a/FastMoq.Tests/MoqProviderExtensionTests.cs
+++ b/FastMoq.Tests/MoqProviderExtensionTests.cs
@@ -9,6 +9,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
+#pragma warning disable FMOQ0003 // Intentional coverage for Moq VerifyLogger compatibility shortcuts.
+
 namespace FastMoq.Tests
 {
     public class MoqProviderExtensionTests
@@ -20,6 +22,19 @@ namespace FastMoq.Tests
             var mocker = new Mocker();
 
             var dependency = mocker.GetOrCreateMock<ProviderTests.IProviderDependency>();
+
+            var mock = dependency.AsMoq();
+
+            mock.Should().BeSameAs(dependency.NativeMock);
+        }
+
+        [Fact]
+        public void AsMoqNonGeneric_ShouldReturnUnderlyingMock_WhenProviderIsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            IFastMock dependency = mocker.GetOrCreateMock<ProviderTests.IProviderDependency>();
 
             var mock = dependency.AsMoq();
 
@@ -44,6 +59,24 @@ namespace FastMoq.Tests
             exception.Message.Should().Contain("MockingProviderRegistry.Push(\"moq\")");
         }
 
+        [Theory]
+        [InlineData("reflection")]
+        [InlineData("nsubstitute")]
+        public void AsMoqNonGeneric_ShouldThrow_WhenProviderIsNotMoq(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            IFastMock dependency = mocker.GetOrCreateMock<ProviderTests.IProviderDependency>();
+
+            Action action = () => dependency.AsMoq();
+
+            var exception = action.Should().Throw<NotSupportedException>().Which;
+            exception.Message.Should().Contain("requires the 'moq' provider");
+            exception.Message.Should().Contain($"active provider is '{providerName}'");
+            exception.Message.Should().Contain("MockingProviderRegistry.Push(\"moq\")");
+        }
+
         [Fact]
         public void SetupShortcut_ShouldConfigureTrackedMock_WithoutCallingAsMoq()
         {
@@ -57,6 +90,32 @@ namespace FastMoq.Tests
             dependency.Instance.Run("alpha");
 
             dependency.AsMoq().Verify(x => x.Run("alpha"), Times.Once);
+        }
+
+        [Fact]
+        public void SetupResultShortcut_ShouldConfigureTrackedMock_WithoutCallingAsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var dependency = mocker.GetOrCreateMock<IProviderValueDependency>();
+
+            dependency.Setup(x => x.GetValue()).Returns("configured");
+
+            dependency.Instance.GetValue().Should().Be("configured");
+        }
+
+        [Fact]
+        public void SetupGetShortcut_ShouldConfigureTrackedMockProperty_WithoutCallingAsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var dependency = mocker.GetOrCreateMock<IProviderPropertyDependency>();
+
+            dependency.SetupGet(x => x.Value).Returns("configured");
+
+            dependency.Instance.Value.Should().Be("configured");
         }
 
         [Fact]
@@ -111,6 +170,47 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void VerifyLoggerShortcut_ShouldUseNonGenericLoggerMock_WithoutCallingAsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var logger = mocker.GetOrCreateMock<ILogger>();
+
+            logger.Instance.LogInformation("processed order");
+
+            logger.VerifyLogger(LogLevel.Information, "processed order", times: 1);
+        }
+
+        [Fact]
+        public void VerifyLoggerShortcut_ShouldSupportNonGenericExceptionOverload_WithoutCallingAsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var logger = mocker.GetOrCreateMock<ILogger>();
+            var exception = new InvalidOperationException("boom");
+
+            logger.Instance.LogError(7, exception, "processing failed");
+
+            logger.VerifyLogger(LogLevel.Error, "processing failed", exception, eventId: 7, times: 1);
+        }
+
+        [Fact]
+        public void VerifyLoggerShortcut_ShouldSupportGenericExceptionOverload_WithoutCallingAsMoq()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var logger = mocker.GetOrCreateMock<ILogger<NullLogger>>();
+            var exception = new InvalidOperationException("boom");
+
+            logger.Instance.LogError(9, exception, "processing failed");
+
+            logger.VerifyLogger(LogLevel.Error, "processing failed", exception, eventId: 9, times: 1);
+        }
+
+        [Fact]
         public void SetupLoggerCallbackShortcut_ShouldCaptureEntries_WithoutCallingAsMoq()
         {
             using var providerScope = MockingProviderRegistry.Push("moq");
@@ -132,9 +232,38 @@ namespace FastMoq.Tests
             capturedMessage.Should().Contain("callback message");
         }
 
+        [Fact]
+        public void SetupLoggerCallbackShortcut_ShouldCaptureEntries_ForNonGenericLogger()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker();
+
+            var logger = mocker.GetOrCreateMock<ILogger>();
+            LogLevel? capturedLevel = null;
+            string? capturedMessage = null;
+
+            logger.SetupLoggerCallback((logLevel, _, message, _) =>
+            {
+                capturedLevel = logLevel;
+                capturedMessage = message;
+            });
+
+            logger.Instance.LogWarning("callback warning");
+
+            capturedLevel.Should().Be(LogLevel.Warning);
+            capturedMessage.Should().Contain("callback warning");
+        }
+
         public interface IProviderValueDependency
         {
             string GetValue();
         }
+
+        public interface IProviderPropertyDependency
+        {
+            string Value { get; }
+        }
     }
 }
+
+#pragma warning restore FMOQ0003

--- a/FastMoq.Tests/PropertySetterCaptureTests.cs
+++ b/FastMoq.Tests/PropertySetterCaptureTests.cs
@@ -28,6 +28,26 @@ namespace FastMoq.Tests
         [Theory]
         [InlineData("moq")]
         [InlineData("nsubstitute")]
+        public void AddPropertyState_ProxyOnlyMode_ShouldKeepAssignmentsDetached_AndForwardOtherMembers(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var trackedMock = mocker.GetOrCreateMock<IPropertySetterCaptureGateway>();
+            var originalMode = trackedMock.Instance.Mode;
+            var gateway = mocker.AddPropertyState<IPropertySetterCaptureGateway>(PropertyStateMode.ProxyOnly);
+
+            gateway.Mode = "fast";
+            gateway.Publish("alpha");
+
+            gateway.Mode.Should().Be("fast");
+            trackedMock.Instance.Mode.Should().Be(originalMode);
+            mocker.Verify<IPropertySetterCaptureGateway>(x => x.Publish("alpha"), TimesSpec.Once);
+        }
+
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
         public void AddPropertySetterCapture_ShouldCaptureAssignments_AndForwardOtherMembers(string providerName)
         {
             using var providerScope = MockingProviderRegistry.Push(providerName);

--- a/FastMoq.Tests/PropertyStateCompatibilityTests.cs
+++ b/FastMoq.Tests/PropertyStateCompatibilityTests.cs
@@ -25,11 +25,35 @@ namespace FastMoq.Tests
             trackedMock.Instance.Should().BeSameAs(trackedInstance);
             trackedMock.Instance.Should().NotBeSameAs(resolved);
 
-            // The proxy replaces the resolved registration, but it still forwards
-            // property assignments to the previously tracked instance underneath.
+            // The proxy replaces the resolved registration, but the default mode
+            // still writes property assignments through to the wrapped inner instance.
             proxy.Mode = "fast";
             proxy.Mode.Should().Be("fast");
             trackedMock.Instance.Mode.Should().Be("fast");
+        }
+
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
+        public void AddPropertyState_ProxyOnlyMode_ShouldKeepAssignmentsDetached_FromWrappedInstance(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var trackedMock = mocker.GetOrCreateMock<IPropertyStateCompatibilityGateway>();
+            var trackedInstance = trackedMock.Instance;
+            var originalMode = trackedInstance.Mode;
+
+            var proxy = mocker.AddPropertyState<IPropertyStateCompatibilityGateway>(PropertyStateMode.ProxyOnly);
+            var resolved = mocker.GetObject<IPropertyStateCompatibilityGateway>();
+
+            proxy.Should().BeSameAs(resolved);
+            proxy.Should().NotBeSameAs(trackedInstance);
+
+            proxy.Mode = "fast";
+
+            proxy.Mode.Should().Be("fast");
+            trackedMock.Instance.Mode.Should().Be(originalMode);
         }
 
         public interface IPropertyStateCompatibilityGateway

--- a/FastMoq.Tests/PropertyStateCompatibilityTests.cs
+++ b/FastMoq.Tests/PropertyStateCompatibilityTests.cs
@@ -1,0 +1,38 @@
+using FastMoq.Extensions;
+using FastMoq.Providers;
+
+namespace FastMoq.Tests
+{
+    public class PropertyStateCompatibilityTests
+    {
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
+        public void AddPropertyState_ShouldReplaceResolvedInstance_WhenTrackedMockAlreadyExists(string providerName)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var trackedMock = mocker.GetOrCreateMock<IPropertyStateCompatibilityGateway>();
+            var trackedInstance = trackedMock.Instance;
+
+            var proxy = mocker.AddPropertyState<IPropertyStateCompatibilityGateway>();
+            var resolved = mocker.GetObject<IPropertyStateCompatibilityGateway>();
+
+            trackedInstance.Should().NotBeNull();
+            proxy.Should().BeSameAs(resolved);
+            proxy.Should().NotBeSameAs(trackedInstance);
+            trackedMock.Instance.Should().BeSameAs(trackedInstance);
+            trackedMock.Instance.Should().NotBeSameAs(resolved);
+
+            proxy.Mode = "fast";
+            proxy.Mode.Should().Be("fast");
+            trackedMock.Instance.Mode.Should().Be("fast");
+        }
+
+        public interface IPropertyStateCompatibilityGateway
+        {
+            string? Mode { get; set; }
+        }
+    }
+}

--- a/FastMoq.Tests/PropertyStateCompatibilityTests.cs
+++ b/FastMoq.Tests/PropertyStateCompatibilityTests.cs
@@ -25,6 +25,8 @@ namespace FastMoq.Tests
             trackedMock.Instance.Should().BeSameAs(trackedInstance);
             trackedMock.Instance.Should().NotBeSameAs(resolved);
 
+            // The proxy replaces the resolved registration, but it still forwards
+            // property assignments to the previously tracked instance underneath.
             proxy.Mode = "fast";
             proxy.Mode.Should().Be("fast");
             trackedMock.Instance.Mode.Should().Be("fast");

--- a/docs/getting-started/provider-capabilities.md
+++ b/docs/getting-started/provider-capabilities.md
@@ -154,6 +154,17 @@ channel.Mode.Should().Be("fast");
 
 That keeps the important part of the test explicit: the collaborator needs real property state, not Moq-specific property plumbing.
 
+`AddPropertyState<TService>(...)` keeps its original write-through behavior by default. If the test needs detached property state on the proxy registration without mutating the previously wrapped instance, use `PropertyStateMode.ProxyOnly`:
+
+```csharp
+var channel = Mocks.AddPropertyState<IOrderSubmissionChannel>(PropertyStateMode.ProxyOnly);
+CreateComponent();
+
+await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None);
+
+channel.Mode.Should().Be("fast");
+```
+
 If the collaborator needs more behavior than one captured property, or the target is not an interface, fall back to a fake plus [PropertyValueCapture&lt;TValue&gt;](xref:FastMoq.PropertyValueCapture`1):
 
 ```csharp

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -365,6 +365,8 @@ if (!Mocks.TryGetTrackedMock<ILogger<OrderService>>(out var logger))
 }
 ```
 
+### Known-type extensibility
+
 After, when the old code only needed the resolved dependency instance:
 
 ```csharp
@@ -864,6 +866,8 @@ await Component.SubmitAsync("order-42", expedited: true, CancellationToken.None)
 
 channel.Mode.Should().Be("fast");
 ```
+
+That helper keeps its original write-through behavior by default. If the migrated test needs proxy-local property state without mutating the previously wrapped instance, use `AddPropertyState<IOrderSubmissionChannel>(PropertyStateMode.ProxyOnly)` instead.
 
 ### Known-type extensibility
 


### PR DESCRIPTION
## Summary
- move the remaining example warning site in `ProviderSelectionExampleTests` to the tracked `GetOrCreateMock<T>()` path while keeping explicit Moq verification via `AsMoq()`
- keep `ExampleTests` on the provider-first tracked mock path while preserving its explicit `IFileSystem.Directory == null` behavior
- add direct coverage for the remaining `IFastMockMoqExtensions` entry points and a regression test showing where `AddPropertyState<T>()` is not a drop-in replacement for identity-sensitive `SetupAllProperties()` flows

## Testing
- `dotnet test .\\FastMoq.Tests\\FastMoq.Tests.csproj --no-restore`
- `dotnet test .\\FastMoq.TestingExample\\FastMoq.TestingExample.csproj --no-restore`