### PR TITLE
Fix analyzer guidance and HTTP helper docs

### DIFF
--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -565,6 +565,30 @@ class Sample
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LegacyMoqCreationLifecycleAnalyzer());
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.AvoidLegacyMockCreationAndLifecycleApis));
             Assert.Equal(DiagnosticIds.AvoidLegacyMockCreationAndLifecycleApis, diagnostic.Id);
+            Assert.Contains("CreateStandaloneFastMock<ILogger<Sample>>()", diagnostic.GetMessage());
+            Assert.Contains("MockingProviderRegistry.Default.CreateMock<ILogger<Sample>>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task LegacyMoqCreationLifecycleAnalyzer_ShouldReport_WhenCreateMockInstanceIsUsed()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.Logging;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var logger = Mocks.CreateMockInstance<ILogger<Sample>>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LegacyMoqCreationLifecycleAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.AvoidLegacyMockCreationAndLifecycleApis));
+            Assert.Equal(DiagnosticIds.AvoidLegacyMockCreationAndLifecycleApis, diagnostic.Id);
+            Assert.Contains("CreateStandaloneFastMock<ILogger<Sample>>()", diagnostic.GetMessage());
+            Assert.Contains("MockingProviderRegistry.Default.CreateMock<ILogger<Sample>>()", diagnostic.GetMessage());
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
@@ -152,14 +152,13 @@ using System.Threading.Tasks;
 using FastMoq;
 using FastMoq.Providers.MoqProvider;
 using Moq;
-using FastMoq.Providers;
 
 class Sample
 {
     void Execute(Mocker Mocks)
     {
         var dependency = Mocks.GetOrCreateMock<IDependency>().AsMoq();
-        Mocks.Verify<IDependency>(x => x.RunAsync(""alpha""), TimesSpec.Once);
+        Mocks.Verify<IDependency>(x => x.RunAsync(""alpha""), FastMoq.Providers.TimesSpec.Once);
     }
 }
 
@@ -211,13 +210,76 @@ class Sample
     void Execute(Mocker Mocks)
     {
         var dependency = Mocks.CreateStandaloneFastMock<IDependency>();
-        MockingProviderRegistry.Default.Verify<IDependency>(dependency, x => x.LoadAsync(""alpha""), TimesSpec.Once);
+        MockingProviderRegistry.Default.Verify<IDependency>(dependency, x => x.LoadAsync(""alpha""), FastMoq.Providers.TimesSpec.Once);
     }
 }
 
 interface IDependency
 {
     Task<string> LoadAsync(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task TrackedMockVerificationAnalyzer_ShouldReportAndFix_DetachedPropertyAlias_UsingPropertyAtCallSite()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+abstract class BaseSample
+{
+    private readonly IFastMock<IDependency> _dependency = new Mocker().CreateStandaloneFastMock<IDependency>();
+
+    protected IFastMock<IDependency> Dependency => _dependency;
+}
+
+class Sample : BaseSample
+{
+    void Execute()
+    {
+        Dependency.AsMoq().Verify(x => x.Run(""alpha""), Times.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockVerificationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UseProviderFirstVerify));
+            Assert.Equal(DiagnosticIds.UseProviderFirstVerify, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new TrackedMockVerificationAnalyzer(), codeFixProvider, DiagnosticIds.UseProviderFirstVerify);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+abstract class BaseSample
+{
+    private readonly IFastMock<IDependency> _dependency = new Mocker().CreateStandaloneFastMock<IDependency>();
+
+    protected IFastMock<IDependency> Dependency => _dependency;
+}
+
+class Sample : BaseSample
+{
+    void Execute()
+    {
+        MockingProviderRegistry.Default.Verify<IDependency>(Dependency, x => x.Run(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
 }");
 
             Assert.Equal(expected, fixedSource);

--- a/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
@@ -120,6 +120,135 @@ interface IDependency
         }
 
         [Fact]
+        public async Task TrackedMockVerificationAnalyzer_ShouldReportAndFix_AsyncReturningTrackedMockAlias()
+        {
+            const string SOURCE = @"
+using System.Threading.Tasks;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var dependency = Mocks.GetOrCreateMock<IDependency>().AsMoq();
+        dependency.Verify(x => x.RunAsync(""alpha""), Times.Once);
+    }
+}
+
+interface IDependency
+{
+    Task RunAsync(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockVerificationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UseProviderFirstVerify));
+            Assert.Equal(DiagnosticIds.UseProviderFirstVerify, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new TrackedMockVerificationAnalyzer(), codeFixProvider, DiagnosticIds.UseProviderFirstVerify);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System.Threading.Tasks;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+using FastMoq.Providers;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var dependency = Mocks.GetOrCreateMock<IDependency>().AsMoq();
+        Mocks.Verify<IDependency>(x => x.RunAsync(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    Task RunAsync(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task TrackedMockVerificationAnalyzer_ShouldReportAndFix_DetachedFastMockAliasWithAsyncReturn()
+        {
+            const string SOURCE = @"
+using System.Threading.Tasks;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var dependency = Mocks.CreateStandaloneFastMock<IDependency>();
+        dependency.AsMoq().Verify(x => x.LoadAsync(""alpha""), Times.Once);
+    }
+}
+
+interface IDependency
+{
+    Task<string> LoadAsync(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockVerificationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UseProviderFirstVerify));
+            Assert.Equal(DiagnosticIds.UseProviderFirstVerify, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new TrackedMockVerificationAnalyzer(), codeFixProvider, DiagnosticIds.UseProviderFirstVerify);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System.Threading.Tasks;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+using FastMoq.Providers;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var dependency = Mocks.CreateStandaloneFastMock<IDependency>();
+        MockingProviderRegistry.Default.Verify<IDependency>(dependency, x => x.LoadAsync(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    Task<string> LoadAsync(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task TrackedMockVerificationAnalyzer_ShouldNotReport_WhenDetachedVerifyUsesTransientCreationExpression()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.CreateStandaloneFastMock<IDependency>().AsMoq().Verify(x => x.Run(""alpha""), Times.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockVerificationAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.UseProviderFirstVerify);
+        }
+
+        [Fact]
         public async Task BareTrackedVerifyAnalyzer_ShouldReport_ForTrackedVerifyWithoutExpression()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers/Analyzers/LegacyMoqCreationLifecycleAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/LegacyMoqCreationLifecycleAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using System.Threading;
 
 namespace FastMoq.Analyzers.Analyzers
 {
@@ -22,7 +23,7 @@ namespace FastMoq.Analyzers.Analyzers
             var invocationExpression = (InvocationExpressionSyntax) context.Node;
             if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var method) ||
                 method is null ||
-                !TryGetGuidance(method, out var guidance))
+                !TryGetGuidance(invocationExpression, context.SemanticModel, context.CancellationToken, method, out var guidance))
             {
                 return;
             }
@@ -34,7 +35,7 @@ namespace FastMoq.Analyzers.Analyzers
                 guidance));
         }
 
-        private static bool TryGetGuidance(IMethodSymbol method, out string guidance)
+        private static bool TryGetGuidance(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, IMethodSymbol method, out string guidance)
         {
             guidance = string.Empty;
 
@@ -43,15 +44,21 @@ namespace FastMoq.Analyzers.Analyzers
                 return false;
             }
 
+            var serviceTypeName = TryGetServiceTypeName(invocationExpression, semanticModel, method, cancellationToken);
+
             switch (method.Name)
             {
                 case "CreateMock":
-                    guidance = "'GetOrCreateMock(...)' for tracked provider-first mocks";
+                    guidance = serviceTypeName is null
+                        ? "'GetOrCreateMock(...)' for tracked provider-first mocks"
+                        : $"'GetOrCreateMock<{serviceTypeName}>()' for tracked provider-first mocks";
                     return true;
 
                 case "CreateMockInstance":
                 case "CreateDetachedMock":
-                    guidance = "'GetOrCreateMock(...)' on a dedicated Mocker instance when possible, or provider-specific escape hatches only when raw Mock<T> is still required";
+                    guidance = serviceTypeName is null
+                        ? "'CreateStandaloneFastMock<T>()' or 'MockingProviderRegistry.Default.CreateMock<T>()' for detached provider-first handles, and 'GetOrCreateMock(...)' only when the collaborator should stay tracked in the parent Mocker"
+                        : $"'CreateStandaloneFastMock<{serviceTypeName}>()' or 'MockingProviderRegistry.Default.CreateMock<{serviceTypeName}>()' for detached provider-first handles, and 'GetOrCreateMock<{serviceTypeName}>()' only when the collaborator should stay tracked in the parent Mocker";
                     return true;
 
                 case "AddMock":
@@ -65,6 +72,27 @@ namespace FastMoq.Analyzers.Analyzers
                 default:
                     return false;
             }
+        }
+
+        private static string? TryGetServiceTypeName(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, IMethodSymbol method, CancellationToken cancellationToken)
+        {
+            method = method.ReducedFrom ?? method;
+            if (method.TypeArguments.Length == 1)
+            {
+                return FastMoqAnalysisHelpers.GetMinimalTypeName(method.TypeArguments[0], semanticModel, invocationExpression.SpanStart);
+            }
+
+            if (invocationExpression.ArgumentList.Arguments.Count > 0 &&
+                invocationExpression.ArgumentList.Arguments[0].Expression is TypeOfExpressionSyntax typeOfExpression)
+            {
+                var serviceType = semanticModel.GetTypeInfo(typeOfExpression.Type, cancellationToken).Type;
+                if (serviceType is not null)
+                {
+                    return FastMoqAnalysisHelpers.GetMinimalTypeName(serviceType, semanticModel, invocationExpression.SpanStart);
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/FastMoq.Analyzers/Analyzers/TrackedMockVerificationAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/TrackedMockVerificationAnalyzer.cs
@@ -25,8 +25,7 @@ namespace FastMoq.Analyzers.Analyzers
                 !FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var method) ||
                 method is null ||
                 !FastMoqAnalysisHelpers.IsMoqVerifyMethod(method) ||
-                !FastMoqAnalysisHelpers.TryResolveTrackedMockOrigin(memberAccess.Expression, context.SemanticModel, context.CancellationToken, out var origin) ||
-                !FastMoqAnalysisHelpers.TryBuildVerifyReplacement(origin, context.SemanticModel, invocationExpression, context.CancellationToken, out var replacement))
+                !FastMoqAnalysisHelpers.TryBuildVerifyReplacement(memberAccess.Expression, context.SemanticModel, invocationExpression, context.CancellationToken, out var replacement, out _))
             {
                 return;
             }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -110,8 +110,8 @@ namespace FastMoq.Analyzers.CodeFixes
 
                         context.RegisterCodeFix(
                             CodeAction.Create(
-                                "Use Mocker.Verify<T>(...)",
-                                cancellationToken => ReplaceInvocationAsync(document, invocationExpression, BuildVerifyReplacementAsync, cancellationToken),
+                                "Use provider-first Verify(...)",
+                                cancellationToken => ReplaceVerifyInvocationAsync(document, invocationExpression, cancellationToken),
                                 nameof(DiagnosticIds.UseProviderFirstVerify)),
                             diagnostic);
                         break;
@@ -491,6 +491,25 @@ namespace FastMoq.Analyzers.CodeFixes
             return document.WithSyntaxRoot(updatedRoot);
         }
 
+        private static async Task<Document> ReplaceVerifyInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !FastMoqAnalysisHelpers.TryBuildVerifyReplacement(memberAccess.Expression, semanticModel, invocationExpression, cancellationToken, out var replacementText, out var requiresProvidersNamespace))
+            {
+                return document;
+            }
+
+            var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
+                .WithTriviaFrom(invocationExpression);
+            var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
         private static async Task<Document> ReplaceTypedProviderExtensionInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -686,13 +705,12 @@ namespace FastMoq.Analyzers.CodeFixes
         private static string? BuildVerifyReplacementAsync(Document document, SemanticModel semanticModel, SyntaxNode syntaxNode, CancellationToken cancellationToken)
         {
             if (syntaxNode is not InvocationExpressionSyntax invocationExpression ||
-                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
-                !FastMoqAnalysisHelpers.TryResolveTrackedMockOrigin(memberAccess.Expression, semanticModel, cancellationToken, out var origin))
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess)
             {
                 return null;
             }
 
