### PR TITLE
Centralize package metadata and refresh NuGet descriptions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <FastMoqBasePackageTags>fastmoq;testing;unit-testing;mocking;test-doubles;dependency-injection;provider-first</FastMoqBasePackageTags>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsPackable)' == 'false' and '$(MSBuildProjectName)' != 'FastMoq.Analyzers.Tests'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)FastMoq.Analyzers\FastMoq.Analyzers.csproj"
                       OutputItemType="Analyzer"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,23 @@
+<Project>
+  <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+    <Authors>Winland, $(AssemblyName)</Authors>
+    <Company>$(Authors)</Company>
+    <Copyright>© 2021–2026 Christopher Winland</Copyright>
+    <PackageCopyright>© 2021–2026 Christopher Winland</PackageCopyright>
+    <PackageId>$(AssemblyName)</PackageId>
+    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseFile>license.txt</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Link="README.md" Pack="true" PackagePath="\" />
+    <Content Include="$(MSBuildThisFileDirectory)LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,6 +18,6 @@
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(MSBuildThisFileDirectory)README.md" Link="README.md" Pack="true" PackagePath="\" />
-    <Content Include="$(MSBuildThisFileDirectory)LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
+    <Content Include="$(MSBuildThisFileDirectory)license.txt" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 </Project>

--- a/FastMoq.Abstractions/FastMoq.Abstractions.csproj
+++ b/FastMoq.Abstractions/FastMoq.Abstractions.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Provider abstractions shared by FastMoq core and provider packages.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;mocking;provider;abstractions;testing</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Provider contracts and abstractions for FastMoq, including IMockingProvider, IFastMock&lt;T&gt;, TimesSpec, and MockRequestOptions for custom providers and advanced extension scenarios.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);mock-provider;abstractions;contracts;extensibility</PackageTags>
     <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Analyzers/FastMoq.Analyzers.csproj
+++ b/FastMoq.Analyzers/FastMoq.Analyzers.csproj
@@ -4,21 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Roslyn analyzers and code fixes for FastMoq migrations and recommended provider-first test patterns.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;analyzers;roslyn;testing;mocking;migration</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Roslyn analyzers and code fixes for FastMoq migrations, provider-first test patterns, and deprecated API cleanup.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);analyzers;roslyn;code-analysis;diagnostics;migration</PackageTags>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);NU5128;RS2008;RS1038</NoWarn>
   </PropertyGroup>
@@ -28,11 +17,6 @@
       <_Parameter1>FastMoq.Analyzers.Tests</_Parameter1>
     </AssemblyAttribute>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('$(OutputPath)$(AssemblyName).pdb')" />
   </ItemGroup>

--- a/FastMoq.Azure/FastMoq.Azure.csproj
+++ b/FastMoq.Azure/FastMoq.Azure.csproj
@@ -5,37 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Shared Azure SDK testing helpers for FastMoq, including credentials, pageable builders, Key Vault helpers, and Azure-oriented service registration support.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;Azure;testing;mocking;credentials;storage;keyvault</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Azure SDK testing helpers for FastMoq, including credential builders, pageable builders, Key Vault helpers, Azure-oriented configuration, and service registration support.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);azure;azure-sdk;credentials;pageable;keyvault;storage</PackageTags>
     <IsPackable>true</IsPackable>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>FastMoq.Azure</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.AzureFunctions/FastMoq.AzureFunctions.csproj
+++ b/FastMoq.AzureFunctions/FastMoq.AzureFunctions.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Azure Functions worker and HTTP-trigger test helpers for FastMoq, including typed FunctionContext.InstanceServices setup, HttpRequestData/HttpResponseData builders, and body readers.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;AzureFunctions;FunctionContext;HttpRequestData;HttpResponseData;testing;mocking</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Azure Functions isolated worker testing helpers for FastMoq, including typed FunctionContext.InstanceServices setup, HttpRequestData and HttpResponseData builders, and request or response body readers.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);azure-functions;functions-worker;http-trigger;function-context</PackageTags>
     <IsPackable>true</IsPackable>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Core/FastMoq.Core.csproj
+++ b/FastMoq.Core/FastMoq.Core.csproj
@@ -5,40 +5,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2023 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Core FastMoq runtime for automatic test double creation, constructor injection, provider-neutral testing helpers, and bundled migration analyzers. Uses reflection by default in v4, includes Moq compatibility, and supports additional providers when added explicitly.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>Easy;fast;injection;inject;mock;extension;Moq;framework;mocking;class;provider</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Provider-first FastMoq runtime for automatic test double creation, constructor injection, provider-neutral verification, and test helper primitives. Includes the default reflection provider, bundled Moq compatibility, and Roslyn analyzers for migration guidance.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);provider-neutral;mock-provider;verification;reflection;moq;migration</PackageTags>
     <IsPackable>true</IsPackable>
     <NoWarn>1701;1702;S1309;S4018;S2436</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>FastMoq</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.pdb')" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Database/FastMoq.Database.csproj
