### PR TITLE
Add Moq onboarding analyzer and constructor guidance

### DIFF
--- a/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
@@ -18,12 +18,17 @@ namespace FastMoq.Analyzers.Tests
     {
         public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source, params DiagnosticAnalyzer[] analyzers)
         {
-            return await GetDiagnosticsAsync(source, includeAzureFunctionsHelpers: false, analyzers).ConfigureAwait(false);
+            return await GetDiagnosticsAsync(source, includeAzureFunctionsHelpers: false, includeMoqProviderPackage: true, includeNSubstituteProviderPackage: true, analyzers).ConfigureAwait(false);
         }
 
         public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source, bool includeAzureFunctionsHelpers, params DiagnosticAnalyzer[] analyzers)
         {
-            var document = CreateDocument(source, includeAzureFunctionsHelpers);
+            return await GetDiagnosticsAsync(source, includeAzureFunctionsHelpers, includeMoqProviderPackage: true, includeNSubstituteProviderPackage: true, analyzers).ConfigureAwait(false);
+        }
+
+        public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source, bool includeAzureFunctionsHelpers, bool includeMoqProviderPackage, bool includeNSubstituteProviderPackage, params DiagnosticAnalyzer[] analyzers)
+        {
+            var document = CreateDocument(source, includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage);
             return await GetDiagnosticsAsync(document, analyzers).ConfigureAwait(false);
         }
 
@@ -41,9 +46,14 @@ namespace FastMoq.Analyzers.Tests
                 .ConfigureAwait(false);
         }
 
-        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null)
+        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null, string? codeFixTitle = null)
         {
-            var document = CreateDocument(source, includeAzureFunctionsHelpers);
+            return await ApplyCodeFixAsync(source, analyzer, codeFixProvider, diagnosticId, includeAzureFunctionsHelpers, includeMoqProviderPackage: true, includeNSubstituteProviderPackage: true, diagnosticOccurrence, diagnosticMessageContains, codeFixTitle).ConfigureAwait(false);
+        }
+
+        public static async Task<string> ApplyCodeFixAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers, bool includeMoqProviderPackage, bool includeNSubstituteProviderPackage, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null, string? codeFixTitle = null)
+        {
+            var document = CreateDocument(source, includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage);
             var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
             var diagnostic = diagnostics
                 .Where(item => item.Id == diagnosticId)
@@ -55,7 +65,9 @@ namespace FastMoq.Analyzers.Tests
             var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
             await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 
-            var action = actions.Single();
+            var action = codeFixTitle is null
+                ? actions.Single()
+                : actions.Single(item => string.Equals(item.Title, codeFixTitle, StringComparison.Ordinal));
             var operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
             var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
             var changedDocument = changedSolution.GetDocument(document.Id)!;
@@ -65,7 +77,12 @@ namespace FastMoq.Analyzers.Tests
 
         public static async Task<ImmutableArray<string>> GetCodeFixTitlesAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers = false, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null)
         {
-            var document = CreateDocument(source, includeAzureFunctionsHelpers);
+            return await GetCodeFixTitlesAsync(source, analyzer, codeFixProvider, diagnosticId, includeAzureFunctionsHelpers, includeMoqProviderPackage: true, includeNSubstituteProviderPackage: true, diagnosticOccurrence, diagnosticMessageContains).ConfigureAwait(false);
+        }
+
+        public static async Task<ImmutableArray<string>> GetCodeFixTitlesAsync(string source, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string diagnosticId, bool includeAzureFunctionsHelpers, bool includeMoqProviderPackage, bool includeNSubstituteProviderPackage, int diagnosticOccurrence = 0, string? diagnosticMessageContains = null)
+        {
+            var document = CreateDocument(source, includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage);
             var diagnostics = await GetDiagnosticsAsync(document, analyzer).ConfigureAwait(false);
             var diagnostic = diagnostics
                 .Where(item => item.Id == diagnosticId)
@@ -88,7 +105,7 @@ namespace FastMoq.Analyzers.Tests
                 .ToFullString();
         }
 
-        private static Document CreateDocument(string source, bool includeAzureFunctionsHelpers = false)
+        private static Document CreateDocument(string source, bool includeAzureFunctionsHelpers = false, bool includeMoqProviderPackage = true, bool includeNSubstituteProviderPackage = true)
         {
             var workspace = new AdhocWorkspace();
             var projectId = ProjectId.CreateNewId();
@@ -99,7 +116,7 @@ namespace FastMoq.Analyzers.Tests
                 .WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Preview))
                 .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-            foreach (var metadataReference in GetMetadataReferences(includeAzureFunctionsHelpers))
+            foreach (var metadataReference in GetMetadataReferences(includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage))
             {
                 solution = solution.AddMetadataReference(projectId, metadataReference);
             }
@@ -108,7 +125,7 @@ namespace FastMoq.Analyzers.Tests
             return solution.GetDocument(documentId)!;
         }
 
-        private static IEnumerable<MetadataReference> GetMetadataReferences(bool includeAzureFunctionsHelpers)
+        private static IEnumerable<MetadataReference> GetMetadataReferences(bool includeAzureFunctionsHelpers, bool includeMoqProviderPackage, bool includeNSubstituteProviderPackage)
         {
             var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trustedPlatformAssemblies)
@@ -121,13 +138,34 @@ namespace FastMoq.Analyzers.Tests
                         continue;
                     }
 
+                    if (!includeMoqProviderPackage &&
+                        string.Equals(Path.GetFileNameWithoutExtension(assemblyPath), "FastMoq.Provider.Moq", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (!includeNSubstituteProviderPackage &&
+                        string.Equals(Path.GetFileNameWithoutExtension(assemblyPath), "FastMoq.Provider.NSubstitute", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     references.Add(assemblyPath);
                 }
             }
 
             references.Add(typeof(FastMoq.Mocker).Assembly.Location);
-            references.Add(typeof(FastMoq.Providers.MoqProvider.IFastMockMoqExtensions).Assembly.Location);
-            references.Add(typeof(FastMoq.Providers.NSubstituteProvider.IFastMockNSubstituteExtensions).Assembly.Location);
+
+            if (includeMoqProviderPackage)
+            {
+                references.Add(typeof(FastMoq.Providers.MoqProvider.IFastMockMoqExtensions).Assembly.Location);
+            }
+
+            if (includeNSubstituteProviderPackage)
+            {
+                references.Add(typeof(FastMoq.Providers.NSubstituteProvider.IFastMockNSubstituteExtensions).Assembly.Location);
+            }
+
             references.Add(typeof(Moq.Mock).Assembly.Location);
             references.Add(typeof(NSubstitute.Substitute).Assembly.Location);
             references.Add(typeof(Microsoft.Extensions.Logging.ILogger).Assembly.Location);

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -36,6 +36,8 @@ namespace FastMoq.Analyzers.Tests
             { new ServiceProviderShimAnalyzer(), DiagnosticDescriptors.PreferTypedServiceProviderHelpers },
             { new KnownTypeAuthoringAnalyzer(), DiagnosticDescriptors.PreferKnownTypeRegistrations },
             { new KeyedDependencyAnalyzer(), DiagnosticDescriptors.PreserveKeyedServiceDistinctness },
+            { new TrackedAddTypeMigrationAnalyzer(), DiagnosticDescriptors.PreserveTrackedResolutionDuringAddTypeMigration },
+            { new LegacyMoqOnboardingAnalyzer(), DiagnosticDescriptors.RequireExplicitMoqOnboarding },
         };
 
         public static TheoryData<DiagnosticDescriptor, DiagnosticSeverity> DescriptorSeverityPairs => new()
@@ -61,6 +63,8 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.PreferTypedServiceProviderHelpers, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.PreferKnownTypeRegistrations, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.PreserveKeyedServiceDistinctness, DiagnosticSeverity.Warning },
+            { DiagnosticDescriptors.PreserveTrackedResolutionDuringAddTypeMigration, DiagnosticSeverity.Warning },
+            { DiagnosticDescriptors.RequireExplicitMoqOnboarding, DiagnosticSeverity.Warning },
         };
 
         [Theory]
@@ -1972,6 +1976,281 @@ class Sample
 
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task TrackedAddTypeMigrationAnalyzer_ShouldReport_WhenTrackedReplacementStillUsesGetObjectForSameService()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Moq;
+
+class Sample
+{
+    interface IService
+    {
+        string? Value { get; set; }
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var tracked = mocks.GetMock<IService>();
+        mocks.AddType<IService>(tracked.Object, replace: true);
+        var resolved = mocks.GetObject<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedAddTypeMigrationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration));
+            Assert.Equal(DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration, diagnostic.Id);
+            Assert.Contains("GetObject<T>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task TrackedAddTypeMigrationAnalyzer_ShouldNotReport_WhenConcreteFakeReplacementOwnsResolution()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        string? Value { get; set; }
+    }
+
+    sealed class FakeService : IService
+    {
+        public string? Value { get; set; }
+    }
+
+    void Execute(Mocker mocks)
+    {
+        mocks.AddType<IService>(_ => new FakeService(), replace: true);
+        var resolved = mocks.GetObject<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedAddTypeMigrationAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenLegacyGetMockIsUsedWithoutExplicitOnboarding()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LegacyMoqOnboardingAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
+            Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
+            Assert.Contains("GetMock<T>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenLegacyGetMockUsesAssemblyDefaultButMoqProviderPackageIsMissing()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+
+[assembly: FastMoqDefaultProvider(""moq"")]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: false,
+                includeNSubstituteProviderPackage: true,
+                new LegacyMoqOnboardingAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
+            Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new LegacyMoqOnboardingAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.RequireExplicitMoqOnboarding,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: false,
+                includeNSubstituteProviderPackage: true);
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenProviderPackageAndAssemblyDefaultArePresent()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+
+[assembly: FastMoqDefaultProvider(""moq"")]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_CodeFix_ShouldAddAssemblyDefault_WhenProviderPackageIsPresent()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new LegacyMoqOnboardingAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.RequireExplicitMoqOnboarding,
+                codeFixTitle: "Add [assembly: FastMoqDefaultProvider(\"moq\")]");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using FastMoq.Providers;
+
+[assembly: FastMoqDefaultProvider(""moq"")]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_CodeFix_ShouldOfferBothMoqOnboardingChoices_WhenProviderPackageIsPresent()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new LegacyMoqOnboardingAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.RequireExplicitMoqOnboarding);
+
+            Assert.Equal(2, codeFixTitles.Length);
+            Assert.Contains("Add [assembly: FastMoqDefaultProvider(\"moq\")]", codeFixTitles);
+            Assert.Contains("Add [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)]", codeFixTitles);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_CodeFix_ShouldAddAssemblyRegistration_WhenExplicitRegisterAndSelectIsPreferred()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new LegacyMoqOnboardingAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.RequireExplicitMoqOnboarding,
+                codeFixTitle: "Add [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)]");
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider), SetAsDefault = true)]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2,8 +2,10 @@ using FastMoq.Analyzers;
 using FastMoq.Analyzers.Analyzers;
 using FastMoq.Analyzers.CodeFixes;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -2007,6 +2009,64 @@ class Sample
         }
 
         [Fact]
