### PR TITLE
Harden provider onboarding for 4.2.0 release

### DIFF
--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -1834,6 +1834,69 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenProviderIsSelectedInOuterScopeAndApiIsInsideLambda()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        using var providerScope = MockingProviderRegistry.Push(""nsubstitute"");
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        Action assertion = () => dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenProviderIsSelectedOnlyInsideNestedLambda()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        Action configure = () =>
+        {
+            using var providerScope = MockingProviderRegistry.Push(""nsubstitute"");
+        };
+
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenProviderIsSelectedByDefault()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -2043,19 +2043,60 @@ namespace FastMoq.Analyzers
 
         public static bool HasProviderSelectionInScope(SyntaxNode node, SemanticModel semanticModel, string providerName, CancellationToken cancellationToken)
         {
-            var scope = node.AncestorsAndSelf().FirstOrDefault(ancestor =>
-                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax)
-                ?? node.SyntaxTree.GetRoot(cancellationToken);
-
-            foreach (var invocationExpression in scope.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            foreach (var scope in EnumerateProviderSelectionScopes(node, cancellationToken))
             {
-                if (IsProviderSelectionInvocation(invocationExpression, semanticModel, providerName, requireDefaultSelection: false, cancellationToken))
+                foreach (var invocationExpression in EnumerateScopeInvocations(scope))
                 {
-                    return true;
+                    if (IsProviderSelectionInvocation(invocationExpression, semanticModel, providerName, requireDefaultSelection: false, cancellationToken))
+                    {
+                        return true;
+                    }
                 }
             }
 
             return false;
+        }
+
+        private static IEnumerable<SyntaxNode> EnumerateProviderSelectionScopes(SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var seenScopes = new HashSet<SyntaxNode>();
+            SyntaxNode? current = node;
+
+            while (current is not null)
+            {
+                var scope = current.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                    ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+
+                if (scope is null)
+                {
+                    var root = node.SyntaxTree.GetRoot(cancellationToken);
+                    if (seenScopes.Add(root))
+                    {
+                        yield return root;
+                    }
+
+                    yield break;
+                }
+
+                if (seenScopes.Add(scope))
+                {
+                    yield return scope;
+                }
+
+                current = scope.Parent;
+            }
+        }
+
+        private static IEnumerable<InvocationExpressionSyntax> EnumerateScopeInvocations(SyntaxNode scope)
+        {
+            return scope
+                .DescendantNodesAndSelf(child => child == scope || !IsNestedExecutableScope(child))
+                .OfType<InvocationExpressionSyntax>();
+        }
+
+        private static bool IsNestedExecutableScope(SyntaxNode node)
+        {
+            return node is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax;
         }
 
         private static bool HasUsingDirective(SyntaxNode node, string namespaceName)

--- a/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
+++ b/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
@@ -341,15 +341,73 @@ namespace FastMoq.Providers.MoqProvider
         private static class MoqProviderTransitionWarning
         {
             private static int _emitted;
+            private static readonly HashSet<string> FastMoqProductAssemblyNames = new(StringComparer.OrdinalIgnoreCase)
+            {
+                "FastMoq",
+                "FastMoq.Abstractions",
+                "FastMoq.Core",
+                "FastMoq.Azure",
+                "FastMoq.AzureFunctions",
+                "FastMoq.Database",
+                "FastMoq.Provider.Moq",
+                "FastMoq.Provider.NSubstitute",
+                "FastMoq.Web",
+            };
 
             internal static void EmitOnce()
             {
+                if (!ShouldEmit())
+                {
+                    return;
+                }
+
                 if (System.Threading.Interlocked.Exchange(ref _emitted, 1) == 1)
                 {
                     return;
                 }
 
                 Console.Error.WriteLine("[FastMoq] Warning: FastMoq.Provider.Moq is a v4 transition dependency and will no longer be bundled by FastMoq.Core in v5. Install and select your mocking provider explicitly before upgrading.");
+            }
+
+            private static bool ShouldEmit()
+            {
+                return !IsReferencedByConsumerAssembly();
+            }
+
+            private static bool IsReferencedByConsumerAssembly()
+            {
+                var providerAssemblyName = typeof(MoqMockingProvider).Assembly.GetName().Name;
+                if (string.IsNullOrWhiteSpace(providerAssemblyName))
+                {
+                    return false;
+                }
+
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (assembly.IsDynamic)
+                    {
+                        continue;
+                    }
+
+                    var assemblyName = assembly.GetName().Name;
+                    if (string.IsNullOrWhiteSpace(assemblyName) || FastMoqProductAssemblyNames.Contains(assemblyName))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (assembly.GetReferencedAssemblies().Any(reference => string.Equals(reference.Name, providerAssemblyName, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            return true;
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                return false;
             }
         }
     }

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
+using System.IO;
 using System.IO.Abstractions;
 using System.Linq.Expressions;
 using System.Net.Http;
@@ -64,6 +65,28 @@ namespace FastMoq.Tests
             untyped.Should().BeSameAs(typed);
             typed.Instance.Endpoint.Should().Be(endpoint);
             typed.Instance.QueueName.Should().Be(queueName);
+        }
+
+        [Fact]
+        public void ExplicitMoqProviderReference_ShouldNotEmitTransitionWarningToStandardError()
+        {
+            using var providerScope = PushProvider("moq");
+            var mocker = new Mocker();
+            var originalError = Console.Error;
+            using var errorWriter = new StringWriter();
+
+            try
+            {
+                Console.SetError(errorWriter);
+
+                _ = mocker.GetOrCreateMock<IProviderDependency>();
+            }
+            finally
+            {
+                Console.SetError(originalError);
+            }
+
+            errorWriter.ToString().Should().BeEmpty();
         }
 
         [Theory]

--- a/docs/whats-new/README.md
+++ b/docs/whats-new/README.md
@@ -1,6 +1,23 @@
 # What's New Since 3.0.0
 
-This page summarizes the release delta between the last public `3.0.0` package and the current published `4.1.0` v4 line in this repository.
+This page summarizes the release delta between the last public `3.0.0` package and the current published `4.2.0` v4 line in this repository.
+
+## 4.2.0
+
+FastMoq `4.2.0` focuses on provider-first release hardening rather than another large package-boundary shift.
+
+Consumer impact:
+
+- provider-selection analyzers now handle outer scoped provider bootstrap more accurately, including provider-specific assertions invoked inside lambdas that live under an already-selected provider scope
+- Moq transition messaging is quieter for projects that already reference `FastMoq.Provider.Moq` explicitly, while the bundled-path warning remains available for suites that still rely on the implicit v4 compatibility path
+- provider-neutral property-state, property-setter capture, typed service-scope helpers, and logger-factory helpers round out the common migration gaps that previously forced provider-specific setup noise
+- constructor-resolution failures now surface actionable `InvalidOperationException` guidance instead of generic `NotImplementedException` failures
+
+Validation run for this change:
+
+- `dotnet test .\FastMoq.Tests\FastMoq.Tests.csproj -c Release`
+- `dotnet test .\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj -c Release`
+- `dotnet build .\FastMoq-Release.sln -c Release`
 
 ## 4.1.0
 


### PR DESCRIPTION
## Summary
- fix provider-selection analyzer scope detection so outer provider bootstrap is honored for provider-specific APIs invoked inside lambdas
- suppress the Moq transition stderr warning for consumers that already reference `FastMoq.Provider.Moq` explicitly
- refresh the 4.2.0 release notes with the current release-line summary and validation commands

## Validation
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj" --configuration Release`
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Tests\FastMoq.Tests.csproj" --configuration Release`
- `dotnet build "c:\Users\chriswin\source\repos\FastMoq\FastMoq-Release.sln" --configuration Release`

## Notes
- this keeps issue #41 out of the 4.2.0 release path and focuses on the concrete release blockers identified in review