+++ b/FastMoq.Database/FastMoq.Database.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Entity Framework and database-focused helpers for FastMoq.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;EntityFramework;DbContext;mocking;testing</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Entity Framework Core testing helpers for FastMoq, including DbContext setup, mocked DbSet support, handle-based mode selection, and real in-memory context flows.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);efcore;entity-framework;dbcontext;database-testing</PackageTags>
     <IsPackable>true</IsPackable>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Provider.Moq/FastMoq.Provider.Moq.csproj
+++ b/FastMoq.Provider.Moq/FastMoq.Provider.Moq.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Moq provider package for FastMoq v4 transition. This bundled dependency will be removed from FastMoq.Core in v5.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;Moq;provider;testing;mocking</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Moq provider package for FastMoq with tracked IFastMock&lt;T&gt; extension methods for setup and verification, plus v4 migration support for Moq-shaped test flows.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);moq;mock-provider;migration;compatibility</PackageTags>
     <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Provider.NSubstitute/FastMoq.Provider.NSubstitute.csproj
+++ b/FastMoq.Provider.NSubstitute/FastMoq.Provider.NSubstitute.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2026 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>NSubstitute provider package for FastMoq.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>FastMoq;NSubstitute;provider;testing;mocking</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>NSubstitute provider package for FastMoq with tracked IFastMock&lt;T&gt; extension methods for NSubstitute-specific arrange and verification flows.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);nsubstitute;mock-provider;alternative-provider</PackageTags>
     <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq.Web/FastMoq.Web.csproj
+++ b/FastMoq.Web/FastMoq.Web.csproj
@@ -5,36 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2023 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Easy and fast extension of the famous Moq mocking framework for mocking and auto injection of classes when testing. Now with Blazor support.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>Easy;fast;injection;inject;mock;extension;Moq;moqthis;framework;mocking;class</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>ASP.NET Core and Blazor testing helpers for FastMoq, including controller and HttpContext setup, claims-principal helpers, IHttpContextAccessor registration, and component-test utilities.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);aspnetcore;blazor;httpcontext;controllers;web-testing</PackageTags>
     <IsPackable>true</IsPackable>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastMoq/FastMoq.csproj
+++ b/FastMoq/FastMoq.csproj
@@ -5,37 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <DebugType>portable</DebugType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Winland, $(AssemblyName)</Authors>
-    <Company>$(Authors)</Company>
-    <Copyright>Copyright(c) 2021-2022 Christopher Winland</Copyright>
-    <PackageId>$(AssemblyName)</PackageId>
-    <Description>Complete FastMoq package for automatic test double creation, constructor injection, EF testing helpers, Azure Functions worker helpers, and Blazor/web testing support. Includes the core runtime plus optional framework helper integrations.</Description>
-    <PackageProjectUrl>https://github.com/cwinland/FastMoq</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cwinland/FastMoq</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>Easy;fast;injection;inject;mock;extension;Moq;moqthis;framework;mocking;class;blazor</PackageTags>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Complete FastMoq testing framework with provider-first test doubles, automatic dependency injection, provider-neutral verification, and first-party helpers for EF Core, Azure SDK, Azure Functions, HttpClient, and ASP.NET Core. Includes Roslyn analyzers for migration guidance.</Description>
+    <PackageTags>$(FastMoqBasePackageTags);provider-neutral;aspnetcore;blazor;efcore;azure;azure-functions;analyzers;moq;nsubstitute</PackageTags>
     <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.github\workflows\publish_FastMoq.yml" Link="publish_FastMoq.yml" />
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('..\FastMoq.Analyzers\bin\$(Configuration)\netstandard2.0\FastMoq.Analyzers.pdb')" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\LICENSE.TXT" Link="license.txt" Pack="true" PackagePath="license.txt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FastMoq.Analyzers\FastMoq.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />


### PR DESCRIPTION
## Summary
- centralize shared NuGet and GitHub package metadata in `Directory.Build.targets` so `IsPackable` drives the common package settings
- keep the shared FastMoq package tag vocabulary in `Directory.Build.props` and refresh package descriptions and tag sets across the published packages
- remove duplicated README and license pack entries plus other repeated package metadata from the individual package projects

## Validation
- `dotnet pack "C:\Users\chriswin\source\repos\FastMoq\FastMoq-Release.sln" -c Release`
- inspected representative generated package metadata from the built `.nupkg` files to confirm descriptions, tags, and copyright