+        public async Task TrackedAddTypeMigrationAnalyzer_ShouldReport_WhenTrackedReplacementUsesGetRequiredTrackedMockInstance()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        string? Value { get; set; }
+    }
+
+    void Execute(Mocker mocks)
+    {
+        mocks.GetOrCreateMock<IService>();
+        mocks.AddType<IService>(mocks.GetRequiredTrackedMock<IService>().Instance, replace: true);
+        var resolved = mocks.GetObject<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedAddTypeMigrationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration));
+            Assert.Contains("GetObject<T>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task TrackedAddTypeMigrationAnalyzer_ShouldReport_WhenNonGenericAddTypeFactoryReturnsTrackedObject()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Moq;
+
+class Sample
+{
+    interface IService
+    {
+        string? Value { get; set; }
+    }
+
+    sealed class FakeService : IService
+    {
+        public string? Value { get; set; }
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var tracked = mocks.GetMock<IService>();
+        mocks.AddType(typeof(IService), typeof(FakeService), _ => tracked.Object, replace: true);
+        var resolved = mocks.GetObject<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedAddTypeMigrationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration));
+            Assert.Contains("GetObject<T>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
         public async Task TrackedAddTypeMigrationAnalyzer_ShouldNotReport_WhenConcreteFakeReplacementOwnsResolution()
         {
             const string SOURCE = @"
@@ -2176,6 +2236,27 @@ class Sample
         }
 
         [Fact]
+        public void FastMoqMigrationCodeFixProvider_ShouldTreatAssemblyDefaultProviderNamesCaseInsensitively()
+        {
+            const string SOURCE = @"
+using FastMoq.Providers;
+
+[assembly: FastMoqDefaultProvider(""MOQ"")]
+";
+
+            var compilationUnit = CSharpSyntaxTree.ParseText(SOURCE).GetCompilationUnitRoot();
+            var hasDefaultProviderMethod = typeof(FastMoqMigrationCodeFixProvider).GetMethod(
+                "HasAssemblyDefaultProviderAttribute",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(hasDefaultProviderMethod);
+            var result = hasDefaultProviderMethod!.Invoke(null, [compilationUnit, "moq"]);
+
+            Assert.IsType<bool>(result);
+            Assert.True((bool) result!);
+        }
+
+        [Fact]
         public async Task LegacyMoqOnboardingAnalyzer_CodeFix_ShouldOfferBothMoqOnboardingChoices_WhenProviderPackageIsPresent()
         {
             const string SOURCE = @"
@@ -2251,6 +2332,28 @@ class Sample
 }");
 
             Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public void FastMoqMigrationCodeFixProvider_ShouldTreatAssemblyRegisteredDefaultProviderNamesCaseInsensitively()
+        {
+            const string SOURCE = @"
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+[assembly: FastMoqRegisterProvider(""MOQ"", typeof(MoqMockingProvider), SetAsDefault = true)]
+";
+
+            var compilationUnit = CSharpSyntaxTree.ParseText(SOURCE).GetCompilationUnitRoot();
+            var hasRegisteredDefaultProviderMethod = typeof(FastMoqMigrationCodeFixProvider).GetMethod(
+                "HasAssemblyRegisteredDefaultProviderAttribute",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(hasRegisteredDefaultProviderMethod);
+            var result = hasRegisteredDefaultProviderMethod!.Invoke(null, [compilationUnit, "moq"]);
+
+            Assert.IsType<bool>(result);
+            Assert.True((bool) result!);
         }
 
         [Fact]

--- a/FastMoq.Analyzers/Analyzers/LegacyMoqOnboardingAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/LegacyMoqOnboardingAnalyzer.cs
@@ -1,0 +1,121 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class LegacyMoqOnboardingAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.RequireExplicitMoqOnboarding);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(RegisterCompilationAnalysis);
+        }
+
+        private static void RegisterCompilationAnalysis(CompilationStartAnalysisContext context)
+        {
+            var moqSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
+            var hasExplicitMoqProviderPackage = FastMoqAnalysisHelpers.HasMoqProviderPackage(context.Compilation);
+
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqSelectedByDefault, hasExplicitMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqSelectedByDefault, hasExplicitMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        {
+            var invocationExpression = (InvocationExpressionSyntax) context.Node;
+            if (!TryGetLegacyMoqApi(invocationExpression, context.SemanticModel, context.CancellationToken, out var apiName) ||
+                IsExplicitlyOnboarded(invocationExpression, context.SemanticModel, context.CancellationToken, moqSelectedByDefault, hasExplicitMoqProviderPackage))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.RequireExplicitMoqOnboarding,
+                FastMoqAnalysisHelpers.GetTargetNameLocation(invocationExpression.Expression),
+                apiName));
+        }
+
+        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        {
+            var memberAccessExpression = (MemberAccessExpressionSyntax) context.Node;
+            if (!TryGetLegacyMoqApi(memberAccessExpression, context.SemanticModel, context.CancellationToken, out var apiName) ||
+                IsExplicitlyOnboarded(memberAccessExpression, context.SemanticModel, context.CancellationToken, moqSelectedByDefault, hasExplicitMoqProviderPackage))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.RequireExplicitMoqOnboarding,
+                memberAccessExpression.Name.GetLocation(),
+                apiName));
+        }
+
+        private static bool IsExplicitlyOnboarded(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        {
+            return hasExplicitMoqProviderPackage &&
+                (moqSelectedByDefault || FastMoqAnalysisHelpers.HasProviderSelectionInScope(node, semanticModel, FastMoqAnalysisHelpers.MoqProviderName, cancellationToken));
+        }
+
+        private static bool TryGetLegacyMoqApi(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string apiName)
+        {
+            apiName = string.Empty;
+            if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) || method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (FastMoqAnalysisHelpers.IsFastMoqVerifyLogger(method))
+            {
+                apiName = "VerifyLogger(...)";
+                return true;
+            }
+
+            if (method.ContainingType.ToDisplayString() != FastMoqAnalysisHelpers.FastMoqMockerTypeName)
+            {
+                return false;
+            }
+
+            apiName = method.Name switch
+            {
+                "GetMock" => "GetMock<T>()",
+                "GetRequiredMock" => "GetRequiredMock(...)",
+                "CreateMock" => "CreateMock<T>(...)",
+                "CreateMockInstance" => "CreateMockInstance<T>(...)",
+                "CreateDetachedMock" => "CreateDetachedMock<T>(...)",
+                _ => string.Empty,
+            };
+
+            return apiName.Length > 0;
+        }
+
+        private static bool TryGetLegacyMoqApi(MemberAccessExpressionSyntax memberAccessExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string apiName)
+        {
+            apiName = string.Empty;
+            if (!FastMoqAnalysisHelpers.TryGetPropertySymbol(memberAccessExpression, semanticModel, cancellationToken, out var property) || property is null)
+            {
+                return false;
+            }
+
+            if (property.Name != "Mock")
+            {
+                return false;
+            }
+
+            if (!FastMoqAnalysisHelpers.IsFastMoqMockModelType(property.ContainingType))
+            {
+                return false;
+            }
+
+            apiName = "MockModel.Mock";
+            return true;
+        }
+    }
+}

--- a/FastMoq.Analyzers/Analyzers/NativeMockAuthoringAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/NativeMockAuthoringAnalyzer.cs
@@ -30,7 +30,7 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            var preferredAccess = providerName == "moq"
+            var preferredAccess = providerName == FastMoqAnalysisHelpers.MoqProviderName
                 ? "GetOrCreateMock<T>().AsMoq()"
                 : "GetOrCreateMock<T>().AsNSubstitute()";
 

--- a/FastMoq.Analyzers/Analyzers/ProviderBootstrapAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/ProviderBootstrapAnalyzer.cs
@@ -20,8 +20,8 @@ namespace FastMoq.Analyzers.Analyzers
 
         private static void RegisterCompilationAnalysis(CompilationStartAnalysisContext context)
         {
-            var moqSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, "moq", CancellationToken.None);
-            var nsubstituteSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, "nsubstitute", CancellationToken.None);
+            var moqSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
+            var nsubstituteSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.NSubstituteProviderName, CancellationToken.None);
 
             context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqSelectedByDefault, nsubstituteSelectedByDefault), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
             context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqSelectedByDefault, nsubstituteSelectedByDefault), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
@@ -37,8 +37,8 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            if ((providerName == "moq" && moqSelectedByDefault) ||
-                (providerName == "nsubstitute" && nsubstituteSelectedByDefault) ||
+            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqSelectedByDefault) ||
+                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteSelectedByDefault) ||
                 FastMoqAnalysisHelpers.HasProviderSelectionInScope(invocationExpression, context.SemanticModel, providerName, context.CancellationToken))
             {
                 return;
@@ -61,8 +61,8 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            if ((providerName == "moq" && moqSelectedByDefault) ||
-                (providerName == "nsubstitute" && nsubstituteSelectedByDefault) ||
+            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqSelectedByDefault) ||
+                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteSelectedByDefault) ||
                 FastMoqAnalysisHelpers.HasProviderSelectionInScope(memberAccessExpression, context.SemanticModel, providerName, context.CancellationToken))
             {
                 return;

--- a/FastMoq.Analyzers/Analyzers/TrackedAddTypeMigrationAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/TrackedAddTypeMigrationAnalyzer.cs
@@ -49,8 +49,8 @@ namespace FastMoq.Analyzers.Analyzers
             method = method.ReducedFrom ?? method;
             if (!FastMoqAnalysisHelpers.IsFastMoqMockerAddTypeMethod(method) ||
                 !TryGetRegisteredServiceType(invocationExpression, method, semanticModel, cancellationToken, out var serviceType) ||
-                invocationExpression.ArgumentList.Arguments.Count == 0 ||
-                !IsTrackedReplacementOrigin(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, serviceType, new HashSet<ISymbol>(SymbolEqualityComparer.Default)) ||
+                !TryGetReplacementOriginExpression(invocationExpression, method, out var replacementOriginExpression) ||
+                !IsTrackedReplacementOrigin(replacementOriginExpression, semanticModel, cancellationToken, serviceType, new HashSet<ISymbol>(SymbolEqualityComparer.Default)) ||
                 !TryFindTrackedSensitiveUsage(invocationExpression, semanticModel, cancellationToken, serviceType, out conflictingApi))
             {
                 return false;
@@ -83,6 +83,31 @@ namespace FastMoq.Analyzers.Analyzers
 
             serviceType = semanticModel.GetTypeInfo(typeOfExpression.Type, cancellationToken).Type!;
             return serviceType is not null;
+        }
+
+        private static bool TryGetReplacementOriginExpression(InvocationExpressionSyntax invocationExpression, IMethodSymbol method, out ExpressionSyntax replacementOriginExpression)
+        {
+            replacementOriginExpression = null!;
+            var arguments = invocationExpression.ArgumentList.Arguments;
+
+            if (method.TypeArguments.Length > 0)
+            {
+                if (arguments.Count == 0)
+                {
+                    return false;
+                }
+
+                replacementOriginExpression = arguments[0].Expression;
+                return true;
+            }
+
+            if (arguments.Count < 3)
+            {
+                return false;
+            }
+
+            replacementOriginExpression = arguments[2].Expression;
+            return true;
         }
 
         private static bool IsTrackedReplacementOrigin(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType, HashSet<ISymbol> visitedSymbols)
@@ -130,8 +155,8 @@ namespace FastMoq.Analyzers.Analyzers
             method = method.ReducedFrom ?? method;
             return method.TypeArguments.Length == 1 &&
                 SymbolEqualityComparer.Default.Equals(method.TypeArguments[0], serviceType) &&
-                method.ContainingType.ToDisplayString() == "FastMoq.Mocker" &&
-                method.Name is "GetMock" or "GetRequiredMock" or "GetOrCreateMock" or "GetObject" or "GetRequiredObject";
+                method.ContainingType.ToDisplayString() == FastMoqAnalysisHelpers.FastMoqMockerTypeName &&
+                method.Name is "GetMock" or "GetRequiredMock" or "GetOrCreateMock" or "GetObject" or "GetRequiredObject" or "TryGetTrackedMock" or "GetRequiredTrackedMock";
         }
 
         private static bool TryFollowLocalInitializer(IdentifierNameSyntax identifierName, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType, HashSet<ISymbol> visitedSymbols)