-            return FastMoqAnalysisHelpers.TryBuildVerifyReplacement(origin, semanticModel, invocationExpression, cancellationToken, out var replacement)
+            return FastMoqAnalysisHelpers.TryBuildVerifyReplacement(memberAccess.Expression, semanticModel, invocationExpression, cancellationToken, out var replacement, out _)
                 ? replacement
                 : null;
         }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -505,7 +505,11 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+
+            if (requiresProvidersNamespace)
+            {
+                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+            }
 
             return document.WithSyntaxRoot(updatedRoot);
         }

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -234,11 +234,11 @@ namespace FastMoq.Analyzers
         public static readonly DiagnosticDescriptor UseProviderFirstVerify = new(
             DiagnosticIds.UseProviderFirstVerify,
             "Use provider-first verification",
-            "Use '{0}' instead of provider-native Verify(...) on tracked FastMoq mocks",
+            "Use '{0}' instead of provider-native Verify(...) on FastMoq mock handles",
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Tracked FastMoq mocks should use Mocker.Verify<T>(...) and TimesSpec instead of Moq Verify(...) when the translation is mechanical and provider-neutral." );
+            description: "Tracked FastMoq mocks should use Mocker.Verify<T>(...) and detached IFastMock<T> handles should use MockingProviderRegistry.Default.Verify(...) instead of Moq Verify(...) when the translation is mechanical and provider-neutral." );
 
         public static readonly DiagnosticDescriptor AvoidBareTrackedVerify = new(
             DiagnosticIds.AvoidBareTrackedVerify,

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -39,6 +39,27 @@ namespace FastMoq.Analyzers
         }
     }
 