@@ -187,7 +212,7 @@ namespace FastMoq.Analyzers.Analyzers
                 return false;
             }
 
-            if (method.ContainingType.ToDisplayString() == "FastMoq.Mocker")
+            if (method.ContainingType.ToDisplayString() == FastMoqAnalysisHelpers.FastMoqMockerTypeName)
             {
                 conflictingApi = method.Name switch
                 {

--- a/FastMoq.Analyzers/Analyzers/TrackedAddTypeMigrationAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/TrackedAddTypeMigrationAnalyzer.cs
@@ -1,0 +1,255 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TrackedAddTypeMigrationAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PreserveTrackedResolutionDuringAddTypeMigration);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax) context.Node;
+            if (!TryGetDiagnosticArguments(invocationExpression, context.SemanticModel, context.CancellationToken, out var serviceTypeName, out var conflictingApi))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.PreserveTrackedResolutionDuringAddTypeMigration,
+                FastMoqAnalysisHelpers.GetTargetNameLocation(invocationExpression.Expression),
+                serviceTypeName,
+                conflictingApi));
+        }
+
+        private static bool TryGetDiagnosticArguments(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string serviceTypeName, out string conflictingApi)
+        {
+            serviceTypeName = string.Empty;
+            conflictingApi = string.Empty;
+
+            if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (!FastMoqAnalysisHelpers.IsFastMoqMockerAddTypeMethod(method) ||
+                !TryGetRegisteredServiceType(invocationExpression, method, semanticModel, cancellationToken, out var serviceType) ||
+                invocationExpression.ArgumentList.Arguments.Count == 0 ||
+                !IsTrackedReplacementOrigin(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, serviceType, new HashSet<ISymbol>(SymbolEqualityComparer.Default)) ||
+                !TryFindTrackedSensitiveUsage(invocationExpression, semanticModel, cancellationToken, serviceType, out conflictingApi))
+            {
+                return false;
+            }
+
+            serviceTypeName = serviceType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            return true;
+        }
+
+        private static bool TryGetRegisteredServiceType(InvocationExpressionSyntax invocationExpression, IMethodSymbol method, SemanticModel semanticModel, CancellationToken cancellationToken, out ITypeSymbol serviceType)
+        {
+            serviceType = null!;
+
+            if (method.TypeArguments.Length > 0)
+            {
+                serviceType = method.TypeArguments[0];
+                return true;
+            }
+
+            if (invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            var firstArgument = FastMoqAnalysisHelpers.Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (firstArgument is not TypeOfExpressionSyntax typeOfExpression)
+            {
+                return false;
+            }
+
+            serviceType = semanticModel.GetTypeInfo(typeOfExpression.Type, cancellationToken).Type!;
+            return serviceType is not null;
+        }
+
+        private static bool IsTrackedReplacementOrigin(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType, HashSet<ISymbol> visitedSymbols)
+        {
+            expression = FastMoqAnalysisHelpers.Unwrap(expression);
+
+            switch (expression)
+            {
+                case LambdaExpressionSyntax lambdaExpression:
+                    return TryGetReturnedExpression(lambdaExpression, out var lambdaReturnExpression) &&
+                        IsTrackedReplacementOrigin(lambdaReturnExpression, semanticModel, cancellationToken, serviceType, visitedSymbols);
+
+                case AnonymousMethodExpressionSyntax anonymousMethodExpression:
+                    return TryGetReturnedExpression(anonymousMethodExpression, out var anonymousReturnExpression) &&
+                        IsTrackedReplacementOrigin(anonymousReturnExpression, semanticModel, cancellationToken, serviceType, visitedSymbols);
+
+                case MemberAccessExpressionSyntax memberAccessExpression when memberAccessExpression.Name.Identifier.ValueText is "Object" or "Instance":
+                    return IsTrackedReplacementOrigin(memberAccessExpression.Expression, semanticModel, cancellationToken, serviceType, visitedSymbols);
+
+                case InvocationExpressionSyntax invocationExpression:
+                    return IsTrackedSourceInvocation(invocationExpression, semanticModel, cancellationToken, serviceType);
+
+                case IdentifierNameSyntax identifierName:
+                    return TryFollowLocalInitializer(identifierName, semanticModel, cancellationToken, serviceType, visitedSymbols);
+
+                case CastExpressionSyntax castExpression:
+                    return IsTrackedReplacementOrigin(castExpression.Expression, semanticModel, cancellationToken, serviceType, visitedSymbols);
+
+                case ConditionalExpressionSyntax conditionalExpression:
+                    return IsTrackedReplacementOrigin(conditionalExpression.WhenTrue, semanticModel, cancellationToken, serviceType, visitedSymbols) ||
+                        IsTrackedReplacementOrigin(conditionalExpression.WhenFalse, semanticModel, cancellationToken, serviceType, visitedSymbols);
+            }
+
+            return false;
+        }
+
+        private static bool IsTrackedSourceInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType)
+        {
+            if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            return method.TypeArguments.Length == 1 &&
+                SymbolEqualityComparer.Default.Equals(method.TypeArguments[0], serviceType) &&
+                method.ContainingType.ToDisplayString() == "FastMoq.Mocker" &&
+                method.Name is "GetMock" or "GetRequiredMock" or "GetOrCreateMock" or "GetObject" or "GetRequiredObject";
+        }
+
+        private static bool TryFollowLocalInitializer(IdentifierNameSyntax identifierName, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType, HashSet<ISymbol> visitedSymbols)
+        {
+            if (semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol is not ILocalSymbol localSymbol ||
+                !visitedSymbols.Add(localSymbol))
+            {
+                return false;
+            }
+
+            var declaration = localSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken) as VariableDeclaratorSyntax;
+            return declaration?.Initializer?.Value is ExpressionSyntax initializer &&
+                IsTrackedReplacementOrigin(initializer, semanticModel, cancellationToken, serviceType, visitedSymbols);
+        }
+
+        private static bool TryFindTrackedSensitiveUsage(InvocationExpressionSyntax addTypeInvocation, SemanticModel semanticModel, CancellationToken cancellationToken, ITypeSymbol serviceType, out string conflictingApi)
+        {
+            conflictingApi = string.Empty;
+            var root = addTypeInvocation.SyntaxTree.GetRoot(cancellationToken);
+
+            foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (addTypeInvocation.Span.Contains(invocationExpression.Span))
+                {
+                    continue;
+                }
+
+                if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                    method is null)
+                {
+                    continue;
+                }
+
+                method = method.ReducedFrom ?? method;
+                if (!IsTrackedSensitiveUsage(method, serviceType, out conflictingApi))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsTrackedSensitiveUsage(IMethodSymbol method, ITypeSymbol serviceType, out string conflictingApi)
+        {
+            conflictingApi = string.Empty;
+
+            if (method.TypeArguments.Length == 0 ||
+                !SymbolEqualityComparer.Default.Equals(method.TypeArguments[0], serviceType))
+            {
+                return false;
+            }
+
+            if (method.ContainingType.ToDisplayString() == "FastMoq.Mocker")
+            {
+                conflictingApi = method.Name switch
+                {
+                    "GetObject" => "GetObject<T>()",
+                    "GetRequiredObject" => "GetRequiredObject<T>()",
+                    "GetRequiredTrackedMock" => "GetRequiredTrackedMock<T>()",
+                    "TryGetTrackedMock" => "TryGetTrackedMock<T>(...)",
+                    "GetMockModel" => "GetMockModel<T>()",
+                    _ => string.Empty,
+                };
+
+                return conflictingApi.Length > 0;
+            }
+
+            if (!method.IsExtensionMethod || !method.ContainingNamespace.ToDisplayString().StartsWith("FastMoq", System.StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            conflictingApi = method.Name switch
+            {
+                "AddPropertyState" => "AddPropertyState<TService>(...)",
+                "AddPropertySetterCapture" => "AddPropertySetterCapture<TService, TValue>(...)",
+                _ => string.Empty,
+            };
+
+            return conflictingApi.Length > 0;
+        }
+
+        private static bool TryGetReturnedExpression(LambdaExpressionSyntax lambdaExpression, out ExpressionSyntax returnedExpression)
+        {
+            returnedExpression = null!;
+            if (lambdaExpression.Body is ExpressionSyntax expressionBody)
+            {
+                returnedExpression = expressionBody;
+                return true;
+            }
+
+            if (lambdaExpression.Body is BlockSyntax blockSyntax)
+            {
+                var returnStatement = blockSyntax.Statements.OfType<ReturnStatementSyntax>().SingleOrDefault();
+                if (returnStatement?.Expression is ExpressionSyntax returned)
+                {
+                    returnedExpression = returned;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetReturnedExpression(AnonymousMethodExpressionSyntax anonymousMethodExpression, out ExpressionSyntax returnedExpression)
+        {
+            returnedExpression = null!;
+            var returnStatement = anonymousMethodExpression.Block?.Statements.OfType<ReturnStatementSyntax>().SingleOrDefault();
+            if (returnStatement?.Expression is not ExpressionSyntax returned)
+            {
+                return false;
+            }
+
+            returnedExpression = returned;
+            return true;
+        }
+    }
+}

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -504,7 +504,7 @@ namespace FastMoq.Analyzers.CodeFixes
                     var firstArgument = attribute.ArgumentList?.Arguments.FirstOrDefault();
                     if (firstArgument?.Expression is LiteralExpressionSyntax literalExpression &&
                         literalExpression.IsKind(SyntaxKind.StringLiteralExpression) &&
-                        literalExpression.Token.ValueText == providerName)
+                        string.Equals(literalExpression.Token.ValueText, providerName, System.StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
                     }
@@ -535,7 +535,7 @@ namespace FastMoq.Analyzers.CodeFixes
                     var firstArgument = argumentList?.Arguments.FirstOrDefault();
                     if (firstArgument?.Expression is not LiteralExpressionSyntax literalExpression ||
                         !literalExpression.IsKind(SyntaxKind.StringLiteralExpression) ||
-                        literalExpression.Token.ValueText != providerName)
+                        !string.Equals(literalExpression.Token.ValueText, providerName, System.StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -24,7 +24,8 @@ namespace FastMoq.Analyzers.CodeFixes
             DiagnosticIds.PreferTypedServiceProviderHelpers,
             DiagnosticIds.UseExplicitOptionalParameterResolution,
             DiagnosticIds.ReplaceInitializeCompatibilityWrapper,
-            DiagnosticIds.PreferSetupOptionsHelper);
+            DiagnosticIds.PreferSetupOptionsHelper,
+            DiagnosticIds.RequireExplicitMoqOnboarding);
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -194,6 +195,30 @@ namespace FastMoq.Analyzers.CodeFixes
                                 "Use SetupOptions(...)",
                                 cancellationToken => ReplaceSetupOptionsInvocationAsync(document, invocationExpression, cancellationToken),
                                 nameof(DiagnosticIds.PreferSetupOptionsHelper)),
+                            diagnostic);
+                        break;
+                    }
+
+                case DiagnosticIds.RequireExplicitMoqOnboarding:
+                    {
+                        var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                        if (semanticModel is null || !FastMoqAnalysisHelpers.HasMoqProviderPackage(semanticModel.Compilation))
+                        {
+                            return;
+                        }
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Add [assembly: FastMoqDefaultProvider(\"moq\")]",
+                                cancellationToken => AddAssemblyDefaultProviderAsync(document, FastMoqAnalysisHelpers.MoqProviderName, cancellationToken),
+                                nameof(DiagnosticIds.RequireExplicitMoqOnboarding) + ".default"),
+                            diagnostic);
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Add [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)]",
+                                cancellationToken => AddAssemblyRegisteredDefaultProviderAsync(document, FastMoqAnalysisHelpers.MoqProviderName, cancellationToken),
+                                nameof(DiagnosticIds.RequireExplicitMoqOnboarding) + ".register"),
                             diagnostic);
                         break;
                     }
@@ -431,6 +456,141 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementMemberAccess = memberAccess.WithName(replacementName);
             var updatedRoot = root.ReplaceNode(memberAccess, replacementMemberAccess);
             return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static async Task<Document> AddAssemblyDefaultProviderAsync(Document document, string providerName, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) as CompilationUnitSyntax;
+            if (root is null || HasAssemblyDefaultProviderAttribute(root, providerName))
+            {
+                return document;
+            }
+
+            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectiveIfMissing(root, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+            updatedRoot = updatedRoot.AddAttributeLists(CreateAssemblyDefaultProviderAttribute(providerName));
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static async Task<Document> AddAssemblyRegisteredDefaultProviderAsync(Document document, string providerName, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) as CompilationUnitSyntax;
+            if (root is null || HasAssemblyRegisteredDefaultProviderAttribute(root, providerName))
+            {
+                return document;
+            }
+
+            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectivesIfMissing(root, [FastMoqAnalysisHelpers.FastMoqProvidersNamespace, FastMoqAnalysisHelpers.MoqProviderNamespace]);
+            updatedRoot = updatedRoot.AddAttributeLists(CreateAssemblyRegisteredDefaultProviderAttribute(providerName));
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static bool HasAssemblyDefaultProviderAttribute(CompilationUnitSyntax compilationUnit, string providerName)
+        {
+            foreach (var attributeList in compilationUnit.AttributeLists)
+            {
+                if (attributeList.Target?.Identifier.IsKind(SyntaxKind.AssemblyKeyword) != true)
+                {
+                    continue;
+                }
+
+                foreach (var attribute in attributeList.Attributes)
+                {
+                    var attributeName = attribute.Name.ToString();
+                    if (attributeName is not "FastMoqDefaultProvider" and not "FastMoqDefaultProviderAttribute" and not "FastMoq.Providers.FastMoqDefaultProvider" and not "FastMoq.Providers.FastMoqDefaultProviderAttribute")
+                    {
+                        continue;
+                    }
+
+                    var firstArgument = attribute.ArgumentList?.Arguments.FirstOrDefault();
+                    if (firstArgument?.Expression is LiteralExpressionSyntax literalExpression &&
+                        literalExpression.IsKind(SyntaxKind.StringLiteralExpression) &&
+                        literalExpression.Token.ValueText == providerName)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasAssemblyRegisteredDefaultProviderAttribute(CompilationUnitSyntax compilationUnit, string providerName)
+        {
+            foreach (var attributeList in compilationUnit.AttributeLists)
+            {
+                if (attributeList.Target?.Identifier.IsKind(SyntaxKind.AssemblyKeyword) != true)
+                {
+                    continue;
+                }
+
+                foreach (var attribute in attributeList.Attributes)
+                {
+                    var attributeName = attribute.Name.ToString();
+                    if (attributeName is not "FastMoqRegisterProvider" and not "FastMoqRegisterProviderAttribute" and not "FastMoq.Providers.FastMoqRegisterProvider" and not "FastMoq.Providers.FastMoqRegisterProviderAttribute")
+                    {
+                        continue;
+                    }
+
+                    var argumentList = attribute.ArgumentList;
+                    var firstArgument = argumentList?.Arguments.FirstOrDefault();
+                    if (firstArgument?.Expression is not LiteralExpressionSyntax literalExpression ||
+                        !literalExpression.IsKind(SyntaxKind.StringLiteralExpression) ||
+                        literalExpression.Token.ValueText != providerName)
+                    {
+                        continue;
+                    }
+
+                    if (argumentList is not null && argumentList.Arguments.Any(argument =>
+                            argument.NameEquals?.Name.Identifier.ValueText == FastMoqAnalysisHelpers.RegisterProviderSetAsDefaultPropertyName &&
+                            argument.Expression is LiteralExpressionSyntax boolLiteral &&
+                            boolLiteral.IsKind(SyntaxKind.TrueLiteralExpression)))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static AttributeListSyntax CreateAssemblyDefaultProviderAttribute(string providerName)
+        {
+            return SyntaxFactory.AttributeList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Attribute(
+                            SyntaxFactory.IdentifierName("FastMoqDefaultProvider"),
+                            SyntaxFactory.AttributeArgumentList(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    SyntaxFactory.AttributeArgument(
+                                        SyntaxFactory.LiteralExpression(
+                                            SyntaxKind.StringLiteralExpression,
+                                            SyntaxFactory.Literal(providerName))))))))
+                .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)));
+        }
+
+        private static AttributeListSyntax CreateAssemblyRegisteredDefaultProviderAttribute(string providerName)
+        {
+            return SyntaxFactory.AttributeList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Attribute(
+                            SyntaxFactory.IdentifierName("FastMoqRegisterProvider"),
+                            SyntaxFactory.AttributeArgumentList(
+                                SyntaxFactory.SeparatedList<AttributeArgumentSyntax>(
+                                [
+                                    SyntaxFactory.AttributeArgument(
+                                        SyntaxFactory.LiteralExpression(
+                                            SyntaxKind.StringLiteralExpression,
+                                            SyntaxFactory.Literal(providerName))),
+                                    SyntaxFactory.AttributeArgument(
+                                        SyntaxFactory.TypeOfExpression(
+                                            SyntaxFactory.IdentifierName(FastMoqAnalysisHelpers.MoqProviderTypeName))),
+                                    SyntaxFactory.AttributeArgument(
+                                        SyntaxFactory.NameEquals(
+                                            SyntaxFactory.IdentifierName(FastMoqAnalysisHelpers.RegisterProviderSetAsDefaultPropertyName)),
+                                        null,
+                                        SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)),
+                                ])))))
+                .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)));
         }
 
         private static SyntaxNode AddUsingDirectiveIfMissing(SyntaxNode root, string namespaceName)

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -194,5 +194,23 @@ namespace FastMoq.Analyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "When the system under test has multiple same-type keyed constructor dependencies, an unkeyed test double can collapse distinct roles into one object and hide routing bugs. Prefer keyed FastMoq setup or explicit separate doubles.");
+
+        public static readonly DiagnosticDescriptor PreserveTrackedResolutionDuringAddTypeMigration = new(
+            DiagnosticIds.PreserveTrackedResolutionDuringAddTypeMigration,
+            "Preserve tracked resolution when migrating to AddType",
+            "AddType<{0}>(...) replaces tracked resolution for '{0}', but this file still uses '{1}' for the same service. Keep a tracked mock/helper path instead of rewriting this dependency to AddType(...).",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "AddType(...) is for concrete replacement. When a migrated helper still relies on tracked resolution, property-state helpers, or setter-capture helpers for the same service, replacing the tracked path with AddType(...) can silently change behavior. Prefer GetOrCreateMock<T>(), GetRequiredTrackedMock<T>(), AddPropertyState<TService>(...), or AddPropertySetterCapture<TService, TValue>(...) in those flows.");
+
+        public static readonly DiagnosticDescriptor RequireExplicitMoqOnboarding = new(
+            DiagnosticIds.RequireExplicitMoqOnboarding,
+            "Add explicit Moq onboarding for legacy compatibility usage",
+            "Legacy Moq-shaped FastMoq API '{0}' is in use without explicit Moq onboarding. If this project stays on FastMoq.Core, add 'FastMoq.Provider.Moq' and select 'moq' with [assembly: FastMoqDefaultProvider(\"moq\")] or [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)].",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Core-only projects can keep legacy Moq-shaped FastMoq usage during migration, but that path should be explicit. Add the FastMoq.Provider.Moq package when staying on FastMoq.Core, and declare moq as the selected provider so future cleanup and analyzer guidance stay deterministic.");
     }
 }

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -23,5 +23,7 @@ namespace FastMoq.Analyzers
         public const string PreferSetupOptionsHelper = "FMOQ0019";
         public const string PreferPropertySetterCaptureHelper = "FMOQ0020";
         public const string PreferPropertyStateHelper = "FMOQ0021";
+        public const string PreserveTrackedResolutionDuringAddTypeMigration = "FMOQ0022";
+        public const string RequireExplicitMoqOnboarding = "FMOQ0023";
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -40,6 +40,20 @@ namespace FastMoq.Analyzers
 
     internal static class FastMoqAnalysisHelpers
     {
+        internal const string FastMoqMockerTypeName = "FastMoq.Mocker";
+        internal const string FastMoqMockModelTypeName = "FastMoq.Models.MockModel";
+        internal const string FastMoqMockModelGenericTypeName = "FastMoq.Models.MockModel<T>";
+        internal const string FastMoqProvidersNamespace = "FastMoq.Providers";
+        internal const string FastMoqMoqProviderAssemblyName = "FastMoq.Provider.Moq";
+        internal const string FastMoqNSubstituteProviderAssemblyName = "FastMoq.Provider.NSubstitute";
+        internal const string MoqProviderNamespace = "FastMoq.Providers.MoqProvider";
+        internal const string NSubstituteProviderNamespace = "FastMoq.Providers.NSubstituteProvider";
+        internal const string MockingProviderRegistryTypeName = "FastMoq.Providers.MockingProviderRegistry";
+        internal const string MoqProviderMetadataName = "FastMoq.Providers.MoqProvider.MoqMockingProvider";
+        internal const string MoqProviderTypeName = "MoqMockingProvider";
+        internal const string MoqProviderName = "moq";
+        internal const string NSubstituteProviderName = "nsubstitute";
+        internal const string RegisterProviderSetAsDefaultPropertyName = "SetAsDefault";
         private const string FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqDefaultProviderAttribute";
         private const string FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqRegisterProviderAttribute";
         private const string FASTMOQ_MOCKER_TEST_BASE_METADATA_NAME = "MockerTestBase`1";
@@ -80,10 +94,26 @@ namespace FastMoq.Analyzers
             return method is not null;
         }
 