+    internal readonly struct DetachedMockOrigin
+    {
+        public DetachedMockOrigin(ExpressionSyntax fastMockExpression, ITypeSymbol serviceType, bool canReuseFastMockExpression)
+        {
+            FastMockExpression = fastMockExpression;
+            ServiceType = serviceType;
+            CanReuseFastMockExpression = canReuseFastMockExpression;
+        }
+
+        public ExpressionSyntax FastMockExpression { get; }
+
+        public ITypeSymbol ServiceType { get; }
+
+        public bool CanReuseFastMockExpression { get; }
+
+        public DetachedMockOrigin WithFastMockExpression(ExpressionSyntax fastMockExpression, bool canReuseFastMockExpression)
+        {
+            return new DetachedMockOrigin(fastMockExpression, ServiceType, canReuseFastMockExpression);
+        }
+    }
+
     internal static class FastMoqAnalysisHelpers
     {
         internal const string FastMoqMockerTypeName = "FastMoq.Mocker";
@@ -126,6 +147,22 @@ namespace FastMoq.Analyzers
 
             var originalDefinitionName = namedType.OriginalDefinition.ToDisplayString();
             return originalDefinitionName is FastMoqMockModelTypeName or FastMoqMockModelGenericTypeName;
+        }
+
+        public static bool IsFastMoqFastMockType(ITypeSymbol? type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            if (type.ToDisplayString() == "FastMoq.Providers.IFastMock")
+            {
+                return true;
+            }
+
+            return type is INamedTypeSymbol namedType &&
+                   namedType.OriginalDefinition.ToDisplayString() == "FastMoq.Providers.IFastMock<T>";
         }
 
         public static bool IsFastMoqMockerMethod(IMethodSymbol method, string methodName)
@@ -474,6 +511,133 @@ namespace FastMoq.Analyzers
             }
         }
 
+        public static bool TryResolveDetachedMockOrigin(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out DetachedMockOrigin origin)
+        {
+            return TryResolveDetachedMockOrigin(expression, semanticModel, cancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out origin);
+        }
+
+        private static bool TryResolveDetachedMockOrigin(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out DetachedMockOrigin origin)
+        {
+            expression = Unwrap(expression);
+
+            if (expression is InvocationExpressionSyntax invocationExpression &&
+                TryResolveDetachedMockOrigin(invocationExpression, semanticModel, cancellationToken, visitedSymbols, out origin))
+            {
+                return true;
+            }
+
+            if (TryResolveDetachedMockOriginFromSymbol(expression, semanticModel, cancellationToken, visitedSymbols, out origin))
+            {
+                return true;
+            }
+
+            origin = default;
+            return false;
+        }
+
+        private static bool TryResolveDetachedMockOrigin(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out DetachedMockOrigin origin)
+        {
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) || method is null)
+            {
+                origin = default;
+                return false;
+            }
+
+            if (IsFastMoqMockerMethod(method, "CreateStandaloneFastMock") && method.TypeArguments.Length == 1)
+            {
+                origin = new DetachedMockOrigin(invocationExpression, method.TypeArguments[0], canReuseFastMockExpression: false);
+                return true;
+            }
+
+            if (TryGetRegistryCreateMockServiceType(invocationExpression, method, semanticModel, cancellationToken, out var serviceType))
+            {
+                origin = new DetachedMockOrigin(invocationExpression, serviceType, canReuseFastMockExpression: false);
+                return true;
+            }
+
+            if ((method.Name == "AsMoq" || method.Name == "AsNSubstitute") && invocationExpression.Expression is MemberAccessExpressionSyntax adapterAccess)
+            {
+                if (TryResolveDetachedMockOrigin(adapterAccess.Expression, semanticModel, cancellationToken, visitedSymbols, out origin))
+                {
+                    if (CanReuseDetachedFastMockExpression(adapterAccess.Expression, semanticModel, cancellationToken))
+                    {
+                        origin = origin.WithFastMockExpression(adapterAccess.Expression, canReuseFastMockExpression: true);
+                    }
+
+                    return true;
+                }
+            }
+
+            origin = default;
+            return false;
+        }
+
+        private static bool TryResolveDetachedMockOriginFromSymbol(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out DetachedMockOrigin origin)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            if (symbol is null || !visitedSymbols.Add(symbol))
+            {
+                origin = default;
+                return false;
+            }
+
+            foreach (var sourceExpression in GetTrackedMockSourceExpressions(symbol, semanticModel, cancellationToken))
+            {
+                if (TryResolveDetachedMockOrigin(sourceExpression, semanticModel, cancellationToken, visitedSymbols, out origin))
+                {
+                    if (CanReuseDetachedFastMockExpression(expression, semanticModel, cancellationToken))
+                    {
+                        origin = origin.WithFastMockExpression(expression, canReuseFastMockExpression: true);
+                    }
+
+                    return true;
+                }
+            }
+
+            origin = default;
+            return false;
+        }
+
+        private static bool CanReuseDetachedFastMockExpression(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            expression = Unwrap(expression);
+            if (!IsFastMoqFastMockType(semanticModel.GetTypeInfo(expression, cancellationToken).Type))
+            {
+                return false;
+            }
+
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            return symbol is ILocalSymbol or IFieldSymbol;
+        }
+
+        private static bool TryGetRegistryCreateMockServiceType(InvocationExpressionSyntax invocationExpression, IMethodSymbol method, SemanticModel semanticModel, CancellationToken cancellationToken, out ITypeSymbol serviceType)
+        {
+            method = method.ReducedFrom ?? method;
+            if (method.Name != "CreateMock" ||
+                method.TypeArguments.Length != 1 ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !IsDefaultMockingProviderAccess(memberAccess.Expression, semanticModel, cancellationToken))
+            {
+                serviceType = default!;
+                return false;
+            }
+
+            serviceType = method.TypeArguments[0];
+            return true;
+        }
+
+        private static bool IsDefaultMockingProviderAccess(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var property = symbolInfo.Symbol as IPropertySymbol ?? symbolInfo.CandidateSymbols.OfType<IPropertySymbol>().FirstOrDefault();
+            return property is not null &&
+                   property.Name == "Default" &&
+                   property.IsStatic &&
+                   property.ContainingType.ToDisplayString() == MockingProviderRegistryTypeName;
+        }
+
         public static bool ContainsGetOrCreateMock(SyntaxNode root, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             return root.DescendantNodes()
@@ -599,6 +763,27 @@ namespace FastMoq.Analyzers
             return true;
         }
 