+        public static bool HasMoqProviderPackage(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName(MoqProviderMetadataName) is not null;
+        }
+
+        public static bool IsFastMoqMockModelType(ITypeSymbol type)
+        {
+            if (type is not INamedTypeSymbol namedType)
+            {
+                return false;
+            }
+
+            var originalDefinitionName = namedType.OriginalDefinition.ToDisplayString();
+            return originalDefinitionName is FastMoqMockModelTypeName or FastMoqMockModelGenericTypeName;
+        }
+
         public static bool IsFastMoqMockerMethod(IMethodSymbol method, string methodName)
         {
             method = method.ReducedFrom ?? method;
-            return method.Name == methodName && method.ContainingType.ToDisplayString() == "FastMoq.Mocker";
+            return method.Name == methodName && method.ContainingType.ToDisplayString() == FastMoqMockerTypeName;
         }
 
         public static bool IsFastMoqVerifyLogger(IMethodSymbol method)
@@ -100,13 +130,13 @@ namespace FastMoq.Analyzers
         public static bool IsFastMoqInitializeMethod(IMethodSymbol method)
         {
             method = method.ReducedFrom ?? method;
-            return method.Name == "Initialize" && method.ContainingType.ToDisplayString() == "FastMoq.Mocker";
+            return method.Name == "Initialize" && method.ContainingType.ToDisplayString() == FastMoqMockerTypeName;
         }
 
         public static bool IsFastMoqMockerAddTypeMethod(IMethodSymbol method)
         {
             method = method.ReducedFrom ?? method;
-            return method.Name == "AddType" && method.ContainingType.ToDisplayString() == "FastMoq.Mocker";
+            return method.Name == "AddType" && method.ContainingType.ToDisplayString() == FastMoqMockerTypeName;
         }
 
         public static bool TryGetRequiredProvider(IMethodSymbol method, out string providerName, out string apiName)
@@ -115,24 +145,24 @@ namespace FastMoq.Analyzers
             providerName = string.Empty;
             apiName = method.Name;
 
-            if (method.ContainingType.ToDisplayString() == "FastMoq.Mocker" &&
+            if (method.ContainingType.ToDisplayString() == FastMoqMockerTypeName &&
                 method.Name is "GetMock" or "GetRequiredMock" or "CreateMockInstance" or "CreateDetachedMock")
             {
-                providerName = "moq";
+                providerName = MoqProviderName;
                 return true;
             }
 
-            if (method.ContainingAssembly.Name == "FastMoq.Provider.Moq" &&
+            if (method.ContainingAssembly.Name == FastMoqMoqProviderAssemblyName &&
                 (method.ContainingType.Name == "IFastMockMoqExtensions" || method.ContainingType.Name == "MockerHttpMoqExtensions"))
             {
-                providerName = "moq";
+                providerName = MoqProviderName;
                 return true;
             }
 
-            if (method.ContainingAssembly.Name == "FastMoq.Provider.NSubstitute" &&
+            if (method.ContainingAssembly.Name == FastMoqNSubstituteProviderAssemblyName &&
                 method.ContainingType.Name == "IFastMockNSubstituteExtensions")
             {
-                providerName = "nsubstitute";
+                providerName = NSubstituteProviderName;
                 return true;
             }
 
@@ -148,9 +178,9 @@ namespace FastMoq.Analyzers
             {
                 for (var containingType = property.ContainingType; containingType is not null; containingType = containingType.BaseType)
                 {
-                    if (containingType.ToDisplayString() == "FastMoq.Models.MockModel")
+                    if (IsFastMoqMockModelType(containingType))
                     {
-                        providerName = "moq";
+                        providerName = MoqProviderName;
                         return true;
                     }
                 }
@@ -168,7 +198,7 @@ namespace FastMoq.Analyzers
 
         public static bool IsFastMoqMockerProperty(IPropertySymbol property, string propertyName)
         {
-            return property.Name == propertyName && property.ContainingType.ToDisplayString() == "FastMoq.Mocker";
+            return property.Name == propertyName && property.ContainingType.ToDisplayString() == FastMoqMockerTypeName;
         }
 
         public static bool IsFastMoqNativeMockProperty(IPropertySymbol property)
@@ -190,7 +220,7 @@ namespace FastMoq.Analyzers
 
             for (var containingType = property.ContainingType; containingType is not null; containingType = containingType.BaseType)
             {
-                if (containingType.ToDisplayString() == "FastMoq.Models.MockModel")
+                if (IsFastMoqMockModelType(containingType))
                 {
                     return true;
                 }
@@ -551,15 +581,15 @@ namespace FastMoq.Analyzers
             providerName = string.Empty;
             providerExtensionName = string.Empty;
 
-            var usesMoqProvider = HasUsingDirective(node, "FastMoq.Providers.MoqProvider");
-            var usesNSubstituteProvider = HasUsingDirective(node, "FastMoq.Providers.NSubstituteProvider");
+            var usesMoqProvider = HasUsingDirective(node, MoqProviderNamespace);
+            var usesNSubstituteProvider = HasUsingDirective(node, NSubstituteProviderNamespace);
 
             if (usesMoqProvider == usesNSubstituteProvider)
             {
                 return false;
             }
 
-            providerName = usesMoqProvider ? "moq" : "nsubstitute";
+            providerName = usesMoqProvider ? MoqProviderName : NSubstituteProviderName;
             providerExtensionName = usesMoqProvider ? "AsMoq()" : "AsNSubstitute()";
             return true;
         }
@@ -634,7 +664,7 @@ namespace FastMoq.Analyzers
             apiName = string.Empty;
 
             method = method.ReducedFrom ?? method;
-            if (method.ContainingAssembly.Name != "FastMoq.Provider.Moq" || method.ContainingType.Name != "MockerHttpMoqExtensions")
+            if (method.ContainingAssembly.Name != FastMoqMoqProviderAssemblyName || method.ContainingType.Name != "MockerHttpMoqExtensions")
             {
                 return false;
             }
@@ -1930,7 +1960,7 @@ namespace FastMoq.Analyzers
             var invokeMethod = namedType.DelegateInvokeMethod;
             return namedType.Name == "Func" &&
                    invokeMethod.Parameters.Length == 2 &&
-                   invokeMethod.Parameters[0].Type.ToDisplayString() == "FastMoq.Mocker";
+                     invokeMethod.Parameters[0].Type.ToDisplayString() == FastMoqMockerTypeName;
         }
 
         public static bool IsProviderSelectedByDefault(Compilation compilation, string providerName, CancellationToken cancellationToken)
@@ -1998,7 +2028,7 @@ namespace FastMoq.Analyzers
                 }
 
                 var setAsDefault = attribute.NamedArguments.Any(argument =>
-                    argument.Key == "SetAsDefault" &&
+                    argument.Key == RegisterProviderSetAsDefaultPropertyName &&
                     argument.Value.Value is bool isDefault &&
                     isDefault);
 
@@ -2043,7 +2073,7 @@ namespace FastMoq.Analyzers
         {
             if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
                 method is null ||
-                method.ContainingType.ToDisplayString() != "FastMoq.Providers.MockingProviderRegistry" ||
+                method.ContainingType.ToDisplayString() != MockingProviderRegistryTypeName ||
                 invocationExpression.ArgumentList.Arguments.Count == 0)
             {
                 return false;

--- a/FastMoq.Core/Mocker.ProviderVerify.cs
+++ b/FastMoq.Core/Mocker.ProviderVerify.cs
@@ -49,10 +49,10 @@ namespace FastMoq
         /// using the supplied constructor arguments for concrete mock creation.
         /// </summary>
         /// <remarks>
-        /// This is a convenience overload for <see cref="GetOrCreateMock{T}(MockRequestOptions?)" /> when the request only needs constructor arguments.
+        /// This is a convenience wrapper for <see cref="GetOrCreateMock{T}(MockRequestOptions?)" /> when the request only needs constructor arguments.
         /// Use <see cref="GetOrCreateMock{T}(MockRequestOptions?)" /> when also setting a service key or non-public constructor behavior.
         /// </remarks>
-        public IFastMock<T> GetOrCreateMock<T>(params object?[] constructorArgs) where T : class
+        public IFastMock<T> GetOrCreateMockWithConstructorArgs<T>(params object?[] constructorArgs) where T : class
         {
             return GetOrCreateTypedFastMock<T>(new MockRequestOptions
             {
@@ -75,10 +75,10 @@ namespace FastMoq
         /// using the supplied constructor arguments for concrete mock creation.
         /// </summary>
         /// <remarks>
-        /// This is a convenience overload for <see cref="GetOrCreateMock(Type, MockRequestOptions?)" /> when the request only needs constructor arguments.
+        /// This is a convenience wrapper for <see cref="GetOrCreateMock(Type, MockRequestOptions?)" /> when the request only needs constructor arguments.
         /// Use <see cref="GetOrCreateMock(Type, MockRequestOptions?)" /> when also setting a service key or non-public constructor behavior.
         /// </remarks>
-        public IFastMock GetOrCreateMock(Type type, params object?[] constructorArgs)
+        public IFastMock GetOrCreateMockWithConstructorArgs(Type type, params object?[] constructorArgs)
         {
             ArgumentNullException.ThrowIfNull(type);
 

--- a/FastMoq.Core/Mocker.ProviderVerify.cs
+++ b/FastMoq.Core/Mocker.ProviderVerify.cs
@@ -45,6 +45,22 @@ namespace FastMoq
         }
 
         /// <summary>
+        /// Gets an existing tracked provider-backed mock or creates and tracks one when it does not yet exist,
+        /// using the supplied constructor arguments for concrete mock creation.
+        /// </summary>
+        /// <remarks>
+        /// This is a convenience overload for <see cref="GetOrCreateMock{T}(MockRequestOptions?)" /> when the request only needs constructor arguments.
+        /// Use <see cref="GetOrCreateMock{T}(MockRequestOptions?)" /> when also setting a service key or non-public constructor behavior.
+        /// </remarks>
+        public IFastMock<T> GetOrCreateMock<T>(params object?[] constructorArgs) where T : class
+        {
+            return GetOrCreateTypedFastMock<T>(new MockRequestOptions
+            {
+                ConstructorArgs = constructorArgs ?? Array.Empty<object?>(),
+            });
+        }
+
+        /// <summary>
         /// Gets an existing tracked provider-backed mock or creates and tracks one when it does not yet exist.
         /// Use the returned <see cref="IFastMock" /> when the test needs the tracked handle itself, and prefer <see cref="Mocker.GetObject(Type, Action{object?}?)" /> when only the instance is needed.
         /// </summary>
@@ -52,6 +68,24 @@ namespace FastMoq
         {
             ArgumentNullException.ThrowIfNull(type);
             return GetOrCreateFastMock(type, options);
+        }
+
+        /// <summary>
+        /// Gets an existing tracked provider-backed mock or creates and tracks one when it does not yet exist,
+        /// using the supplied constructor arguments for concrete mock creation.
+        /// </summary>
+        /// <remarks>
+        /// This is a convenience overload for <see cref="GetOrCreateMock(Type, MockRequestOptions?)" /> when the request only needs constructor arguments.
+        /// Use <see cref="GetOrCreateMock(Type, MockRequestOptions?)" /> when also setting a service key or non-public constructor behavior.
+        /// </remarks>
+        public IFastMock GetOrCreateMock(Type type, params object?[] constructorArgs)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            return GetOrCreateFastMock(type, new MockRequestOptions
+            {
+                ConstructorArgs = constructorArgs ?? Array.Empty<object?>(),
+            });
         }
 
         /// <summary>

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -1221,7 +1221,7 @@ namespace FastMoq
             {
                 if (Behavior.Has(MockFeatures.FailOnUnconfigured))
                 {
-                    throw new NotImplementedException("Unable to find the constructor.");
+                    throw GetConstructorResolutionException(targetType, "The requested type is an interface and strict construction does not allow fallback object resolution.");
                 }
 
                 return GetObject<T>();
@@ -1251,6 +1251,54 @@ namespace FastMoq
         internal bool ShouldAllowNonPublicConstructorsForMockRequest(bool? allowNonPublicConstructors)
         {
             return allowNonPublicConstructors ?? !ShouldCreateStrictMocks();
+        }
+
+        private static InvalidOperationException GetConstructorResolutionException(Type type, string? detail = null)
+        {
+            var message = $"Unable to find a usable constructor for type '{type}'.";
+            if (!string.IsNullOrWhiteSpace(detail))
+            {
+                message = $"{message} {detail}";
+            }
+
+            message = $"{message} {GetConstructorResolutionGuidance(type)}";
+
+            return new InvalidOperationException(message);
+        }
+
+        private static string GetConstructorResolutionGuidance(Type type)
+        {
+            if (type.IsInterface)
+            {
+                return "If the request should stay abstract, use GetObject<T>() or GetOrCreateMock<T>(), or register a concrete implementation with AddType(...).";
+            }
+
+            return "If the test must pick an exact signature, use CreateInstanceByType(...). If only non-public constructors are valid, enable InstanceCreationFlags.AllowNonPublicConstructorFallback or Policy.DefaultFallbackToNonPublicConstructors. Register required dependencies with AddType(...), AddKeyedType(...), or GetOrCreateMock(...) before creating the instance.";
+        }
+
+        private static string FormatRequestedParameterTypes(IEnumerable<Type?> parameterTypes)
+        {
+            return $"({string.Join(", ", parameterTypes.Select(parameterType => parameterType?.Name ?? "null"))})";
+        }
+
+        private static string FormatRequestedArguments(IEnumerable<object?> arguments)
+        {
+            return $"({string.Join(", ", arguments.Select(FormatRequestedArgument))})";
+        }
+
+        private static string FormatRequestedArgument(object? argument)
+        {
+            if (argument is null)
+            {
+                return "null";
+            }
+
+            if (argument is string text)
+            {
+                return $"\"{text}\"";
+            }
+
+            return $"{argument} [{argument.GetType().Name}]";
         }
 
         private ConstructorModel GetConstructorByArgs(object?[] args, Type instanceType, bool nonPublic, bool fallbackToNonPublicConstructors, OptionalParameterResolutionMode optionalParameterResolution, ConstructorAmbiguityBehavior constructorAmbiguityBehavior)
@@ -1342,7 +1390,7 @@ namespace FastMoq
 
             if (ctors.Count == 0)
             {
-                throw new NotImplementedException("Unable to find the constructor.");
+                throw GetConstructorResolutionException(type, $"Requested parameter types: {FormatRequestedParameterTypes(args)}.");
             }
 
             return ctors[0];
@@ -1361,7 +1409,7 @@ namespace FastMoq
 
             if (ctors.Count == 0)
             {
-                throw new NotImplementedException("Unable to find the constructor.");
+                throw GetConstructorResolutionException(type, $"Requested parameter types: {FormatRequestedParameterTypes(args)}.");
             }
 
             return ctors[0];
@@ -1386,7 +1434,7 @@ namespace FastMoq
                     return FindConstructor(type, true, optionalParameterResolution, args);
                 }
 
-                throw new NotImplementedException("Unable to find the constructor.");
+                throw GetConstructorResolutionException(type, $"Requested arguments: {FormatRequestedArguments(args)}.");
             }
             return filtered.FirstOrDefault(x => x.ParameterList.Length == args.Length) ?? filtered[0];
         }
@@ -1407,7 +1455,7 @@ namespace FastMoq
                     return FindConstructor(type, true, fallbackToNonPublicConstructors, optionalParameterResolution, args);
                 }
 
-                throw new NotImplementedException("Unable to find the constructor.");
+                throw GetConstructorResolutionException(type, $"Requested arguments: {FormatRequestedArguments(args)}.");
             }
 
             return filtered.FirstOrDefault(x => x.ParameterList.Length == args.Length) ?? filtered[0];
@@ -1463,7 +1511,7 @@ namespace FastMoq
             }
 
             return SelectPreferredConstructor(type, this.GetTestedConstructors(type, nonPublicConstructors), constructorAmbiguityBehavior)
-                ?? throw new NotImplementedException("Unable to find the constructor.");
+                ?? throw GetConstructorResolutionException(type, "No public or eligible non-public constructors were available after filtering.");
         }
 
         private ConstructorModel? SelectPreferredConstructor(Type type, List<ConstructorModel>? constructors)
@@ -2279,7 +2327,7 @@ namespace FastMoq
                 .Select(ci => new ConstructorModel(ci, new object?[ci.GetParameters().Length]))
                 .ToList();
             var constructor = SelectPreferredConstructor(type.InstanceType, constructors, constructorAmbiguityBehavior)
-                ?? throw new NotImplementedException("Unable to find the constructor.");
+                ?? throw GetConstructorResolutionException(type.InstanceType, "No usable constructor was available to infer argument data.");
 
             return constructor.ConstructorInfo == null
                 ? Array.Empty<object?>()

--- a/FastMoq.Core/MockerTestBase.cs
+++ b/FastMoq.Core/MockerTestBase.cs
@@ -121,13 +121,13 @@ namespace FastMoq
         #endregion
 
         /// <summary>
-        ///     Waits for an action.
+        /// Waits until <paramref name="logic" /> returns a value other than <c>default(T)</c>.
         /// </summary>
-        /// <typeparam name="T">Logic of T.</typeparam>
-        /// <param name="logic">The action.</param>
-        /// <param name="timespan">The maximum time to wait.</param>
-        /// <param name="waitBetweenChecks">Time between each check.</param>
-        /// <returns>T.</returns>
+        /// <typeparam name="T">The result type produced by the polling logic.</typeparam>
+        /// <param name="logic">The polling function to evaluate.</param>
+        /// <param name="timespan">The maximum time to wait for a non-default result.</param>
+        /// <param name="waitBetweenChecks">The delay between polling attempts while the result remains <c>default(T)</c>.</param>
+        /// <returns>The first non-default value returned by <paramref name="logic" />.</returns>
         /// <exception cref="System.ArgumentNullException">logic</exception>
         /// <exception cref="System.ApplicationException">Timeout waiting for condition</exception>
         public static T WaitFor<T>(Func<T> logic, TimeSpan timespan, TimeSpan waitBetweenChecks)
@@ -143,30 +143,38 @@ namespace FastMoq
             while (EqualityComparer<T>.Default.Equals(result, default) && DateTimeOffset.Now <= timeout)
             {
                 result = logic();
+                if (!EqualityComparer<T>.Default.Equals(result, default))
+                {
+                    break;
+                }
+
                 Thread.Sleep(waitBetweenChecks);
             }
 
-            return !EqualityComparer<T>.Default.Equals(result, default) && DateTimeOffset.Now > timeout
-                ? throw new ApplicationException("Timeout waiting for condition")
-                : result;
+            if (EqualityComparer<T>.Default.Equals(result, default))
+            {
+                throw new ApplicationException("Timeout waiting for condition");
+            }
+
+            return result;
         }
 
         /// <summary>
-        ///     Waits for an action.
+        /// Waits until <paramref name="logic" /> returns a value other than <c>default(T)</c>.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="logic">The action.</param>
-        /// <returns>T.</returns>
+        /// <typeparam name="T">The result type produced by the polling logic.</typeparam>
+        /// <param name="logic">The polling function to evaluate.</param>
+        /// <returns>The first non-default value returned by <paramref name="logic" />.</returns>
         /// <exception cref="System.ArgumentNullException">logic</exception>
         public static T WaitFor<T>(Func<T> logic) => WaitFor(logic, TimeSpan.FromSeconds(4));
 
         /// <summary>
-        ///     Waits for an action.
+        /// Waits until <paramref name="logic" /> returns a value other than <c>default(T)</c>.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="logic">The action.</param>
-        /// <param name="timespan">The timespan, defaults to 4 seconds.</param>
-        /// <returns>T.</returns>
+        /// <typeparam name="T">The result type produced by the polling logic.</typeparam>
+        /// <param name="logic">The polling function to evaluate.</param>
+        /// <param name="timespan">The maximum time to wait for a non-default result.</param>
+        /// <returns>The first non-default value returned by <paramref name="logic" />.</returns>
         /// <exception cref="System.ArgumentNullException">logic</exception>
         public static T WaitFor<T>(Func<T> logic, TimeSpan timespan) => WaitFor(logic, timespan, TimeSpan.FromMilliseconds(100));
 

--- a/FastMoq.Tests/MocksTests.cs
+++ b/FastMoq.Tests/MocksTests.cs
@@ -278,12 +278,25 @@ namespace FastMoq.Tests
             Mocks.Behavior.Enable(MockFeatures.FailOnUnconfigured);
             Mocks.Policy.EnabledBuiltInTypeResolutions &= ~BuiltInTypeResolutionFlags.FileSystem;
             // No Constructor.
-            new Action(() => Mocks.CreateInstance<IFileSystem>().Should().NotBeNull()).Should().Throw<NotImplementedException>();
+            new Action(() => Mocks.CreateInstance<IFileSystem>().Should().NotBeNull()).Should().Throw<InvalidOperationException>();
 
             // Built-in file-system resolution resumes on the normal lenient path.
             Mocks.Policy.EnabledBuiltInTypeResolutions |= BuiltInTypeResolutionFlags.FileSystem;
             Mocks.Behavior.Disable(MockFeatures.FailOnUnconfigured);
             new Action(() => Mocks.CreateInstance<IFileSystem>().Should().NotBeNull()).Should().NotThrow();