+        public static bool TryBuildVerifyReplacement(ExpressionSyntax verifyTargetExpression, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement, out bool requiresProvidersNamespace)
+        {
+            if (TryResolveTrackedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var trackedOrigin) &&
+                TryBuildVerifyReplacement(trackedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+            {
+                requiresProvidersNamespace = true;
+                return true;
+            }
+
+            if (TryResolveDetachedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var detachedOrigin) &&
+                TryBuildVerifyReplacement(detachedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+            {
+                requiresProvidersNamespace = true;
+                return true;
+            }
+
+            replacement = string.Empty;
+            requiresProvidersNamespace = false;
+            return false;
+        }
+
         public static bool TryBuildVerifyReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
         {
             replacement = string.Empty;
@@ -622,7 +807,7 @@ namespace FastMoq.Analyzers
 
             if (arguments.Count == 2)
             {
-                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, "TimesSpec", out var convertedArgument, out var omitArgument))
                 {
                     return false;
                 }
@@ -636,6 +821,47 @@ namespace FastMoq.Analyzers
             var mockerExpression = origin.MockerExpression.WithoutTrivia().ToString();
             var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
             replacement = $"{mockerExpression}.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
+            return true;
+        }
+
+        private static bool TryBuildVerifyReplacement(DetachedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
+        {
+            replacement = string.Empty;
+            if (!origin.CanReuseFastMockExpression ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null ||
+                !IsMoqVerifyMethod(method))
+            {
+                return false;
+            }
+
+            var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count == 0 || arguments.Count > 2)
+            {
+                return false;
+            }
+
+            var replacementArguments = new List<string>
+            {
+                origin.FastMockExpression.WithoutTrivia().ToString(),
+                arguments[0].WithoutTrivia().ToString(),
+            };
+
+            if (arguments.Count == 2)
+            {
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, "TimesSpec", out var convertedArgument, out var omitArgument))
+                {
+                    return false;
+                }
+
+                if (!omitArgument)
+                {
+                    replacementArguments.Add(convertedArgument);
+                }
+            }
+
+            var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
+            replacement = $"MockingProviderRegistry.Default.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
             return true;
         }
 

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -609,7 +609,7 @@ namespace FastMoq.Analyzers
 
             var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
             var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
-            return symbol is ILocalSymbol or IFieldSymbol;
+            return symbol is ILocalSymbol or IFieldSymbol or IPropertySymbol or IParameterSymbol;
         }
 
         private static bool TryGetRegistryCreateMockServiceType(InvocationExpressionSyntax invocationExpression, IMethodSymbol method, SemanticModel semanticModel, CancellationToken cancellationToken, out ITypeSymbol serviceType)
@@ -768,7 +768,7 @@ namespace FastMoq.Analyzers
             if (TryResolveTrackedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var trackedOrigin) &&
                 TryBuildVerifyReplacement(trackedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
             {
-                requiresProvidersNamespace = true;
+                requiresProvidersNamespace = false;
                 return true;
             }
 
@@ -807,7 +807,7 @@ namespace FastMoq.Analyzers
 
             if (arguments.Count == 2)
             {
-                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, "TimesSpec", out var convertedArgument, out var omitArgument))
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
                 {
                     return false;
                 }
@@ -849,7 +849,7 @@ namespace FastMoq.Analyzers
 
             if (arguments.Count == 2)
             {
-                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, "TimesSpec", out var convertedArgument, out var omitArgument))
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
                 {
                     return false;
                 }

--- a/FastMoq.Core/Extensions/MockerHttpExtensions.cs
+++ b/FastMoq.Core/Extensions/MockerHttpExtensions.cs
@@ -15,6 +15,9 @@ namespace FastMoq.Extensions
         /// This entry point remains supported after v5.
         /// New tests should prefer the provider-neutral request helpers in this class for HTTP behavior.
         /// Advanced protected-member setups remain available from the Moq provider package for migration scenarios.
+        /// When the current <see cref="Mocker" /> is still using the built-in HTTP compatibility registrations,
+        /// repeated calls update that built-in handler and <see cref="IHttpClientFactory" /> path.
+        /// If the test replaces <see cref="IHttpClientFactory" /> explicitly, it owns <c>CreateClient(...)</c> behavior.
         /// </remarks>
         public static HttpClient CreateHttpClient(this Mocker mocker, string clientName = "FastMoqHttpClient", string baseAddress = "http://localhost",
             HttpStatusCode statusCode = HttpStatusCode.OK, string stringContent = "[{'id':1}]")
@@ -146,16 +149,43 @@ namespace FastMoq.Extensions
 
         private static void EnsureProviderNeutralHttpDependencies(Mocker mocker, Uri baseUri, HttpStatusCode statusCode, string stringContent)
         {
-            if (!mocker.Contains<HttpMessageHandler>() && !mocker.typeMap.ContainsKey(typeof(HttpMessageHandler)))
+            if (!mocker.Contains<HttpMessageHandler>())
             {
-                var handler = new ConfigurableHttpMessageHandler(() => CreateResponse(statusCode, stringContent));
-                mocker.AddType<HttpMessageHandler>(_ => handler, replace: true);
+                if (mocker.typeMap.TryGetValue(typeof(HttpMessageHandler), out _) &&
+                    mocker.GetObject<HttpMessageHandler>() is ConfigurableHttpMessageHandler existingHandler)
+                {
+                    existingHandler.UpdateDefault(() => CreateResponse(statusCode, stringContent));
+                }
+                else if (!mocker.typeMap.ContainsKey(typeof(HttpMessageHandler)))
+                {
+                    var handler = new ConfigurableHttpMessageHandler(() => CreateResponse(statusCode, stringContent));
+                    mocker.AddType<HttpMessageHandler>(_ => handler, replace: true);
+                }
             }
 
-            if (!mocker.Contains<IHttpClientFactory>() && !mocker.typeMap.ContainsKey(typeof(IHttpClientFactory)))
+            if (!mocker.Contains<IHttpClientFactory>())
             {
-                var factory = new ConfigurableHttpClientFactory(() => mocker.CreateHttpClientInternal(baseUri));
-                mocker.AddType<IHttpClientFactory>(factory, replace: true);
+                if (mocker.typeMap.TryGetValue(typeof(IHttpClientFactory), out _) &&
+                    mocker.GetObject<IHttpClientFactory>() is ConfigurableHttpClientFactory existingFactory)
+                {
+                    existingFactory.UpdateClientFactory(() => mocker.CreateHttpClientInternal(baseUri));
+                }
+                else if (!mocker.typeMap.ContainsKey(typeof(IHttpClientFactory)))
+                {
+                    var factory = new ConfigurableHttpClientFactory(() => mocker.CreateHttpClientInternal(baseUri));
+                    mocker.AddType<IHttpClientFactory>(factory, replace: true);
+                }
+            }
+        }
+
+        internal static void RemoveBuiltInHttpClientFactoryRegistration(Mocker mocker)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            if (mocker.typeMap.TryGetValue(typeof(IHttpClientFactory), out _) &&
+                mocker.GetObject<IHttpClientFactory>() is ConfigurableHttpClientFactory)
+            {
+                mocker.typeMap.Remove(typeof(IHttpClientFactory));
             }
         }
 
@@ -200,8 +230,20 @@ namespace FastMoq.Extensions
             return handler;
         }
 
-        private sealed class ConfigurableHttpClientFactory(Func<HttpClient> clientFactory) : IHttpClientFactory
+        private sealed class ConfigurableHttpClientFactory : IHttpClientFactory
         {
+            private Func<HttpClient> clientFactory;
+
+            public ConfigurableHttpClientFactory(Func<HttpClient> clientFactory)
+            {
+                this.clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+            }
+
+            internal void UpdateClientFactory(Func<HttpClient> clientFactory)
+            {
+                this.clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+            }
+
             public HttpClient CreateClient(string name) => clientFactory();
         }
 

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -2045,6 +2045,7 @@ namespace FastMoq
         internal IFastMock GetOrCreateFastMock(Type type, bool nonPublic = false, params object?[] args)
         {
             type = CleanType(type);
+            PrepareBuiltInOverrideForTrackedMock(type);
             if (!Contains(type))
             {
                 return CreateFastMock(type, nonPublic, args);
@@ -2069,12 +2070,21 @@ namespace FastMoq
             options ??= new MockRequestOptions();
             var args = options.ConstructorArgs ?? Array.Empty<object?>();
             var allowNonPublicConstructors = ShouldAllowNonPublicConstructorsForMockRequest(options.AllowNonPublicConstructors);
+            PrepareBuiltInOverrideForTrackedMock(typeof(T));
 
             MockModel model = options.ServiceKey == null
                 ? GetMockModelFast(typeof(T), allowNonPublicConstructors, args)
                 : GetKeyedMockModelFast(typeof(T), options.ServiceKey, allowNonPublicConstructors, args);
 
             return GetTypedFastMockFromModel<T>(model);
+        }
+
+        private void PrepareBuiltInOverrideForTrackedMock(Type type)
+        {
+            if (type == typeof(IHttpClientFactory))
+            {
+                MockerHttpExtensions.RemoveBuiltInHttpClientFactoryRegistration(this);
+            }
         }
 
         private IFastMock<T> GetTypedFastMockFromModel<T>(MockModel model) where T : class

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -2070,7 +2070,11 @@ namespace FastMoq
             options ??= new MockRequestOptions();
             var args = options.ConstructorArgs ?? Array.Empty<object?>();
             var allowNonPublicConstructors = ShouldAllowNonPublicConstructorsForMockRequest(options.AllowNonPublicConstructors);
-            PrepareBuiltInOverrideForTrackedMock(typeof(T));
+
+            if (options.ServiceKey == null)
+            {
+                PrepareBuiltInOverrideForTrackedMock(typeof(T));
+            }
 
             MockModel model = options.ServiceKey == null
                 ? GetMockModelFast(typeof(T), allowNonPublicConstructors, args)

--- a/FastMoq.Tests/HttpTests.cs
+++ b/FastMoq.Tests/HttpTests.cs
@@ -237,6 +237,31 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public async Task GetOrCreateMock_KeyedIHttpClientFactory_ShouldNotReplaceUnkeyedBuiltInCompatibilityFactory()
+        {
+            _ = Mocks.CreateHttpClient(
+                clientName: "WeatherApiClient",
+                baseAddress: "https://keyed.fastmoq.test/",
+                statusCode: HttpStatusCode.Accepted,
+                stringContent: "{\"temperature\":31}");
+
+            var keyedFactory = Mocks.GetOrCreateMock<IHttpClientFactory>(new MockRequestOptions
+            {
+                ServiceKey = "keyed"
+            });
+
+            var resolvedFactory = Mocks.GetObject<IHttpClientFactory>();
+            using var builtInClient = resolvedFactory!.CreateClient("any-name");
+            var response = await builtInClient.GetAsync("weather");
+
+            resolvedFactory.Should().NotBeNull();
+            resolvedFactory.Should().NotBeSameAs(keyedFactory.Instance);
+            builtInClient.BaseAddress.Should().Be(new Uri("https://keyed.fastmoq.test/"));
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            (await Mocks.GetStringContent(response.Content)).Should().Be("{\"temperature\":31}");
+        }
+
+        [Fact]
         public async Task WhenHttpRequestJson_ShouldReturnJsonContent_WithApplicationJsonMediaType()
         {
             Mocks.WhenHttpRequestJson(HttpMethod.Post, "/api/orders", "{\"status\":\"created\"}", HttpStatusCode.Created);

--- a/FastMoq.Tests/HttpTests.cs
+++ b/FastMoq.Tests/HttpTests.cs
@@ -196,6 +196,47 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public async Task CreateHttpClient_ShouldUpdateBuiltInHttpClientFactoryConfiguration()
+        {
+            using var client = Mocks.CreateHttpClient(
+                clientName: "WeatherApiClient",
+                baseAddress: "https://api.fastmoq.test/",
+                statusCode: HttpStatusCode.Accepted,
+                stringContent: "{\"temperature\":25}");
+
+            client.BaseAddress.Should().Be(new Uri("https://api.fastmoq.test/"));
+
+            var factory = Mocks.GetObject<IHttpClientFactory>();
+            using var factoryClient = factory!.CreateClient("any-name");
+
+            factoryClient.BaseAddress.Should().Be(new Uri("https://api.fastmoq.test/"));
+
+            var response = await factoryClient.GetAsync("weather");
+
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            (await Mocks.GetStringContent(response.Content)).Should().Be("{\"temperature\":25}");
+        }
+
+        [Fact]
+        public void GetObject_IHttpClientFactory_ShouldPreferTrackedMock_OverBuiltInCompatibilityFactory()
+        {
+            using var expected = new HttpClient
+            {
+                BaseAddress = new Uri("http://tracked-factory.fastmoq/")
+            };
+
+            var factory = Mocks.GetOrCreateMock<IHttpClientFactory>();
+            factory.AsMoq().Setup(x => x.CreateClient("tracked")).Returns(expected);
+
+            var resolvedFactory = Mocks.GetObject<IHttpClientFactory>();
+            using var client = Mocks.CreateHttpClient(clientName: "tracked");
+
+            resolvedFactory.Should().NotBeNull();
+            client.Should().BeSameAs(expected);
+            resolvedFactory!.CreateClient("tracked").Should().BeSameAs(expected);
+        }
+
+        [Fact]
         public async Task WhenHttpRequestJson_ShouldReturnJsonContent_WithApplicationJsonMediaType()
         {
             Mocks.WhenHttpRequestJson(HttpMethod.Post, "/api/orders", "{\"status\":\"created\"}", HttpStatusCode.Created);

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,12 +111,6 @@ Summary of the major architecture, packaging, API, and documentation changes aft
 
 Intentional v4 breaking changes, with migration notes for changed behavior.
 
-### 🔄 [Migration Guide](./migration/README.md)
-
-Practical guidance for moving from the `3.0.0` public release toward the current v4 provider-first patterns.
-
-- Complete analyzer catalog and package-aware migration guidance
-
 ## 🎯 Quick Navigation
 
 ### By Experience Level
@@ -125,7 +119,7 @@ Practical guidance for moving from the `3.0.0` public release toward the current
 | ---------- | ---------- | ---------- |
 | **New to Mocking** | [Getting Started](./getting-started/README.md) | [Simple Cookbook Examples](./cookbook/README.md#api-controller-testing) |
 | **Coming from Moq** | [Feature Parity](./feature-parity/README.md) | [Migration Guide](./migration/README.md) |
-| **Enterprise Teams** | [Sample Applications](./samples/README.md) | Performance notes coming in a future published docs pass |
+| **Enterprise Teams** | [Sample Applications](./samples/README.md) | [Testing Guide](./getting-started/testing-guide.md) |
 
 ### By Use Case
 

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -994,7 +994,17 @@ public class WeatherServiceMoqCompatibilityTests : MockerTestBase<WeatherService
 
 ### Advanced HTTP Testing Scenarios
 
-#### Combining CreateHttpClient with IHttpClientFactory
+#### Using the built-in IHttpClientFactory compatibility path
+
+FastMoq exposes a lightweight `IHttpClientFactory` so tests that only need `CreateClient(...)` can stay on the built-in HTTP helper path. The returned clients use the same provider-neutral handler as `Mocks.HttpClient` and `CreateHttpClient()`.
+
+That compatibility factory accepts the requested client name but does not apply per-name configuration.
+
+Later `CreateHttpClient(...)` calls update the built-in compatibility factory and handler to use the latest base address and default response.
+
+If you intentionally replace `IHttpClientFactory` with `GetOrCreateMock<IHttpClientFactory>()` or `AddType<IHttpClientFactory>(...)`, that replacement wins and you must set up `CreateClient(...)` yourself.
+
+If the code under test depends on named clients, typed clients, or `services.AddHttpClient(...)` configuration semantics, register your own `IHttpClientFactory` or a typed service provider instead of relying on this compatibility factory.
 
 ```csharp
 using Microsoft.Extensions.Options;
@@ -1004,35 +1014,24 @@ public class WeatherServiceFactoryTests : MockerTestBase<WeatherService>
     protected override Action<Mocker> SetupMocksAction => mocker =>
     {
         mocker.SetupOptions(new WeatherApiOptions { ApiKey = "test-api-key" });
-        
-        // ✅ CreateHttpClient automatically sets up IHttpClientFactory
-        mocker.CreateHttpClient(
-            clientName: "WeatherApiClient",
-            baseAddress: "https://api.openweathermap.org/data/2.5/",
-            statusCode: HttpStatusCode.OK,
-            stringContent: JsonSerializer.Serialize(new { temperature = 25, description = "Sunny" })
-        );
-        
-        // IHttpClientFactory is now available and configured
+
+        mocker.WhenHttpRequestJson(
+            HttpMethod.Get,
+            "/weather?q=Miami&appid=test-api-key",
+            JsonSerializer.Serialize(new { temperature = 25, description = "Sunny" }));
     };
 
     [Fact]
-    public async Task GetWeatherAsync_ShouldUseNamedHttpClient_WhenIHttpClientFactoryProvided()
+    public async Task GetWeatherAsync_ShouldResolveFactoryBackedClient_WhenIHttpClientFactoryIsNeeded()
     {
-        // Arrange
-        var city = "Miami";
-        
-        // Act - Service can use named HttpClient from factory
         var factory = Mocks.GetObject<IHttpClientFactory>();
         var httpClient = factory!.CreateClient("WeatherApiClient");
-        
-        var response = await httpClient.GetAsync($"weather?q={city}&appid=test-api-key");
+
+        var response = await httpClient.GetAsync("weather?q=Miami&appid=test-api-key");
         var content = await Mocks.GetStringContent(response.Content);
-        
-        // Assert
+
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         content.Should().Contain("temperature");
-        httpClient.BaseAddress.Should().Be("https://api.openweathermap.org/data/2.5/");
     }
 }
 ```
@@ -1130,7 +1129,7 @@ FastMoq provides several convenient methods for HTTP testing:
 
 **Key Benefits:**
 
-- **Auto-Registration**: `CreateHttpClient` automatically registers `HttpClient` and `IHttpClientFactory`
+- **Factory Compatibility**: `Mocker` exposes a lightweight `IHttpClientFactory` backed by the same provider-neutral handler as `CreateHttpClient()`
 - **Default Values**: Provides sensible defaults (localhost, OK status, JSON response)
 - **Flexible Setup**: `WhenHttpRequest(...)` and `WhenHttpRequestJson(...)` keep most HTTP customization provider-neutral
 - **Content Helpers**: Built-in methods for content extraction

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -998,6 +998,8 @@ public class WeatherServiceMoqCompatibilityTests : MockerTestBase<WeatherService
 
 FastMoq exposes a lightweight `IHttpClientFactory` so tests that only need `CreateClient(...)` can stay on the built-in HTTP helper path. The returned clients use the same provider-neutral handler as `Mocks.HttpClient` and `CreateHttpClient()`.
 
+Resolve that built-in factory with `GetObject<IHttpClientFactory>()`, `GetRequiredObject<IHttpClientFactory>()`, or normal constructor injection. Do not call `GetOrCreateMock<IHttpClientFactory>()` unless you mean to replace the built-in compatibility factory with a tracked mock.
+
 That compatibility factory accepts the requested client name but does not apply per-name configuration.
 
 Later `CreateHttpClient(...)` calls update the built-in compatibility factory and handler to use the latest base address and default response.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -166,7 +166,10 @@ dotnet add package FastMoq.Azure
 dotnet add package FastMoq.AzureFunctions
 dotnet add package FastMoq.Database
 dotnet add package FastMoq.Web
+# choose the provider package your tests actually use
 dotnet add package FastMoq.Provider.Moq
+# or
+# dotnet add package FastMoq.Provider.NSubstitute
 ```
 
 ### Package Manager Console
@@ -189,7 +192,10 @@ Split-package example:
 <PackageReference Include="FastMoq.AzureFunctions" Version="4.*" />
 <PackageReference Include="FastMoq.Database" Version="4.*" />
 <PackageReference Include="FastMoq.Web" Version="4.*" />
+<!-- choose the provider package your tests actually use -->
 <PackageReference Include="FastMoq.Provider.Moq" Version="4.*" />
+<!-- or -->
+<!-- <PackageReference Include="FastMoq.Provider.NSubstitute" Version="4.*" /> -->
 ```
 
 > Note: this guide targets the current v4 release line. For the release delta relative to the last public `3.0.0` package, see [What's New Since 3.0.0](../whats-new/README.md).
@@ -227,8 +233,9 @@ If you intentionally want Moq-specific tracked `.Setup(...)`, `SetupSequence(...
 
 ```bash
 dotnet add package FastMoq.Provider.Moq
-dotnet add package Moq
 ```
+
+`FastMoq.Provider.Moq` already brings `Moq` transitively. Add a top-level `Moq` package reference only when you intentionally need to pin or override the transitive Moq version.
 
 ```csharp
 using FastMoq.Providers;
@@ -483,11 +490,10 @@ When a test needs a specific constructor, prefer the explicit constructor-select
 ```csharp
 internal sealed class ArchiveInvokerTests : MockerTestBase<ArchiveInvoker>
 {
-    private readonly MockFileSystem fileSystem = new();
-
     protected override Action<Mocker>? SetupMocksAction => mocker =>
     {
-        mocker.AddType<IFileSystem>(fileSystem, replace: true);
+        var fileSystem = mocker.GetFileSystem();
+
         mocker.AddServiceProvider(services =>
         {
             services.AddLogging();
@@ -501,6 +507,8 @@ internal sealed class ArchiveInvokerTests : MockerTestBase<ArchiveInvoker>
         new Type?[] { typeof(IFileSystem), typeof(IServiceScopeFactory) };
 }
 ```
+
+Use `GetFileSystem()` when you want FastMoq's shared in-memory file system to flow through both constructor injection and the typed provider. Reach for `AddType<IFileSystem>(...)` only when you intentionally need a different `IFileSystem` instance than the built-in one.
 
 See the [Testing Guide](./testing-guide.md#explicit-constructor-selection-in-tests) for the full constructor-selection rules and the [typed `IServiceProvider` helper guidance](./testing-guide.md#typed-iserviceprovider-helpers) for framework-heavy ServiceCollection patterns.
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -556,6 +556,8 @@ FastMoq has a built-in `HttpClient` helper path. Every new `Mocker` starts with 
 
 Use that built-in path when the subject depends on `HttpClient` directly or only needs `IHttpClientFactory.CreateClient(...)` to hand back a client. Prefer `WhenHttpRequest(...)` and `WhenHttpRequestJson(...)` for provider-neutral response setup instead of manually composing handlers for every test.
 
+Use `GetObject<IHttpClientFactory>()`, `GetRequiredObject<IHttpClientFactory>()`, or normal constructor injection when you want that built-in factory. Do not call `GetOrCreateMock<IHttpClientFactory>()` unless you intentionally want to replace the built-in compatibility factory with a tracked mock.
+
 The built-in compatibility factory accepts the requested client name but does not apply per-name configuration.
 
 If you call `CreateHttpClient(...)` again later with a different base address or default response, FastMoq updates that built-in compatibility factory and handler to match the latest helper call.

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -215,9 +215,8 @@ That overload exposes the supplied `IServiceProvider`, a fixed `IServiceScope`, 
 If a constructor takes `IServiceScopeFactory`, prefer this shape:
 
 ```csharp
-var fileSystem = new MockFileSystem();
+var fileSystem = Mocks.GetFileSystem();
 
-Mocks.AddType<IFileSystem>(fileSystem, replace: true);
 Mocks.AddServiceProvider(services =>
 {
     services.AddLogging();
@@ -229,7 +228,9 @@ Mocks.AddServiceProvider(services =>
 var scopeFactory = Mocks.GetRequiredObject<IServiceScopeFactory>();
 ```
 
-instead of building a provider manually and registering only `provider.GetRequiredService<IServiceScopeFactory>()`. Keeping the full typed provider registered makes constructor injection, nested framework resolution, and service-scope behavior stay aligned.
+Reuse `GetFileSystem()` when you want FastMoq's shared in-memory file system to stay aligned across constructor injection and the typed provider. Use `AddType<IFileSystem>(...)` only when you intentionally want to replace that shared instance with a custom file system.
+
+Instead of building a provider manually and registering only `provider.GetRequiredService<IServiceScopeFactory>()`, keep the full typed provider registered so constructor injection, nested framework resolution, and service-scope behavior stay aligned.
 
 When framework code should resolve a mix of real DI registrations and normal FastMoq collaborators, use `includeMockerFallback: true` on `CreateTypedServiceProvider(...)`, `CreateTypedServiceScope(...)`, `AddServiceProvider(...)`, or `AddServiceScope(...)`.
 
@@ -526,12 +527,12 @@ protected override Action<MockerPolicyOptions>? ConfigureMockerPolicy => policy 
 
 ### `IFileSystem`
 
-`GetObject<IFileSystem>()` can return the predefined `MockFileSystem` instance when FastMoq is in lenient mode and you have not already registered or created an `IFileSystem` dependency.
+Use `GetFileSystem()` when you want FastMoq's shared in-memory file system explicitly. `GetObject<IFileSystem>()` resolves that same shared instance when built-in file-system resolution is enabled and you have not already registered or created an `IFileSystem` dependency.
 
 Use this when you want a real in-memory file system quickly:
 
 ```csharp
-var fileSystem = Mocks.GetObject<IFileSystem>();
+var fileSystem = Mocks.GetFileSystem();
 fileSystem.File.WriteAllText("/tmp/test.txt", "hello");
 ```
 
@@ -545,11 +546,23 @@ Mocks.GetOrCreateMock<IFileSystem>()
 
 FastMoq can automatically provide a built-in `IFileSystem` backed by its shared in-memory `MockFileSystem` when the built-in file-system resolution is enabled and you have not already registered `IFileSystem` explicitly.
 
+Reach for `AddType<IFileSystem>(...)` only when you intentionally need to replace that shared file system with a custom or isolated instance.
+
 If you need the wider filesystem abstraction family (`IFile`, `IPath`, `IDirectory`, and related factories) to resolve coherently alongside that shared file system, call [AddFileSystemAbstractionMapping()](../../api/FastMoq.Mocker.yml).
 
 ### `HttpClient`
 
-FastMoq has a built-in `HttpClient` helper path. Use the existing HTTP setup helpers when the subject depends on `HttpClient` directly instead of manually composing handlers for every test.
+FastMoq has a built-in `HttpClient` helper path. Every new `Mocker` starts with a shared `HttpClient` plus a lightweight `IHttpClientFactory` compatibility registration backed by the same provider-neutral handler.
+
+Use that built-in path when the subject depends on `HttpClient` directly or only needs `IHttpClientFactory.CreateClient(...)` to hand back a client. Prefer `WhenHttpRequest(...)` and `WhenHttpRequestJson(...)` for provider-neutral response setup instead of manually composing handlers for every test.
+
+The built-in compatibility factory accepts the requested client name but does not apply per-name configuration.
+
+If you call `CreateHttpClient(...)` again later with a different base address or default response, FastMoq updates that built-in compatibility factory and handler to match the latest helper call.
+
+If you intentionally replace `IHttpClientFactory` with `GetOrCreateMock<IHttpClientFactory>()` or `AddType<IHttpClientFactory>(...)`, that replacement wins and you own `CreateClient(...)` setup yourself.
+
+If the subject depends on named-client, typed-client, or `AddHttpClient(...)` configuration semantics, register your own `IHttpClientFactory` or typed provider-backed container instead of relying on the built-in compatibility factory.
 
 ### `DbContext`
 

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -39,7 +39,7 @@ The sample test projects intentionally showcase FastMoq extension helpers so you
 
 ### HTTP / External API
 
-- `CreateHttpClient()` to quickly register an `HttpClient` and (if needed) an `IHttpClientFactory` with a default response.
+- `CreateHttpClient()` to quickly use FastMoq's built-in `HttpClient` path; a lightweight `IHttpClientFactory` is available for simple `CreateClient(...)` flows without per-name configuration, and later helper calls update that built-in factory path.
 - Prefer `WhenHttpRequest(...)` and `WhenHttpRequestJson(...)` for provider-neutral request matching and response setup.
 - Use `SetupHttpMessage(...)` only when you intentionally need Moq-specific protected `SendAsync` behavior from the Moq provider package. Keep `using FastMoq.Extensions;`, add `FastMoq.Provider.Moq`, and select the Moq provider for the test assembly when you use that compatibility path.
 - Content helpers: `GetStringContent`, `GetContentBytesAsync()`, `GetContentStreamAsync()` for asserting raw payloads.
@@ -117,7 +117,7 @@ The current samples are intentionally focused. Consider extending locally with:
 
 | Goal | Helper | Notes |
 | ---- | ------ | ----- |
-| Fast default HttpClient | `CreateHttpClient()` | Registers handler + factory if missing |
+| Fast default HttpClient | `CreateHttpClient()` | Uses the built-in handler; lightweight factory compatibility is available without per-name configuration |
 | Custom per‑test HTTP behavior | `WhenHttpRequest()` / `WhenHttpRequestJson()` | Provider-neutral request matching and response setup |
 | Mock EF Core context | `GetMockDbContext<T>()` | Auto sets up DbSets; seed data before use |
 | Extra independent same-type double | `CreateStandaloneFastMock<T>()` | Detached provider-first mock; does not register into the current `Mocker` |

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -39,7 +39,7 @@ The sample test projects intentionally showcase FastMoq extension helpers so you
 
 ### HTTP / External API
 
-- `CreateHttpClient()` to quickly use FastMoq's built-in `HttpClient` path; a lightweight `IHttpClientFactory` is available for simple `CreateClient(...)` flows without per-name configuration, and later helper calls update that built-in factory path.
+- `CreateHttpClient()` to quickly use FastMoq's built-in `HttpClient` path; a lightweight `IHttpClientFactory` is available for simple `CreateClient(...)` flows without per-name configuration, and later helper calls update that built-in factory path. Resolve or inject that built-in factory as an object instead of calling `GetOrCreateMock<IHttpClientFactory>()` unless you intentionally want to replace it.
 - Prefer `WhenHttpRequest(...)` and `WhenHttpRequestJson(...)` for provider-neutral request matching and response setup.
 - Use `SetupHttpMessage(...)` only when you intentionally need Moq-specific protected `SendAsync` behavior from the Moq provider package. Keep `using FastMoq.Extensions;`, add `FastMoq.Provider.Moq`, and select the Moq provider for the test assembly when you use that compatibility path.
 - Content helpers: `GetStringContent`, `GetContentBytesAsync()`, `GetContentStreamAsync()` for asserting raw payloads.


### PR DESCRIPTION
## Summary

This PR finishes the analyzer follow-up for detached provider-first creation and verification guidance, and folds in the related HTTP helper and documentation corrections that were completed alongside it.

## What changed

- update legacy analyzer guidance so detached creation points to `CreateStandaloneFastMock<T>()` or `MockingProviderRegistry.Default.CreateMock<T>()` instead of defaulting to a separate `Mocker` plus tracked mock flow
- extend `FMOQ0024` and the migration code fix so detached `IFastMock<T>` verification migrates to `MockingProviderRegistry.Default.Verify(...)`, while tracked verification stays on `Mocks.Verify<T>(...)`
- add analyzer regression coverage for detached aliases, async-return verification, and revised legacy creation guidance
- update the built-in `IHttpClientFactory` compatibility path so later `CreateHttpClient(...)` calls refresh the shared compatibility factory and handler, while intentional tracked `IHttpClientFactory` overrides still win
- clarify package/provider docs so `FastMoq.Provider.Moq` is documented as bringing `Moq` transitively, split-package guidance shows provider choice, and HTTP/file-system docs match current runtime behavior
- remove the duplicate Migration Guide section from the docs index

## Validation

- `dotnet test FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj`
- `dotnet test FastMoq.Tests/FastMoq.Tests.csproj --filter "FullyQualifiedName~FastMoq.Tests.HttpTests"`

Fixes #111