+        }
+
+        [Fact]
+        public void CreateBest_ShouldIncludeInterfaceResolutionGuidance_WhenStrictInterfaceCreationFails()
+        {
+            Mocks.Behavior.Enable(MockFeatures.FailOnUnconfigured);
+            Mocks.Policy.EnabledBuiltInTypeResolutions &= ~BuiltInTypeResolutionFlags.FileSystem;
+
+            var act = () => Mocks.CreateInstance<IFileSystem>();
+
+            act.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*GetObject<T>()*GetOrCreateMock<T>()*AddType(...)*");
         }
 
         [Fact]
@@ -651,12 +664,22 @@ namespace FastMoq.Tests
             Mocks.CreateInstance<TestClassMany>(4, "str").Should().NotBeNull();
 
             Action a = () => Mocks.CreateInstance<TestClassMany>("4", "str").Should().NotBeNull();
-            a.Should().Throw<NotImplementedException>();
+            a.Should().Throw<InvalidOperationException>();
             IFile file = new FileWrapper(new FileSystem());
             Mocks.CreateInstance<TestClassOne>(InstanceCreationFlags.AllowNonPublicConstructorFallback, file).Should().NotBeNull();
             Mocks.CreateInstance<TestClassOne>(InstanceCreationFlags.AllowNonPublicConstructorFallback, new FileSystem()).Should().NotBeNull();
             Action b = () => Mocks.CreateInstance<TestClassOne>(InstanceCreationFlags.AllowNonPublicConstructorFallback, "4", "str").Should().NotBeNull();
-            b.Should().Throw<NotImplementedException>();
+            b.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void CreateExact_ShouldIncludeConstructorSelectionGuidance_WhenArgumentsDoNotMatch()
+        {
+            var act = () => Mocks.CreateInstance<TestClassMany>("4", "str");
+
+            act.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*CreateInstanceByType(...)*AddType(...)*GetOrCreateMock(...)*");
         }
 
         [Fact]
@@ -666,7 +689,7 @@ namespace FastMoq.Tests
             Mocks.CreateInstanceByType<TestClassMany>(new Type[] { typeof(string) }).Should().NotBeNull();
             Mocks.CreateInstanceByType<TestClassMany>(new Type[] { typeof(int), typeof(string) }).Should().NotBeNull();
             Action a = () => Mocks.CreateInstance<TestClassMany>(new Type[] { typeof(string), typeof(string) }).Should().NotBeNull();
-            a.Should().Throw<NotImplementedException>();
+            a.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -680,7 +703,7 @@ namespace FastMoq.Tests
             byNonPublic.Should().NotBeNull();
 
             var act = () => Mocks.CreateInstance<TestClassOne>(InstanceCreationFlags.PublicConstructorsOnly, new FileSystem().File);
-            act.Should().Throw<NotImplementedException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -706,7 +729,7 @@ namespace FastMoq.Tests
         {
             var act = () => Mocks.CreateInstance<TestClassOne>(InstanceCreationFlags.PublicConstructorsOnly, new FileSystem().File);
 
-            act.Should().Throw<NotImplementedException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -947,7 +970,7 @@ namespace FastMoq.Tests
         public void FindConstructor_Missing_ShouldThrow()
         {
             Action a = () => Mocks.FindConstructor(typeof(TestClassMany), false, Mocks.GetObject<IFileSystem>());
-            a.Should().Throw<NotImplementedException>();
+            a.Should().Throw<InvalidOperationException>();
         }
 
         [Theory]
@@ -1127,14 +1150,14 @@ namespace FastMoq.Tests
 
                 if (!autoCreate)
                 {
-                    throw new NotImplementedException("Unable to find the constructor.");
+                    throw new InvalidOperationException("Unable to find a tracked mock for the requested type.");
                 }
 
                 _ = mocker.GetOrCreateFastMock(type);
                 index = mocker.mockCollection.FindIndex(model => model.Type == type);
                 if (index < 0)
                 {
-                    throw new NotImplementedException("Unable to find the constructor.");
+                    throw new InvalidOperationException("Unable to find a tracked mock for the requested type.");
                 }
 
                 return index;
@@ -1145,7 +1168,7 @@ namespace FastMoq.Tests
 
             // Should not find it, because it doesn't exist.
             Action a = () => GetTrackedMockIndex(Component, typeof(IFileSystem), false);
-            a.Should().Throw<NotImplementedException>();
+            a.Should().Throw<InvalidOperationException>();
 
             // Should find it because it is auto created.
             GetTrackedMockIndex(Component, typeof(IFileSystem)).Should().Be(mockCount);
@@ -1333,7 +1356,7 @@ namespace FastMoq.Tests
         public void CreateInstanceByType_ShouldRequireExactParameterlessSignature_WhenEmptyTypeArrayIsProvided()
         {
             new Action(() => Mocks.CreateInstanceByType<NoParameterlessConstructorSelectionTarget>(Array.Empty<Type>()))
-                .Should().Throw<NotImplementedException>();
+                .Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -1536,7 +1559,7 @@ namespace FastMoq.Tests
 
             var act = () => testBase.TestMocks.CreateInstance<TestClassOne>(new FileSystem().File);
 
-            act.Should().Throw<NotImplementedException>();
+            act.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -50,6 +50,22 @@ namespace FastMoq.Tests
             }
         }
 
+        [Fact]
+        public void GetOrCreateMock_WithConstructorArgs_ShouldCreateConcreteMockThroughSupportedProviderFirstPath()
+        {
+            using var providerScope = PushProvider("moq");
+            var mocker = new Mocker();
+            var endpoint = new Uri("https://fastmoq.test/providers/orders");
+            const string queueName = "orders";
+
+            var typed = mocker.GetOrCreateMock<ProviderConstructedDependency>(endpoint, queueName);
+            var untyped = mocker.GetOrCreateMock(typeof(ProviderConstructedDependency), endpoint, queueName);
+
+            untyped.Should().BeSameAs(typed);
+            typed.Instance.Endpoint.Should().Be(endpoint);
+            typed.Instance.QueueName.Should().Be(queueName);
+        }
+
         [Theory]
         [MemberData(nameof(ProviderNames))]
         public void TryGetTrackedMock_ShouldReturnFalse_WhenTrackedMockDoesNotExist(string providerName)
@@ -817,6 +833,12 @@ namespace FastMoq.Tests
         public class KeyedProviderFallbackConsumer([FromKeyedServices("dep")] IProviderDependency dependency)
         {
             public IProviderDependency Dependency { get; } = dependency;
+        }
+
+        public class ProviderConstructedDependency(Uri endpoint, string queueName)
+        {
+            public Uri Endpoint { get; } = endpoint;
+            public string QueueName { get; } = queueName;
         }
 
         public interface IExpressionConsumer

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -58,8 +58,8 @@ namespace FastMoq.Tests
             var endpoint = new Uri("https://fastmoq.test/providers/orders");
             const string queueName = "orders";
 
-            var typed = mocker.GetOrCreateMock<ProviderConstructedDependency>(endpoint, queueName);
-            var untyped = mocker.GetOrCreateMock(typeof(ProviderConstructedDependency), endpoint, queueName);
+            var typed = mocker.GetOrCreateMockWithConstructorArgs<ProviderConstructedDependency>(endpoint, queueName);
+            var untyped = mocker.GetOrCreateMockWithConstructorArgs(typeof(ProviderConstructedDependency), endpoint, queueName);
 
             untyped.Should().BeSameAs(typed);
             typed.Instance.Endpoint.Should().Be(endpoint);

--- a/FastMoq.Tests/TestBase/TestBaseTests.cs
+++ b/FastMoq.Tests/TestBase/TestBaseTests.cs
@@ -161,33 +161,40 @@ namespace FastMoq.Tests.TestBase
             }
         }
 
-        [Fact(Skip = "Revisit later")]
-        public void WaitForTest()
+        [Fact]
+        public void WaitFor_ShouldReturnOnceLogicProducesNonDefaultResult()
         {
-            var result1 = false;
-            var result2 = false;
+            var attempts = 0;
 
-            var task1 = new Task(() =>
+            var result = WaitFor(() =>
                 {
-                    Thread.Sleep(1000);
-                    result1 = true;
-                }
-            );
+                    attempts++;
+                    return attempts >= 3;
+                },
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.Zero);
 
-            var task2 = new Task(() =>
+            result.Should().BeTrue();
+            attempts.Should().Be(3);
+        }
+
+        [Fact]
+        public void WaitFor_ShouldThrowTimeout_WhenLogicRemainsDefault()
+        {
+            var attempts = 0;
+
+            var action = () => WaitFor(() =>
                 {
-                    Thread.Sleep(500);
-                    result2 = true;
-                }
-            );
+                    attempts++;
+                    return false;
+                },
+                TimeSpan.FromMilliseconds(20),
+                TimeSpan.FromMilliseconds(1));
 
-            task1.Start();
-            task2.Start();
-            WaitFor(() => result1 && result2, TimeSpan.FromSeconds(2));
-            result1.Should().BeTrue();
-            result2.Should().BeTrue();
-            task1.Dispose();
-            task2.Dispose();
+            action.Should()
+                .Throw<ApplicationException>()
+                .WithMessage("Timeout waiting for condition");
+            attempts.Should().BeGreaterThan(0);
         }
 
         public class ConstructorTestClass

--- a/FastMoq.Tests/TestBase/TestBaseTests.cs
+++ b/FastMoq.Tests/TestBase/TestBaseTests.cs
@@ -49,14 +49,14 @@ namespace FastMoq.Tests.TestBase
 
                 if (!autoCreate)
                 {
-                    throw new NotImplementedException("Unable to find the constructor.");
+                    throw new InvalidOperationException("Unable to find a tracked mock for the requested type.");
                 }
 
                 _ = mocker.GetOrCreateFastMock(type);
                 index = mocker.mockCollection.FindIndex(model => model.Type == type);
                 if (index < 0)
                 {
-                    throw new NotImplementedException("Unable to find the constructor.");
+                    throw new InvalidOperationException("Unable to find a tracked mock for the requested type.");
                 }
 
                 return index;

--- a/docs/breaking-changes/README.md
+++ b/docs/breaking-changes/README.md
@@ -164,6 +164,32 @@ This breaking change is currently specific to strict `IFileSystem` mock enrichme
 
 In other words, the repo did not broadly change every built-in type to ignore strict-mode behavior. The compatibility break identified here is the tracked `IFileSystem` mock path.
 
+### `MockerTestBase<TComponent>.WaitFor<T>(...)` now throws on timeout
+
+`WaitFor<T>(...)` is documented as polling until the supplied logic returns a value other than `default(T)`, then throwing if that never happens before the timeout expires.
+
+What changed:
+
+- timeout now consistently throws `ApplicationException("Timeout waiting for condition")` when the result remains `default(T)` through the configured wait window
+- the XML docs on all overloads now make the non-`default(T)` success contract explicit
+- tests should now assert the timeout exception directly instead of treating `default(T)` as a timeout sentinel value
+
+Migration guidance:
+
+```csharp
+// Previous accidental timeout-sentinel pattern
+var result = WaitFor(() => false, TimeSpan.FromMilliseconds(20));
+result.Should().BeFalse();
+
+// Current behavior
+Action action = () => WaitFor(() => false, TimeSpan.FromMilliseconds(20));
+action.Should()
+    .Throw<ApplicationException>()
+    .WithMessage("Timeout waiting for condition");
+```
+
+If `default(T)` is a valid success result for the polling path, use a different readiness signal so the helper can distinguish "not ready yet" from "ready with the default value".
+
 ## Historical package-line change summary
 
 The root README previously carried this older package-line summary. It is kept here so compatibility notes live in one place.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -96,6 +96,7 @@ Important package boundaries in the current v4 line:
 - `FastMoq` also includes the FastMoq analyzer assets by default so most test projects get migration guidance without extra setup
 - `FastMoq.Core` stays lighter on purpose, so shared Azure SDK helpers, EF helpers, Azure Functions helpers, and web helpers are separate package decisions when you consume core directly
 - `FastMoq.Core` does not include analyzer assets; add `FastMoq.Analyzers` explicitly if you want analyzer guidance in a core-only package graph
+- if a core-only test project stays on the legacy Moq-shaped path with `GetMock<T>()`, `VerifyLogger(...)`, `MockModel.Mock`, `SetupSet(...)`, `SetupAllProperties()`, or other Moq-specific compatibility flows, add `FastMoq.Analyzers` and `FastMoq.Provider.Moq` explicitly, then select `moq` at assembly scope instead of relying on the default `reflection` provider
 - `FastMoq.Core` includes the built-in `reflection` provider and the bundled Moq compatibility runtime, but the Moq tracked-mock extension methods such as `Setup(...)` and `Protected()` still belong to the `FastMoq.Provider.Moq` package
 - provider-package extension methods still follow the provider-package docs and selection rules described in [Provider Selection and Setup](./provider-selection.md)
 - if you are wiring Azure SDK clients, pageable sequences, or token credentials through tests while consuming `FastMoq.Core` directly, add `FastMoq.Azure`

--- a/docs/getting-started/provider-selection.md
+++ b/docs/getting-started/provider-selection.md
@@ -36,6 +36,16 @@ Why this matters:
 - Moq compatibility APIs such as `GetMock<T>()`, `VerifyLogger(...)`, `Protected()`, and direct `Mock<T>` setup require the Moq provider to be selected.
 - provider-package extensions such as `AsMoq()`, `Setup(...)` on `IFastMock<T>`, `AsNSubstitute()`, and `Received(...)` also require their corresponding provider package and selected provider.
 
+For concrete mocks that need constructor arguments, stay on the provider-first path instead of falling back to `GetMock<T>(...)`. When the request only needs constructor arguments, `GetOrCreateMock<T>(...)` can take them directly:
+
+```csharp
+var queueClient = mocker.GetOrCreateMock<QueueClient>(
+    new Uri("https://account.queue.core.windows.net/work-items"),
+    new QueueClientOptions());
+```
+
+Use `MockRequestOptions` when the request also needs a service key or non-public constructor selection. This still depends on the selected provider supporting concrete class mocking; the bundled `reflection` provider remains limited to interfaces and parameterless concrete types.
+
 ## First decision: do you need a non-default provider?
 
 Use this quick check before reading the rest of the page:
@@ -63,6 +73,20 @@ That keeps the test assembly explicit without requiring a startup hook. This wor
 
 The attribute selects the assembly-wide default provider by name. It does not create a new provider registration or alias.
 
+If an entire test subtree stays on one provider and your repository already uses `Directory.Build.props` or `Directory.Build.targets` to stamp assembly attributes, centralize the default there instead of repeating a bootstrap file in every test project:
+
+```xml
+<Project>
+    <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+        <AssemblyAttribute Include="FastMoq.Providers.FastMoqDefaultProviderAttribute">
+            <_Parameter1>moq</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+</Project>
+```
+
+That pattern fits repositories that already stamp `InternalsVisibleTo` or similar assembly metadata from MSBuild. Avoid a repo-wide default when some test projects intentionally stay on `reflection` or use a different provider.
+
 When registration and selection need to happen together at assembly scope, use [FastMoqRegisterProviderAttribute](../../api/FastMoq.Providers.FastMoqRegisterProviderAttribute.yml):
 
 ```csharp
@@ -79,6 +103,10 @@ Use startup code instead when you need more than declarative assembly metadata. 
 - choosing the provider dynamically at runtime from configuration, environment, or target-specific logic
 - combining provider selection with other one-time test bootstrap work in the same startup path
 - running custom registration logic that cannot be expressed as a provider type plus `SetAsDefault`
+
+Analyzer note:
+
+- `FMOQ0023` warns when legacy Moq-shaped FastMoq APIs remain in a project without explicit Moq onboarding. For core-only package graphs, that means adding `FastMoq.Provider.Moq` and selecting `moq` explicitly.
 
 ### Assembly startup alternatives
 

--- a/docs/getting-started/provider-selection.md
+++ b/docs/getting-started/provider-selection.md
@@ -36,10 +36,10 @@ Why this matters:
 - Moq compatibility APIs such as `GetMock<T>()`, `VerifyLogger(...)`, `Protected()`, and direct `Mock<T>` setup require the Moq provider to be selected.
 - provider-package extensions such as `AsMoq()`, `Setup(...)` on `IFastMock<T>`, `AsNSubstitute()`, and `Received(...)` also require their corresponding provider package and selected provider.
 
-For concrete mocks that need constructor arguments, stay on the provider-first path instead of falling back to `GetMock<T>(...)`. When the request only needs constructor arguments, `GetOrCreateMock<T>(...)` can take them directly:
+For concrete mocks that need constructor arguments, stay on the provider-first path instead of falling back to `GetMock<T>(...)`. When the request only needs constructor arguments, `GetOrCreateMockWithConstructorArgs<T>(...)` keeps that intent explicit without changing `GetOrCreateMock<T>(null)` binding:
 
 ```csharp
-var queueClient = mocker.GetOrCreateMock<QueueClient>(
+var queueClient = mocker.GetOrCreateMockWithConstructorArgs<QueueClient>(
     new Uri("https://account.queue.core.windows.net/work-items"),
     new QueueClientOptions());
 ```

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -58,6 +58,15 @@ Mocks.AddType<IClock>(_ => new FakeClock(DateTimeOffset.Parse("2026-04-01T12:00:
 
 If the dependency is still conceptually a mock, prefer [GetOrCreateMock&lt;T&gt;()](xref:FastMoq.Mocker.GetOrCreateMock``1(FastMoq.MockRequestOptions)). If you are changing how the type is resolved, prefer [AddType(...)](xref:FastMoq.Mocker.AddType``1(System.Func{FastMoq.Mocker,``0},System.Boolean,System.Object[])).
 
+Migration guardrail:
+
+- do not rewrite a tracked helper to [AddType(...)](xref:FastMoq.Mocker.AddType``1(System.Func{FastMoq.Mocker,``0},System.Boolean,System.Object[])) when the same service still flows through `GetObject<T>()`, `GetRequiredTrackedMock<T>()`, `GetMockModel<T>()`, `AddPropertyState<TService>(...)`, or `AddPropertySetterCapture<TService, TValue>(...)`
+- that is still a tracked FastMoq dependency, not a concrete type-map override
+
+Analyzer note:
+
+- `FMOQ0022` warns when an `AddType(...)` rewrite comes from a tracked mock/object path and the same file still uses tracked-resolution APIs or property helpers for that service
+
 ## Typed IServiceProvider Helpers
 
 Framework-heavy tests should not fake `IServiceProvider` with a single mocked `GetService(Type)` callback that returns the same object for every request.

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -770,6 +770,12 @@ For practical fallback patterns when you do not want to stay on Moq, see [Provid
 
 Property-setter and cache-entry tests are still a common Moq-only pocket because they often rely on `SetupSet(...)` or `SetupAllProperties()`. For ordinary interface collaborators, FastMoq now has first-party answers in `AddPropertySetterCapture<TService, TValue>(...)` and `AddPropertyState<TService>(...)`, but `ICacheEntry` tests often still need the broader Moq shape.
 
+Important migration rule:
+
+- do not replace a tracked cache-entry helper with `AddType<ICacheEntry>(...)` just because the immediate call site only needs an object
+- if the same helper later resolves `ICacheEntry` through `GetObject<T>()`, `GetRequiredTrackedMock<T>()`, `GetMockModel<T>()`, `AddPropertyState<TService>(...)`, or `AddPropertySetterCapture<TService, TValue>(...)`, keep the tracked mock/helper path
+- `FMOQ0022` exists specifically to catch this risky rewrite shape
+
 ```csharp
 var cacheEntry = Mocks.GetMock<ICacheEntry>();
 cacheEntry.SetupAllProperties();

--- a/docs/whats-new/README.md
+++ b/docs/whats-new/README.md
@@ -167,13 +167,15 @@ Important points:
 - `UseStrictPreset()` and `UseLenientPreset()` now express the broader behavior profiles directly.
 - Moq-specific HTTP helpers such as `SetupHttpMessage(...)` moved out of `FastMoq.Core` and into `FastMoq.Provider.Moq`, while remaining in the `FastMoq.Extensions` namespace for lower source churn.
 - `MockerTestBase<TComponent>` gained clearer component-construction and policy hooks.
+- `MockerTestBase<TComponent>.WaitFor<T>(...)` now consistently treats timeout as a failure and throws `ApplicationException` when the polling logic never produces a non-`default(T)` result.
 
 ### Breaking behavior to account for
 
-Two release-facing behavior changes deserve special attention:
+Three release-facing behavior changes deserve special attention:
 
 - strict-mode semantics are now more explicit and less overloaded than they were in `3.0.0`
 - strict `IFileSystem` mocks now stay enriched by the built-in in-memory file system pipeline instead of behaving like a raw empty Moq mock
+- `WaitFor<T>(...)` no longer falls through and returns `default(T)` on timeout; timeout now surfaces as the documented exception path
 
 For detailed migration notes, see [Breaking Changes](../breaking-changes/README.md).
 


### PR DESCRIPTION
## Summary
- add `FMOQ0022` and `FMOQ0023` analyzer coverage for tracked `AddType(...)` migrations and explicit Moq onboarding
- add a second `FMOQ0023` code fix for assembly-level `FastMoqRegisterProvider(...)` onboarding and centralize shared analyzer provider/type constants
- improve constructor resolution failures with actionable `InvalidOperationException` guidance, add provider-first constructor-argument `GetOrCreateMock(...)` overloads, and document the supported migration paths

## Validation
- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj --nologo -v minimal`
- `dotnet test .\FastMoq.Tests\FastMoq.Tests.csproj --nologo -v minimal`

## Notes
- `FastMoq.Tests` still emits the existing compatibility-analyzer warnings in its legacy coverage files, but the suite passes cleanly.