### PR TITLE
Align analyzer guidance with migration docs

### DIFF
--- a/FastMoq.Analyzers.Tests/AnalyzerDocumentationTests.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerDocumentationTests.cs
@@ -14,8 +14,9 @@ namespace FastMoq.Analyzers.Tests
         public void MigrationGuideAnalyzerCatalog_ShouldListEveryPublicDiagnosticId()
         {
             var catalogSection = ReadAnalyzerCatalogSection();
-            var documentedIds = Regex.Matches(catalogSection, @"FMOQ\d{4}")
-                .Select(match => match.Value)
+            const string AnalyzerCatalogTableRowPattern = @"^\|\s*`(FMOQ\d{4})`\s*\|";
+            var documentedIds = Regex.Matches(catalogSection, AnalyzerCatalogTableRowPattern, RegexOptions.Multiline)
+                .Select(match => match.Groups[1].Value)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(item => item, StringComparer.Ordinal)
                 .ToArray();
@@ -32,7 +33,7 @@ namespace FastMoq.Analyzers.Tests
 
         private static string ReadAnalyzerCatalogSection()
         {
-            var readmePath = FindRepositoryFile(Path.Combine("docs", "migration", "README.md"));
+            var readmePath = Path.Combine(AppContext.BaseDirectory, "docs", "migration", "README.md");
             var readme = File.ReadAllText(readmePath);
             const string startMarker = "## Analyzer catalog";
             const string endMarker = "## Migration summary";
@@ -44,20 +45,6 @@ namespace FastMoq.Analyzers.Tests
             Assert.True(endIndex > startIndex, $"Could not find '{endMarker}' after '{startMarker}' in '{readmePath}'.");
 
             return readme.Substring(startIndex, endIndex - startIndex);
-        }
-
-        private static string FindRepositoryFile(string relativePath)
-        {
-            for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
-            {
-                var candidate = Path.Combine(directory.FullName, relativePath);
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-
-            throw new FileNotFoundException($"Could not locate repository file '{relativePath}' starting from '{AppContext.BaseDirectory}'.");
         }
     }
 }

--- a/FastMoq.Analyzers.Tests/AnalyzerDocumentationTests.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerDocumentationTests.cs
@@ -1,0 +1,63 @@
+using FastMoq.Analyzers;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace FastMoq.Analyzers.Tests
+{
+    public class AnalyzerDocumentationTests
+    {
+        [Fact]
+        public void MigrationGuideAnalyzerCatalog_ShouldListEveryPublicDiagnosticId()
+        {
+            var catalogSection = ReadAnalyzerCatalogSection();
+            var documentedIds = Regex.Matches(catalogSection, @"FMOQ\d{4}")
+                .Select(match => match.Value)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(item => item, StringComparer.Ordinal)
+                .ToArray();
+
+            var expectedIds = typeof(DiagnosticIds)
+                .GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(field => field.FieldType == typeof(string) && field.IsLiteral && !field.IsInitOnly)
+                .Select(field => (string) field.GetRawConstantValue()!)
+                .OrderBy(item => item, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(expectedIds, documentedIds);
+        }
+
+        private static string ReadAnalyzerCatalogSection()
+        {
+            var readmePath = FindRepositoryFile(Path.Combine("docs", "migration", "README.md"));
+            var readme = File.ReadAllText(readmePath);
+            const string startMarker = "## Analyzer catalog";
+            const string endMarker = "## Migration summary";
+
+            var startIndex = readme.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(startIndex >= 0, $"Could not find '{startMarker}' in '{readmePath}'.");
+
+            var endIndex = readme.IndexOf(endMarker, startIndex, StringComparison.Ordinal);
+            Assert.True(endIndex > startIndex, $"Could not find '{endMarker}' after '{startMarker}' in '{readmePath}'.");
+
+            return readme.Substring(startIndex, endIndex - startIndex);
+        }
+
+        private static string FindRepositoryFile(string relativePath)
+        {
+            for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+            {
+                var candidate = Path.Combine(directory.FullName, relativePath);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new FileNotFoundException($"Could not locate repository file '{relativePath}' starting from '{AppContext.BaseDirectory}'.");
+        }
+    }
+}

--- a/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
+++ b/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
@@ -42,4 +42,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\docs\migration\README.md" Link="docs\migration\README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
+++ b/FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
@@ -43,7 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\docs\migration\README.md" Link="docs\migration\README.md">
+    <Content Include="../docs/migration/README.md" Link="docs/migration/README.md">
+      <TargetPath>docs/migration/README.md</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2842,7 +2842,12 @@ class Sample
     }
 }";
 
-            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
         }
 
@@ -2871,7 +2876,12 @@ class Sample
     }
 }";
 
-            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
         }
 
@@ -2939,7 +2949,52 @@ class Sample
     }
 }";
 
-            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenProviderIsRegisteredWithoutExplicitSetAsDefaultAndIsTheOnlyVisibleProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static void Initialize()
+    {
+        MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance);
+    }
+}
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
         }
 
@@ -3201,6 +3256,44 @@ class Sample
         {
             const string SOURCE = @"
 using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenMoqIsRegisteredWithoutExplicitSetAsDefaultAndIsTheOnlyVisibleProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static void Initialize()
+    {
+        MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance);
+    }
+}
 
 class Sample
 {

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -3040,6 +3040,48 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenMultipleAliasesResolveToSameSingleProviderTypeThroughInterfaceTypedVariable()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static void Initialize()
+    {
+        IMockingProvider provider = MoqMockingProvider.Instance;
+        MockingProviderRegistry.Register(""legacy-moq"", provider);
+        MockingProviderRegistry.Register(""archived-moq"", provider);
+    }
+}
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenAssemblyDeclaresMoqDefaultProvider()
         {
             const string SOURCE = @"
@@ -3368,6 +3410,46 @@ using FastMoq.Providers.MoqProvider;
 
 [assembly: FastMoqRegisterProvider(""legacy-moq"", typeof(MoqMockingProvider))]
 [assembly: FastMoqRegisterProvider(""archived-moq"", typeof(MoqMockingProvider))]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenMultipleAliasesResolveToSameSingleProviderTypeThroughInterfaceTypedVariable()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static void Initialize()
+    {
+        IMockingProvider provider = MoqMockingProvider.Instance;
+        MockingProviderRegistry.Register(""legacy-moq"", provider);
+        MockingProviderRegistry.Register(""archived-moq"", provider);
+    }
+}
 
 class Sample
 {

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -109,6 +109,40 @@ namespace FastMoq.Analyzers.Tests
         }
 
         [Fact]
+        public void UseProviderFirstObjectAccess_ShouldExplainInstanceVersusObjectRetrieval()
+        {
+            Assert.Equal(
+                "Use provider-first dependency instance access",
+                DiagnosticDescriptors.UseProviderFirstObjectAccess.Title.ToString());
+            Assert.Equal(
+                "Use '{0}' for the dependency instance instead of using '.Object' on a tracked FastMoq mock",
+                DiagnosticDescriptors.UseProviderFirstObjectAccess.MessageFormat.ToString());
+
+            var description = DiagnosticDescriptors.UseProviderFirstObjectAccess.Description.ToString();
+            Assert.Contains(".Instance", description);
+            Assert.Contains("GetObject<T>()", description);
+            Assert.Contains("GetRequiredObject<T>()", description);
+            Assert.Contains("AsMoq().Object", description);
+        }
+
+        [Fact]
+        public void AvoidTrackedMockShimAlias_ShouldExplainVerificationOnlyScope()
+        {
+            Assert.Equal(
+                "Avoid verification-only Mock<T> aliases for tracked mocks",
+                DiagnosticDescriptors.AvoidTrackedMockShimAlias.Title.ToString());
+            Assert.Equal(
+                "Tracked alias '{0}' is only used for Moq Verify calls. Prefer an IFastMock<T> handle or verify directly with Mocker.Verify<T>(...).",
+                DiagnosticDescriptors.AvoidTrackedMockShimAlias.MessageFormat.ToString());
+
+            var description = DiagnosticDescriptors.AvoidTrackedMockShimAlias.Description.ToString();
+            Assert.Contains("field, property, or local", description);
+            Assert.Contains("Moq Verify(...)", description);
+            Assert.Contains("IFastMock<T>", description);
+            Assert.Contains("Moq-specific setup", description);
+        }
+
+        [Fact]
         public async Task TrackedMockObjectAnalyzer_ShouldReportAndFix_GetMockObjectUsage()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2999,6 +2999,47 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenMultipleAliasesResolveToSameSingleProviderType()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static void Initialize()
+    {
+        MockingProviderRegistry.Register(""legacy-moq"", MoqMockingProvider.Instance);
+        MockingProviderRegistry.Register(""archived-moq"", MoqMockingProvider.Instance);
+    }
+}
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenAssemblyDeclaresMoqDefaultProvider()
         {
             const string SOURCE = @"
@@ -3294,6 +3335,39 @@ static class Bootstrap
         MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance);
     }
 }
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenMultipleAssemblyAliasesResolveToSameSingleProviderType()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+[assembly: FastMoqRegisterProvider(""legacy-moq"", typeof(MoqMockingProvider))]
+[assembly: FastMoqRegisterProvider(""archived-moq"", typeof(MoqMockingProvider))]
 
 class Sample
 {

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -75,7 +75,7 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.UseProviderFirstVerify, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.AvoidBareTrackedVerify, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.AvoidFastMockVerifyHelperWrappers, DiagnosticSeverity.Info },
-            { DiagnosticDescriptors.AvoidProviderSpecificFastMockVerifyHelperWrappers, DiagnosticSeverity.Warning },
+            { DiagnosticDescriptors.AvoidProviderSpecificFastMockVerifyHelperWrappers, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferSharedMockFileSystem, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.UseFastArgMatcherInProviderFirstVerify, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.AvoidUnsupportedMoqMatcherInProviderFirstVerify, DiagnosticSeverity.Info },
@@ -140,6 +140,38 @@ namespace FastMoq.Analyzers.Tests
             Assert.Contains("Moq Verify(...)", description);
             Assert.Contains("IFastMock<T>", description);
             Assert.Contains("Moq-specific setup", description);
+        }
+
+        [Fact]
+        public void SelectProviderBeforeProviderSpecificApi_ShouldExplainEffectiveProviderResolution()
+        {
+            Assert.Equal(
+                "Resolve the matching provider before using provider-specific FastMoq APIs",
+                DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi.Title.ToString());
+            Assert.Equal(
+                "API '{0}' requires FastMoq provider '{1}', but this project does not resolve '{1}' as the effective provider. Use [assembly: FastMoqDefaultProvider(\"{1}\")], [assembly: FastMoqRegisterProvider(\"{1}\", typeof(...), SetAsDefault = true)], Push(\"{1}\"), SetDefault(\"{1}\"), or Register(\"{1}\", ..., setAsDefault: true).",
+                DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi.MessageFormat.ToString());
+
+            var description = DiagnosticDescriptors.SelectProviderBeforeProviderSpecificApi.Description.ToString();
+            Assert.Contains("single registered non-reflection provider", description);
+            Assert.Contains("multiple providers are visible", description);
+            Assert.Contains("select it explicitly", description);
+        }
+
+        [Fact]
+        public void RequireExplicitMoqOnboarding_ShouldExplainEffectiveMoqResolution()
+        {
+            Assert.Equal(
+                "Resolve Moq provider selection for legacy compatibility usage",
+                DiagnosticDescriptors.RequireExplicitMoqOnboarding.Title.ToString());
+            Assert.Equal(
+                "Legacy Moq-shaped FastMoq API '{0}' is in use, but this project does not resolve 'moq' as the effective provider. If the Moq provider is not already referenced, add 'FastMoq.Provider.Moq', then select 'moq' with [assembly: FastMoqDefaultProvider(\"moq\")] or [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)] when provider selection is otherwise ambiguous.",
+                DiagnosticDescriptors.RequireExplicitMoqOnboarding.MessageFormat.ToString());
+
+            var description = DiagnosticDescriptors.RequireExplicitMoqOnboarding.Description.ToString();
+            Assert.Contains("compile-time-visible provider registration", description);
+            Assert.Contains("Moq provider is missing", description);
+            Assert.Contains("multiple providers are visible", description);
         }
 
         [Fact]
@@ -2674,6 +2706,68 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenMoqIsTheOnlyVisibleRegisteredProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenNSubstituteIsTheOnlyVisibleRegisteredProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: false,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenLegacyGetMockIsUsedWithoutProviderSelection()
         {
             const string SOURCE = @"
@@ -3078,7 +3172,7 @@ class Sample
         }
 
         [Fact]
-        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenLegacyGetMockIsUsedWithoutExplicitOnboarding()
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenLegacyGetMockIsUsedWithoutResolvableMoqProvider()
         {
             const string SOURCE = @"
 using FastMoq;
@@ -3100,6 +3194,34 @@ class Sample
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
             Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
             Assert.Contains("GetMock<T>()", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenMoqIsTheOnlyVisibleRegisteredProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -178,6 +178,31 @@ class Sample
         }
 
         [Fact]
+        public async Task TrackedMockObjectAnalyzer_CodeFix_ShouldUseUpdatedDescriptorTitle()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.Logging;
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        var logger = Mocks.GetMock<ILogger<Sample>>().Object;
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new TrackedMockObjectAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.UseProviderFirstObjectAccess);
+
+            Assert.Single(codeFixTitles);
+            Assert.Equal("Use provider-first dependency instance access", codeFixTitles[0]);
+        }
+
+        [Fact]
         public async Task TrackedMockResetAnalyzer_ShouldReportAndFix_ResetUsage()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
@@ -629,6 +629,74 @@ interface IDependency
         }
 
         [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReportAndFix_WhenTrackedQualifiedStaticCallUsesProviderSpecificVerifyWrapper()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, Times times)
+        where T : class
+        => fastMock.AsMoq().Verify(expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        VerifyHelpers.Verify(Mocks.GetOrCreateMock<IDependency>(), x => x.Run(""alpha""), Times.Never());
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var matchingDiagnostics = diagnostics.Where(item => item.Id == DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers).OrderBy(item => item.Location.SourceSpan.Start).ToArray();
+            Assert.Equal(2, matchingDiagnostics.Length);
+            Assert.Equal(DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers, matchingDiagnostics[1].Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new FastMockVerifyHelperAnalyzer(), codeFixProvider, DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers, diagnosticOccurrence: 1);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, Times times)
+        where T : class
+        => fastMock.AsMoq().Verify(expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.Verify<IDependency>(x => x.Run(""alpha""), TimesSpec.NeverCalled);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task FastMockVerifyHelperAnalyzer_ShouldReportAndFix_WhenTrackedCallSiteUsesFastMoqVerifyWrapper()
         {
             const string SOURCE = @"
@@ -666,6 +734,72 @@ interface IDependency
             var expected = AnalyzerTestHelpers.NormalizeCode(@"
 using System;
 using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+        where T : class
+        => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.Verify<IDependency>(x => x.Run(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReportAndFix_WhenTrackedUsingStaticCallUsesFastMoqVerifyWrapper()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using static VerifyHelpers;
+using FastMoq;
+using FastMoq.Providers;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+        where T : class
+        => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Verify(Mocks.GetOrCreateMock<IDependency>(), x => x.Run(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var matchingDiagnostics = diagnostics.Where(item => item.Id == DiagnosticIds.AvoidFastMockVerifyHelperWrappers).OrderBy(item => item.Location.SourceSpan.Start).ToArray();
+            Assert.Equal(2, matchingDiagnostics.Length);
+            Assert.Equal(DiagnosticIds.AvoidFastMockVerifyHelperWrappers, matchingDiagnostics[1].Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new FastMockVerifyHelperAnalyzer(), codeFixProvider, DiagnosticIds.AvoidFastMockVerifyHelperWrappers, diagnosticOccurrence: 1);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using System.Linq.Expressions;
+using static VerifyHelpers;
 using FastMoq;
 using FastMoq.Providers;
 

--- a/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/PriorityIssueAnalyzerTests.cs
@@ -561,6 +561,173 @@ interface IDependency
         }
 
         [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReportAndFix_WhenTrackedCallSiteUsesProviderSpecificVerifyWrapper()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, Times times)
+        where T : class
+        => fastMock.AsMoq().Verify(expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.GetOrCreateMock<IDependency>().Verify(x => x.Run(""alpha""), Times.Never());
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var matchingDiagnostics = diagnostics.Where(item => item.Id == DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers).OrderBy(item => item.Location.SourceSpan.Start).ToArray();
+            Assert.Equal(2, matchingDiagnostics.Length);
+            Assert.Equal(DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers, matchingDiagnostics[1].Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new FastMockVerifyHelperAnalyzer(), codeFixProvider, DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers, diagnosticOccurrence: 1);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, Times times)
+        where T : class
+        => fastMock.AsMoq().Verify(expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.Verify<IDependency>(x => x.Run(""alpha""), TimesSpec.NeverCalled);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReportAndFix_WhenTrackedCallSiteUsesFastMoqVerifyWrapper()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+        where T : class
+        => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.GetOrCreateMock<IDependency>().Verify(x => x.Run(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var matchingDiagnostics = diagnostics.Where(item => item.Id == DiagnosticIds.AvoidFastMockVerifyHelperWrappers).OrderBy(item => item.Location.SourceSpan.Start).ToArray();
+            Assert.Equal(2, matchingDiagnostics.Length);
+            Assert.Equal(DiagnosticIds.AvoidFastMockVerifyHelperWrappers, matchingDiagnostics[1].Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new FastMockVerifyHelperAnalyzer(), codeFixProvider, DiagnosticIds.AvoidFastMockVerifyHelperWrappers, diagnosticOccurrence: 1);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+        where T : class
+        => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.Verify<IDependency>(x => x.Run(""alpha""), TimesSpec.Once);
+    }
+}
+
+interface IDependency
+{
+    void Run(string value);
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReportWithoutCodeFix_WhenTrackedCallSiteUsesBareVerifyWrapper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+
+static class VerifyHelpers
+{
+    internal static void Verify<T>(this IFastMock<T> fastMock)
+        where T : class
+        => MockingProviderRegistry.Default.Verify(fastMock, _ => _.ToString(), TimesSpec.Once);
+}
+
+class Sample
+{
+    void Execute(Mocker Mocks)
+    {
+        Mocks.GetOrCreateMock<IDependency>().Verify();
+    }
+}
+
+interface IDependency
+{
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var matchingDiagnostics = diagnostics.Where(item => item.Id == DiagnosticIds.AvoidFastMockVerifyHelperWrappers).OrderBy(item => item.Location.SourceSpan.Start).ToArray();
+            Assert.Equal(2, matchingDiagnostics.Length);
+            Assert.Equal(DiagnosticIds.AvoidFastMockVerifyHelperWrappers, matchingDiagnostics[1].Id);
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(SOURCE, new FastMockVerifyHelperAnalyzer(), codeFixProvider, DiagnosticIds.AvoidFastMockVerifyHelperWrappers, diagnosticOccurrence: 1);
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
         public async Task TrackedMockShimAnalyzer_ShouldReport_ForVerificationOnlyPropertyAlias()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers/Analyzers/FastMockVerifyHelperAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/FastMockVerifyHelperAnalyzer.cs
@@ -19,6 +19,7 @@ namespace FastMoq.Analyzers.Analyzers
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, Microsoft.CodeAnalysis.CSharp.SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
         }
 
         private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
@@ -32,7 +33,7 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            var wrapperKind = GetWrappedVerifyKind(methodDeclaration, methodSymbol.Parameters[0], context.SemanticModel, context.CancellationToken);
+            var wrapperKind = FastMoqAnalysisHelpers.GetFastMockVerifyWrapperKind(methodSymbol, context.SemanticModel, context.CancellationToken);
             var descriptor = wrapperKind switch
             {
                 FastMockVerifyWrapperKind.FastMoqBoundary => DiagnosticDescriptors.AvoidFastMockVerifyHelperWrappers,
@@ -51,108 +52,33 @@ namespace FastMoq.Analyzers.Analyzers
                 methodSymbol.Name));
         }
 
-        private static FastMockVerifyWrapperKind GetWrappedVerifyKind(MethodDeclarationSyntax methodDeclaration, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
-            var analysisRoot = methodDeclaration.ExpressionBody?.Expression ?? (SyntaxNode?) methodDeclaration.Body;
-            if (analysisRoot is null)
-            {
-                return FastMockVerifyWrapperKind.None;
-            }
-
-            var hasMoqVerify = false;
-            var hasAsMoqOnFastMock = false;
-            var hasDefaultVerifyOnFastMock = false;
-
-            foreach (var invocationExpression in analysisRoot.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
-            {
-                if (IsDefaultVerifyOnFastMock(invocationExpression, fastMockParameter, semanticModel, cancellationToken))
-                {
-                    hasDefaultVerifyOnFastMock = true;
-                    continue;
-                }
-
-                if (IsAsMoqOnFastMock(invocationExpression, fastMockParameter, semanticModel, cancellationToken))
-                {
-                    hasAsMoqOnFastMock = true;
-                    continue;
-                }
-
-                if (FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) &&
-                    method is not null &&
-                    FastMoqAnalysisHelpers.IsMoqVerifyMethod(method))
-                {
-                    hasMoqVerify = true;
-                }
-            }
-
-            if (hasAsMoqOnFastMock && hasMoqVerify)
-            {
-                return FastMockVerifyWrapperKind.ProviderSpecific;
-            }
-
-            if (hasDefaultVerifyOnFastMock)
-            {
-                return FastMockVerifyWrapperKind.FastMoqBoundary;
-            }
-
-            return FastMockVerifyWrapperKind.None;
-        }
-
-        private static bool IsAsMoqOnFastMock(InvocationExpressionSyntax invocationExpression, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
+            var invocationExpression = (InvocationExpressionSyntax) context.Node;
             if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
-                !FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
-                method is null)
+                !FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var methodSymbol) ||
+                methodSymbol is null)
             {
-                return false;
+                return;
             }
 
-            method = method.ReducedFrom ?? method;
-            return method.Name == "AsMoq" &&
-                method.ContainingNamespace.ToDisplayString() == FastMoqAnalysisHelpers.MoqProviderNamespace &&
-                ReferencesParameter(memberAccess.Expression, fastMockParameter, semanticModel, cancellationToken);
-        }
-
-        private static bool IsDefaultVerifyOnFastMock(InvocationExpressionSyntax invocationExpression, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
-                !FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
-                method is null)
+            var wrapperKind = FastMoqAnalysisHelpers.GetFastMockVerifyWrapperKind(methodSymbol, context.SemanticModel, context.CancellationToken);
+            var descriptor = wrapperKind switch
             {
-                return false;
+                FastMockVerifyWrapperKind.FastMoqBoundary => DiagnosticDescriptors.AvoidFastMockVerifyHelperWrappers,
+                FastMockVerifyWrapperKind.ProviderSpecific => DiagnosticDescriptors.AvoidProviderSpecificFastMockVerifyHelperWrappers,
+                _ => null,
+            };
+
+            if (descriptor is null)
+            {
+                return;
             }
 
-            method = method.ReducedFrom ?? method;
-            return method.Name == "Verify" &&
-                IsDefaultMockingProviderAccess(memberAccess.Expression, semanticModel, cancellationToken) &&
-                invocationExpression.ArgumentList.Arguments.Count > 0 &&
-                ReferencesParameter(invocationExpression.ArgumentList.Arguments[0].Expression, fastMockParameter, semanticModel, cancellationToken);
-        }
-
-        private static bool IsDefaultMockingProviderAccess(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            semanticModel = FastMoqAnalysisHelpers.GetSemanticModelForNode(expression, semanticModel);
-            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
-            var property = symbolInfo.Symbol as IPropertySymbol ?? symbolInfo.CandidateSymbols.OfType<IPropertySymbol>().FirstOrDefault();
-
-            return property is not null &&
-                property.Name == "Default" &&
-                property.IsStatic &&
-                property.ContainingType.ToDisplayString() == FastMoqAnalysisHelpers.MockingProviderRegistryTypeName;
-        }
-
-        private static bool ReferencesParameter(ExpressionSyntax expression, IParameterSymbol parameterSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            var symbolInfo = semanticModel.GetSymbolInfo(FastMoqAnalysisHelpers.Unwrap(expression), cancellationToken);
-            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
-            return SymbolEqualityComparer.Default.Equals(symbol, parameterSymbol);
-        }
-
-        private enum FastMockVerifyWrapperKind
-        {
-            None,
-            FastMoqBoundary,
-            ProviderSpecific,
+            context.ReportDiagnostic(Diagnostic.Create(
+                descriptor,
+                memberAccess.Name.GetLocation(),
+                methodSymbol.Name));
         }
     }
 }

--- a/FastMoq.Analyzers/Analyzers/FastMockVerifyHelperAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/FastMockVerifyHelperAnalyzer.cs
@@ -55,8 +55,7 @@ namespace FastMoq.Analyzers.Analyzers
         private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
             var invocationExpression = (InvocationExpressionSyntax) context.Node;
-            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
-                !FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var methodSymbol) ||
+            if (!FastMoqAnalysisHelpers.TryGetFastMockVerifyWrapperMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var methodSymbol) ||
                 methodSymbol is null)
             {
                 return;
@@ -75,9 +74,13 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
+            var diagnosticLocation = invocationExpression.Expression is MemberAccessExpressionSyntax memberAccess
+                ? memberAccess.Name.GetLocation()
+                : invocationExpression.Expression.GetLocation();
+
             context.ReportDiagnostic(Diagnostic.Create(
                 descriptor,
-                memberAccess.Name.GetLocation(),
+                diagnosticLocation,
                 methodSymbol.Name));
         }
     }

--- a/FastMoq.Analyzers/Analyzers/LegacyMoqOnboardingAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/LegacyMoqOnboardingAnalyzer.cs
@@ -20,18 +20,18 @@ namespace FastMoq.Analyzers.Analyzers
 
         private static void RegisterCompilationAnalysis(CompilationStartAnalysisContext context)
         {
-            var moqSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
-            var hasExplicitMoqProviderPackage = FastMoqAnalysisHelpers.HasMoqProviderPackage(context.Compilation);
+            var moqResolvedAsDefaultProvider = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
+            var hasMoqProviderPackage = FastMoqAnalysisHelpers.HasMoqProviderPackage(context.Compilation);
 
-            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqSelectedByDefault, hasExplicitMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqSelectedByDefault, hasExplicitMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqResolvedAsDefaultProvider, hasMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqResolvedAsDefaultProvider, hasMoqProviderPackage), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
         }
 
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, bool moqResolvedAsDefaultProvider, bool hasMoqProviderPackage)
         {
             var invocationExpression = (InvocationExpressionSyntax) context.Node;
             if (!TryGetLegacyMoqApi(invocationExpression, context.SemanticModel, context.CancellationToken, out var apiName) ||
-                IsExplicitlyOnboarded(invocationExpression, context.SemanticModel, context.CancellationToken, moqSelectedByDefault, hasExplicitMoqProviderPackage))
+                IsMoqCompatibilityAvailable(invocationExpression, context.SemanticModel, context.CancellationToken, moqResolvedAsDefaultProvider, hasMoqProviderPackage))
             {
                 return;
             }
@@ -42,11 +42,11 @@ namespace FastMoq.Analyzers.Analyzers
                 apiName));
         }
 
-        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, bool moqResolvedAsDefaultProvider, bool hasMoqProviderPackage)
         {
             var memberAccessExpression = (MemberAccessExpressionSyntax) context.Node;
             if (!TryGetLegacyMoqApi(memberAccessExpression, context.SemanticModel, context.CancellationToken, out var apiName) ||
-                IsExplicitlyOnboarded(memberAccessExpression, context.SemanticModel, context.CancellationToken, moqSelectedByDefault, hasExplicitMoqProviderPackage))
+                IsMoqCompatibilityAvailable(memberAccessExpression, context.SemanticModel, context.CancellationToken, moqResolvedAsDefaultProvider, hasMoqProviderPackage))
             {
                 return;
             }
@@ -57,10 +57,10 @@ namespace FastMoq.Analyzers.Analyzers
                 apiName));
         }
 
-        private static bool IsExplicitlyOnboarded(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken, bool moqSelectedByDefault, bool hasExplicitMoqProviderPackage)
+        private static bool IsMoqCompatibilityAvailable(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken, bool moqResolvedAsDefaultProvider, bool hasMoqProviderPackage)
         {
-            return hasExplicitMoqProviderPackage &&
-                (moqSelectedByDefault || FastMoqAnalysisHelpers.HasProviderSelectionInScope(node, semanticModel, FastMoqAnalysisHelpers.MoqProviderName, cancellationToken));
+            return hasMoqProviderPackage &&
+                (moqResolvedAsDefaultProvider || FastMoqAnalysisHelpers.HasProviderSelectionInScope(node, semanticModel, FastMoqAnalysisHelpers.MoqProviderName, cancellationToken));
         }
 
         private static bool TryGetLegacyMoqApi(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string apiName)

--- a/FastMoq.Analyzers/Analyzers/ProviderBootstrapAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/ProviderBootstrapAnalyzer.cs
@@ -20,14 +20,14 @@ namespace FastMoq.Analyzers.Analyzers
 
         private static void RegisterCompilationAnalysis(CompilationStartAnalysisContext context)
         {
-            var moqSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
-            var nsubstituteSelectedByDefault = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.NSubstituteProviderName, CancellationToken.None);
+            var moqResolvedAsDefaultProvider = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.MoqProviderName, CancellationToken.None);
+            var nsubstituteResolvedAsDefaultProvider = FastMoqAnalysisHelpers.IsProviderSelectedByDefault(context.Compilation, FastMoqAnalysisHelpers.NSubstituteProviderName, CancellationToken.None);
 
-            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqSelectedByDefault, nsubstituteSelectedByDefault), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqSelectedByDefault, nsubstituteSelectedByDefault), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeInvocation(nodeContext, moqResolvedAsDefaultProvider, nsubstituteResolvedAsDefaultProvider), Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(nodeContext => AnalyzeMemberAccess(nodeContext, moqResolvedAsDefaultProvider, nsubstituteResolvedAsDefaultProvider), Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression);
         }
 
-        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool nsubstituteSelectedByDefault)
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, bool moqResolvedAsDefaultProvider, bool nsubstituteResolvedAsDefaultProvider)
         {
             var invocationExpression = (InvocationExpressionSyntax) context.Node;
             if (!FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var method) ||
@@ -37,8 +37,8 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqSelectedByDefault) ||
-                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteSelectedByDefault) ||
+            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqResolvedAsDefaultProvider) ||
+                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteResolvedAsDefaultProvider) ||
                 FastMoqAnalysisHelpers.HasProviderSelectionInScope(invocationExpression, context.SemanticModel, providerName, context.CancellationToken))
             {
                 return;
@@ -51,7 +51,7 @@ namespace FastMoq.Analyzers.Analyzers
                 providerName));
         }
 
-        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, bool moqSelectedByDefault, bool nsubstituteSelectedByDefault)
+        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, bool moqResolvedAsDefaultProvider, bool nsubstituteResolvedAsDefaultProvider)
         {
             var memberAccessExpression = (MemberAccessExpressionSyntax) context.Node;
             if (!FastMoqAnalysisHelpers.TryGetPropertySymbol(memberAccessExpression, context.SemanticModel, context.CancellationToken, out var property) ||
@@ -61,8 +61,8 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
-            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqSelectedByDefault) ||
-                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteSelectedByDefault) ||
+            if ((providerName == FastMoqAnalysisHelpers.MoqProviderName && moqResolvedAsDefaultProvider) ||
+                (providerName == FastMoqAnalysisHelpers.NSubstituteProviderName && nsubstituteResolvedAsDefaultProvider) ||
                 FastMoqAnalysisHelpers.HasProviderSelectionInScope(memberAccessExpression, context.SemanticModel, providerName, context.CancellationToken))
             {
                 return;

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
                         context.RegisterCodeFix(
                             CodeAction.Create(
-                                "Use provider-first object access",
+                                DiagnosticDescriptors.UseProviderFirstObjectAccess.Title.ToString(),
                                 cancellationToken => ReplaceMemberAccessAsync(document, memberAccess, BuildObjectReplacementAsync, cancellationToken),
                                 nameof(DiagnosticIds.UseProviderFirstObjectAccess)),
                             diagnostic);

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -138,8 +138,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
                         var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
                         if (semanticModel is null ||
-                            invocationExpression.Expression is not MemberAccessExpressionSyntax wrapperAccess ||
-                            !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(wrapperAccess.Expression, semanticModel, invocationExpression, context.CancellationToken, out _, out _))
+                            !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(invocationExpression, semanticModel, context.CancellationToken, out _, out _))
                         {
                             return;
                         }
@@ -572,8 +571,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             if (root is null || semanticModel is null ||
-                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
-                !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(memberAccess.Expression, semanticModel, invocationExpression, cancellationToken, out var replacementText, out var requiresProvidersNamespace))
+                !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(invocationExpression, semanticModel, cancellationToken, out var replacementText, out var requiresProvidersNamespace))
             {
                 return document;
             }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -26,6 +26,8 @@ namespace FastMoq.Analyzers.CodeFixes
             DiagnosticIds.UseProviderFirstReset,
             DiagnosticIds.UseVerifyLogged,
             DiagnosticIds.UseProviderFirstVerify,
+            DiagnosticIds.AvoidFastMockVerifyHelperWrappers,
+            DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers,
             DiagnosticIds.UseFastArgMatcherInProviderFirstVerify,
             DiagnosticIds.UseConsistentMockRetrieval,
             DiagnosticIds.UseProviderFirstMockRetrieval,
@@ -121,6 +123,32 @@ namespace FastMoq.Analyzers.CodeFixes
                                 "Use provider-first Verify(...)",
                                 cancellationToken => ReplaceVerifyInvocationAsync(document, invocationExpression, cancellationToken),
                                 nameof(DiagnosticIds.UseProviderFirstVerify)),
+                            diagnostic);
+                        break;
+                    }
+
+                case DiagnosticIds.AvoidFastMockVerifyHelperWrappers:
+                case DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers:
+                    {
+                        var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                        if (invocationExpression is null)
+                        {
+                            return;
+                        }
+
+                        var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                        if (semanticModel is null ||
+                            invocationExpression.Expression is not MemberAccessExpressionSyntax wrapperAccess ||
+                            !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(wrapperAccess.Expression, semanticModel, invocationExpression, context.CancellationToken, out _, out _))
+                        {
+                            return;
+                        }
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Use explicit FastMoq verification",
+                                cancellationToken => ReplaceFastMockVerifyWrapperInvocationAsync(document, invocationExpression, cancellationToken),
+                                diagnostic.Id),
                             diagnostic);
                         break;
                     }
@@ -523,6 +551,29 @@ namespace FastMoq.Analyzers.CodeFixes
             if (root is null || semanticModel is null ||
                 invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
                 !FastMoqAnalysisHelpers.TryBuildVerifyReplacement(memberAccess.Expression, semanticModel, invocationExpression, cancellationToken, out var replacementText, out var requiresProvidersNamespace))
+            {
+                return document;
+            }
+
+            var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
+                .WithTriviaFrom(invocationExpression);
+            var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
+
+            if (requiresProvidersNamespace)
+            {
+                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+            }
+
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static async Task<Document> ReplaceFastMockVerifyWrapperInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !FastMoqAnalysisHelpers.TryBuildFastMockVerifyWrapperUsageReplacement(memberAccess.Expression, semanticModel, invocationExpression, cancellationToken, out var replacementText, out var requiresProvidersNamespace))
             {
                 return document;
             }

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -8,12 +8,12 @@ namespace FastMoq.Analyzers
 
         public static readonly DiagnosticDescriptor UseProviderFirstObjectAccess = new(
             DiagnosticIds.UseProviderFirstObjectAccess,
-            "Use provider-first object access",
-            "Use '{0}' instead of '.Object' on tracked FastMoq mocks",
+            "Use provider-first dependency instance access",
+            "Use '{0}' for the dependency instance instead of using '.Object' on a tracked FastMoq mock",
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Tracked FastMoq mocks should use provider-first instance access instead of raw Mock.Object retrieval.");
+            description: "When the code only needs the resolved dependency instance, stay on the provider-first surface instead of going through Mock<T>.Object. Use .Instance when you already have an IFastMock<T> handle, or use GetObject<T>() / GetRequiredObject<T>() when the code is retrieving the dependency from Mocker. Keep AsMoq().Object only for a deliberate local Moq-only compatibility pocket.");
 
         public static readonly DiagnosticDescriptor UseProviderFirstReset = new(
             DiagnosticIds.UseProviderFirstReset,
@@ -302,12 +302,12 @@ namespace FastMoq.Analyzers
 
         public static readonly DiagnosticDescriptor AvoidTrackedMockShimAlias = new(
             DiagnosticIds.AvoidTrackedMockShimAlias,
-            "Avoid tracked Mock<T> shim aliases",
-            "Tracked alias '{0}' is typed as 'Mock<T>' and keeps later work on the Moq surface. Prefer an IFastMock<T> handle plus Mocker.Verify<T>(...).",
+            "Avoid verification-only Mock<T> aliases for tracked mocks",
+            "Tracked alias '{0}' is only used for Moq Verify calls. Prefer an IFastMock<T> handle or verify directly with Mocker.Verify<T>(...).",
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Properties, fields, and locals typed as Mock<T> but sourced from tracked FastMoq mocks unnecessarily keep verification and helper usage provider-specific.");
+            description: "This rule applies when a field, property, or local is typed as Mock<T>, comes from a tracked FastMoq mock, and is only used later for Moq Verify(...) calls. Replace the alias with an IFastMock<T> handle, or keep verification explicit at the call site with Mocker.Verify<T>(...). Keep a Mock<T> alias only when that symbol also needs Moq-specific setup or other raw Mock<T> behavior.");
 
         public static readonly DiagnosticDescriptor AvoidRawMockCreationInFastMoqSuites = new(
             DiagnosticIds.AvoidRawMockCreationInFastMoqSuites,

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -143,12 +143,12 @@ namespace FastMoq.Analyzers
 
         public static readonly DiagnosticDescriptor SelectProviderBeforeProviderSpecificApi = new(
             DiagnosticIds.SelectProviderBeforeProviderSpecificApi,
-            "Select a provider before using provider-specific FastMoq APIs",
-            "API '{0}' requires FastMoq provider '{1}', but this project does not select it. Reflection remains the default. Use [assembly: FastMoqDefaultProvider(\"{1}\")], [assembly: FastMoqRegisterProvider(\"{1}\", typeof(...), SetAsDefault = true)], Push(\"{1}\"), SetDefault(\"{1}\"), or Register(\"{1}\", ..., setAsDefault: true).",
+            "Resolve the matching provider before using provider-specific FastMoq APIs",
+            "API '{0}' requires FastMoq provider '{1}', but this project does not resolve '{1}' as the effective provider. Use [assembly: FastMoqDefaultProvider(\"{1}\")], [assembly: FastMoqRegisterProvider(\"{1}\", typeof(...), SetAsDefault = true)], Push(\"{1}\"), SetDefault(\"{1}\"), or Register(\"{1}\", ..., setAsDefault: true).",
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Provider-specific FastMoq APIs require an explicit provider selection because reflection remains the default in v4. Assembly-level defaults can use FastMoqDefaultProviderAttribute when the provider name is already resolvable, or FastMoqRegisterProviderAttribute when registration and selection need to happen together.");
+            description: "Provider-specific FastMoq APIs require the matching effective provider. FastMoq can infer a single registered non-reflection provider when that provider is visible through compile-time registration metadata, but once multiple providers are visible or the intended provider is not registered, select it explicitly at assembly scope or inside the local execution scope.");
 
         public static readonly DiagnosticDescriptor PreferTypedProviderExtensions = new(
             DiagnosticIds.PreferTypedProviderExtensions,
@@ -224,12 +224,12 @@ namespace FastMoq.Analyzers
 
         public static readonly DiagnosticDescriptor RequireExplicitMoqOnboarding = new(
             DiagnosticIds.RequireExplicitMoqOnboarding,
-            "Add explicit Moq onboarding for legacy compatibility usage",
-            "Legacy Moq-shaped FastMoq API '{0}' is in use without explicit Moq onboarding. If this project stays on FastMoq.Core, add 'FastMoq.Provider.Moq' and select 'moq' with [assembly: FastMoqDefaultProvider(\"moq\")] or [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)].",
+            "Resolve Moq provider selection for legacy compatibility usage",
+            "Legacy Moq-shaped FastMoq API '{0}' is in use, but this project does not resolve 'moq' as the effective provider. If the Moq provider is not already referenced, add 'FastMoq.Provider.Moq', then select 'moq' with [assembly: FastMoqDefaultProvider(\"moq\")] or [assembly: FastMoqRegisterProvider(\"moq\", typeof(MoqMockingProvider), SetAsDefault = true)] when provider selection is otherwise ambiguous.",
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "Core-only projects can keep legacy Moq-shaped FastMoq usage during migration, but that path should be explicit. Add the FastMoq.Provider.Moq package when staying on FastMoq.Core, and declare moq as the selected provider so future cleanup and analyzer guidance stay deterministic.");
+            description: "Legacy Moq-shaped FastMoq usage requires the Moq provider to be available and selected as the effective provider. A single compile-time-visible provider registration can satisfy that automatically, but when the Moq provider is missing or multiple providers are visible, add the Moq provider package if needed and select moq explicitly so the compatibility path stays deterministic.");
 
         public static readonly DiagnosticDescriptor UseProviderFirstVerify = new(
             DiagnosticIds.UseProviderFirstVerify,
@@ -263,7 +263,7 @@ namespace FastMoq.Analyzers
             "Avoid provider-specific IFastMock.Verify wrappers",
             "Wrapper '{0}(...)' reintroduces provider-specific verification through IFastMock<T>. Use provider-first verification at the call site instead of routing through AsMoq().Verify(...) or provider-specific Times adapters.",
             Category,
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: "IFastMock.Verify wrappers that route through AsMoq().Verify(...), Moq Verify(...), or TimesSpec-to-Times conversion helpers hide tracked-versus-detached intent and pull provider-specific verification back into shared helper code. Keep those provider-specific escape hatches local to the call site instead of baking them into a new wrapper API.");
 

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -46,7 +46,7 @@ namespace FastMoq.Analyzers
         public const string UseTimesSpecAtHelperBoundary = "FMOQ0008";
 
         /// <summary>
-        /// Select a provider explicitly before using provider-specific APIs.
+        /// Resolve the matching provider before using provider-specific APIs.
         /// </summary>
         public const string SelectProviderBeforeProviderSpecificApi = "FMOQ0009";
 
@@ -116,7 +116,7 @@ namespace FastMoq.Analyzers
         public const string PreserveTrackedResolutionDuringAddTypeMigration = "FMOQ0022";
 
         /// <summary>
-        /// Require explicit Moq onboarding when legacy Moq-shaped APIs remain in use.
+        /// Resolve Moq provider selection when legacy Moq-shaped APIs remain in use.
         /// </summary>
         public const string RequireExplicitMoqOnboarding = "FMOQ0023";
 

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -60,6 +60,13 @@ namespace FastMoq.Analyzers
         }
     }
 
+    internal enum FastMockVerifyWrapperKind
+    {
+        None,
+        FastMoqBoundary,
+        ProviderSpecific,
+    }
+
     internal static class FastMoqAnalysisHelpers
     {
         internal const string FastMoqMockerTypeName = "FastMoq.Mocker";
@@ -816,6 +823,68 @@ namespace FastMoq.Analyzers
             return false;
         }
 
+        public static bool TryBuildFastMockVerifyWrapperUsageReplacement(ExpressionSyntax verifyTargetExpression, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement, out bool requiresProvidersNamespace)
+        {
+            replacement = string.Empty;
+            requiresProvidersNamespace = false;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null ||
+                GetFastMockVerifyWrapperKind(method, semanticModel, cancellationToken) == FastMockVerifyWrapperKind.None)
+            {
+                return false;
+            }
+
+            if (TryResolveTrackedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var trackedOrigin) &&
+                TryBuildFastMockVerifyWrapperUsageReplacement(trackedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+            {
+                return true;
+            }
+
+            if (TryResolveDetachedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var detachedOrigin) &&
+                TryBuildFastMockVerifyWrapperUsageReplacement(detachedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+            {
+                requiresProvidersNamespace = true;
+                return true;
+            }
+
+            return false;
+        }
+
+        public static FastMockVerifyWrapperKind GetFastMockVerifyWrapperKind(IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            methodSymbol = methodSymbol.ReducedFrom ?? methodSymbol;
+            if (methodSymbol.Name != "Verify" ||
+                methodSymbol.Parameters.Length == 0 ||
+                !IsFastMoqFastMockType(methodSymbol.Parameters[0].Type))
+            {
+                return FastMockVerifyWrapperKind.None;
+            }
+
+            var wrapperKind = FastMockVerifyWrapperKind.None;
+            foreach (var syntaxReference in methodSymbol.DeclaringSyntaxReferences)
+            {
+                if (syntaxReference.GetSyntax(cancellationToken) is not MethodDeclarationSyntax methodDeclaration)
+                {
+                    continue;
+                }
+
+                var declarationSemanticModel = GetSemanticModelForNode(methodDeclaration, semanticModel);
+                var declarationKind = GetFastMockVerifyWrapperKind(methodDeclaration, methodSymbol.Parameters[0], declarationSemanticModel, cancellationToken);
+                if (declarationKind == FastMockVerifyWrapperKind.ProviderSpecific)
+                {
+                    return declarationKind;
+                }
+
+                if (declarationKind == FastMockVerifyWrapperKind.FastMoqBoundary)
+                {
+                    wrapperKind = declarationKind;
+                }
+            }
+
+            return wrapperKind;
+        }
+
         public static bool TryGetProviderFirstVerifyExpressionArgument(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out ExpressionSyntax expressionArgument)
         {
             expressionArgument = null!;
@@ -977,6 +1046,163 @@ namespace FastMoq.Analyzers
             var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
             replacement = $"MockingProviderRegistry.Default.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
             return true;
+        }
+
+        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
+        {
+            replacement = string.Empty;
+
+            var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count == 0 || arguments.Count > 2)
+            {
+                return false;
+            }
+
+            var replacementArguments = new List<string>
+            {
+                arguments[0].WithoutTrivia().ToString(),
+            };
+
+            if (arguments.Count == 2)
+            {
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
+                {
+                    return false;
+                }
+
+                if (!omitArgument)
+                {
+                    replacementArguments.Add(convertedArgument);
+                }
+            }
+
+            var mockerExpression = origin.MockerExpression.WithoutTrivia().ToString();
+            var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
+            replacement = $"{mockerExpression}.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
+            return true;
+        }
+
+        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(DetachedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
+        {
+            replacement = string.Empty;
+            if (!origin.CanReuseFastMockExpression)
+            {
+                return false;
+            }
+
+            var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count == 0 || arguments.Count > 2)
+            {
+                return false;
+            }
+
+            var replacementArguments = new List<string>
+            {
+                origin.FastMockExpression.WithoutTrivia().ToString(),
+                arguments[0].WithoutTrivia().ToString(),
+            };
+
+            if (arguments.Count == 2)
+            {
+                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
+                {
+                    return false;
+                }
+
+                if (!omitArgument)
+                {
+                    replacementArguments.Add(convertedArgument);
+                }
+            }
+
+            var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
+            replacement = $"MockingProviderRegistry.Default.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
+            return true;
+        }
+
+        private static FastMockVerifyWrapperKind GetFastMockVerifyWrapperKind(MethodDeclarationSyntax methodDeclaration, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var analysisRoot = methodDeclaration.ExpressionBody?.Expression ?? (SyntaxNode?) methodDeclaration.Body;
+            if (analysisRoot is null)
+            {
+                return FastMockVerifyWrapperKind.None;
+            }
+
+            var hasMoqVerify = false;
+            var hasAsMoqOnFastMock = false;
+            var hasDefaultVerifyOnFastMock = false;
+
+            foreach (var invocationExpression in analysisRoot.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
+            {
+                if (IsDefaultVerifyOnFastMock(invocationExpression, fastMockParameter, semanticModel, cancellationToken))
+                {
+                    hasDefaultVerifyOnFastMock = true;
+                    continue;
+                }
+
+                if (IsAsMoqOnFastMock(invocationExpression, fastMockParameter, semanticModel, cancellationToken))
+                {
+                    hasAsMoqOnFastMock = true;
+                    continue;
+                }
+
+                if (TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) &&
+                    method is not null &&
+                    IsMoqVerifyMethod(method))
+                {
+                    hasMoqVerify = true;
+                }
+            }
+
+            if (hasAsMoqOnFastMock && hasMoqVerify)
+            {
+                return FastMockVerifyWrapperKind.ProviderSpecific;
+            }
+
+            if (hasDefaultVerifyOnFastMock)
+            {
+                return FastMockVerifyWrapperKind.FastMoqBoundary;
+            }
+
+            return FastMockVerifyWrapperKind.None;
+        }
+
+        private static bool IsAsMoqOnFastMock(InvocationExpressionSyntax invocationExpression, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            return method.Name == "AsMoq" &&
+                method.ContainingNamespace.ToDisplayString() == MoqProviderNamespace &&
+                ReferencesParameter(memberAccess.Expression, fastMockParameter, semanticModel, cancellationToken);
+        }
+
+        private static bool IsDefaultVerifyOnFastMock(InvocationExpressionSyntax invocationExpression, IParameterSymbol fastMockParameter, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            return method.Name == "Verify" &&
+                IsDefaultMockingProviderAccess(memberAccess.Expression, semanticModel, cancellationToken) &&
+                invocationExpression.ArgumentList.Arguments.Count > 0 &&
+                ReferencesParameter(invocationExpression.ArgumentList.Arguments[0].Expression, fastMockParameter, semanticModel, cancellationToken);
+        }
+
+        private static bool ReferencesParameter(ExpressionSyntax expression, IParameterSymbol parameterSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(Unwrap(expression), cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            return SymbolEqualityComparer.Default.Equals(symbol, parameterSymbol);
         }
 
         public static bool TryBuildMockOptionalReplacement(AssignmentExpressionSyntax assignmentExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string replacement)
@@ -3417,26 +3643,80 @@ namespace FastMoq.Analyzers
 
         public static bool IsProviderSelectedByDefault(Compilation compilation, string providerName, CancellationToken cancellationToken)
         {
-            if (HasAssemblyDefaultProvider(compilation.Assembly, providerName))
+            if (TryGetEffectiveDefaultProviderName(compilation, cancellationToken, out var selectedProviderName))
+            {
+                return string.Equals(selectedProviderName, providerName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        public static bool TryGetEffectiveDefaultProviderName(Compilation compilation, CancellationToken cancellationToken, out string providerName)
+        {
+            if (TryGetExplicitDefaultProviderName(compilation, cancellationToken, out providerName))
             {
                 return true;
             }
 
-            foreach (var syntaxTree in compilation.SyntaxTrees)
+            return TryGetImplicitDefaultProviderName(compilation, cancellationToken, out providerName);
+        }
+
+        public static bool TryGetExplicitDefaultProviderName(Compilation compilation, CancellationToken cancellationToken, out string providerName)
+        {
+            var explicitDefaultProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var assemblySymbol in EnumerateVisibleAssemblySymbols(compilation))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
-                var root = syntaxTree.GetRoot(cancellationToken);
 
-                foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                foreach (var assemblyDefaultProviderName in GetAssemblyDefaultProviderNames(assemblySymbol))
                 {
-                    if (IsProviderSelectionInvocation(invocationExpression, semanticModel, providerName, requireDefaultSelection: true, cancellationToken))
-                    {
-                        return true;
-                    }
+                    explicitDefaultProviders.Add(assemblyDefaultProviderName);
                 }
             }
 
+            foreach (var sourceDefaultProviderName in GetSourceRegisteredProviderNames(compilation, requireDefaultSelection: true, cancellationToken))
+            {
+                explicitDefaultProviders.Add(sourceDefaultProviderName);
+            }
+
+            if (explicitDefaultProviders.Count == 1)
+            {
+                providerName = explicitDefaultProviders.Single();
+                return true;
+            }
+
+            providerName = string.Empty;
+            return false;
+        }
+
+        public static bool TryGetImplicitDefaultProviderName(Compilation compilation, CancellationToken cancellationToken, out string providerName)
+        {
+            var registeredProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var assemblySymbol in EnumerateVisibleAssemblySymbols(compilation))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var registeredProviderName in GetAssemblyRegisteredProviderNames(assemblySymbol))
+                {
+                    registeredProviders.Add(registeredProviderName);
+                }
+            }
+
+            foreach (var sourceRegisteredProviderName in GetSourceRegisteredProviderNames(compilation, requireDefaultSelection: false, cancellationToken))
+            {
+                registeredProviders.Add(sourceRegisteredProviderName);
+            }
+
+            registeredProviders.Remove("reflection");
+            if (registeredProviders.Count == 1)
+            {
+                providerName = registeredProviders.Single();
+                return true;
+            }
+
+            providerName = string.Empty;
             return false;
         }
 
@@ -3447,50 +3727,56 @@ namespace FastMoq.Analyzers
                    || HasAssemblyRegisteredDefaultProvider(assemblySymbol, providerName);
         }
 
+        public static IEnumerable<IAssemblySymbol> EnumerateVisibleAssemblySymbols(Compilation compilation)
+        {
+            yield return compilation.Assembly;
+
+            foreach (var assemblySymbol in compilation.SourceModule.ReferencedAssemblySymbols)
+            {
+                yield return assemblySymbol;
+            }
+        }
+
         public static bool TryGetAssemblyDefaultProviderName(IAssemblySymbol assemblySymbol, out string providerName)
+        {
+            providerName = GetAssemblyDefaultProviderNames(assemblySymbol).FirstOrDefault() ?? string.Empty;
+            return !string.IsNullOrWhiteSpace(providerName);
+        }
+
+        public static IEnumerable<string> GetAssemblyDefaultProviderNames(IAssemblySymbol assemblySymbol)
         {
             foreach (var attribute in assemblySymbol.GetAttributes())
             {
-                if (attribute.AttributeClass?.ToDisplayString() != FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE ||
-                    attribute.ConstructorArguments.Length != 1 ||
-                    attribute.ConstructorArguments[0].Value is not string declaredProvider ||
-                    string.IsNullOrWhiteSpace(declaredProvider))
+                if (attribute.AttributeClass?.ToDisplayString() == FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE &&
+                    attribute.ConstructorArguments.Length == 1 &&
+                    attribute.ConstructorArguments[0].Value is string declaredProvider &&
+                    !string.IsNullOrWhiteSpace(declaredProvider))
                 {
-                    continue;
+                    yield return declaredProvider;
                 }
-
-                providerName = declaredProvider;
-                return true;
             }
 
-            providerName = string.Empty;
-            return false;
+            foreach (var registeredDefaultProviderName in GetAssemblyRegisteredProviderNames(assemblySymbol, requireDefaultSelection: true))
+            {
+                yield return registeredDefaultProviderName;
+            }
         }
 
         public static bool HasAssemblyRegisteredDefaultProvider(IAssemblySymbol assemblySymbol, string providerName)
         {
+            return GetAssemblyRegisteredProviderNames(assemblySymbol, requireDefaultSelection: true)
+                .Any(declaredProvider => string.Equals(declaredProvider, providerName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static IEnumerable<string> GetAssemblyRegisteredProviderNames(IAssemblySymbol assemblySymbol, bool requireDefaultSelection = false)
+        {
             foreach (var attribute in assemblySymbol.GetAttributes())
             {
-                if (attribute.AttributeClass?.ToDisplayString() != FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE ||
-                    attribute.ConstructorArguments.Length < 2 ||
-                    attribute.ConstructorArguments[0].Value is not string declaredProvider ||
-                    string.IsNullOrWhiteSpace(declaredProvider))
+                if (TryGetAssemblyRegisteredProviderName(attribute, requireDefaultSelection, out var declaredProvider))
                 {
-                    continue;
-                }
-
-                var setAsDefault = attribute.NamedArguments.Any(argument =>
-                    argument.Key == RegisterProviderSetAsDefaultPropertyName &&
-                    argument.Value.Value is bool isDefault &&
-                    isDefault);
-
-                if (setAsDefault && string.Equals(declaredProvider, providerName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
+                    yield return declaredProvider;
                 }
             }
-
-            return false;
         }
 
         public static bool HasProviderSelectionInScope(SyntaxNode node, SemanticModel semanticModel, string providerName, CancellationToken cancellationToken)
@@ -3626,6 +3912,58 @@ namespace FastMoq.Analyzers
 
         private static bool IsProviderSelectionInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, string providerName, bool requireDefaultSelection, CancellationToken cancellationToken)
         {
+            if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var registeredProviderName, out var selectsByDefault, out var isScopedSelection))
+            {
+                return false;
+            }
+
+            if (!string.Equals(registeredProviderName, providerName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (isScopedSelection)
+            {
+                return !requireDefaultSelection;
+            }
+
+            return !requireDefaultSelection || selectsByDefault;
+        }
+
+        private static IEnumerable<string> GetSourceRegisteredProviderNames(Compilation compilation, bool requireDefaultSelection, CancellationToken cancellationToken)
+        {
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var root = syntaxTree.GetRoot(cancellationToken);
+
+                foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                {
+                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out var selectsByDefault, out var isScopedSelection))
+                    {
+                        continue;
+                    }
+
+                    if (isScopedSelection)
+                    {
+                        continue;
+                    }
+
+                    if (!requireDefaultSelection || selectsByDefault)
+                    {
+                        yield return providerName;
+                    }
+                }
+            }
+        }
+
+        private static bool TryGetProviderRegistrationInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string providerName, out bool selectsByDefault, out bool isScopedSelection)
+        {
+            providerName = string.Empty;
+            selectsByDefault = false;
+            isScopedSelection = false;
+
             if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
                 method is null ||
                 method.ContainingType.ToDisplayString() != MockingProviderRegistryTypeName ||
@@ -3634,32 +3972,111 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
-            if (!IsMatchingProviderLiteral(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, providerName, cancellationToken))
+            if (!TryGetStringConstant(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, out providerName))
             {
+                providerName = string.Empty;
                 return false;
             }
 
             method = method.ReducedFrom ?? method;
             if (method.Name == "Push")
             {
-                return !requireDefaultSelection;
+                isScopedSelection = true;
+                return true;
             }
 
             if (method.Name == "SetDefault")
             {
+                selectsByDefault = true;
                 return true;
             }
 
-            if (method.Name == "Register")
+            if (method.Name != "Register")
             {
-                if (invocationExpression.ArgumentList.Arguments.Count < 3)
+                providerName = string.Empty;
+                return false;
+            }
+
+            if (TryGetRegisterSetAsDefaultArgument(invocationExpression, semanticModel, cancellationToken, out var setAsDefault))
+            {
+                selectsByDefault = setAsDefault;
+                return true;
+            }
+
+            providerName = string.Empty;
+            return false;
+        }
+
+        private static bool TryGetAssemblyRegisteredProviderName(AttributeData attribute, bool requireDefaultSelection, out string providerName)
+        {
+            providerName = string.Empty;
+            if (attribute.AttributeClass?.ToDisplayString() != FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE ||
+                attribute.ConstructorArguments.Length < 2 ||
+                attribute.ConstructorArguments[0].Value is not string declaredProvider ||
+                string.IsNullOrWhiteSpace(declaredProvider))
+            {
+                return false;
+            }
+
+            if (requireDefaultSelection)
+            {
+                var setAsDefault = attribute.NamedArguments.Any(argument =>
+                    argument.Key == RegisterProviderSetAsDefaultPropertyName &&
+                    argument.Value.Value is bool isDefault &&
+                    isDefault);
+
+                if (!setAsDefault)
                 {
                     return false;
                 }
-
-                return TryGetBooleanConstant(invocationExpression.ArgumentList.Arguments[2].Expression, semanticModel, cancellationToken, out var setAsDefault) && setAsDefault;
             }
 
+            providerName = declaredProvider;
+            return true;
+        }
+
+        private static bool TryGetRegisterSetAsDefaultArgument(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out bool setAsDefault)
+        {
+            setAsDefault = false;
+            if (invocationExpression.ArgumentList.Arguments.Count < 3)
+            {
+                return false;
+            }
+
+            var method = semanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol as IMethodSymbol;
+            method = method?.ReducedFrom ?? method;
+            if (method is null)
+            {
+                return false;
+            }
+
+            var argument = invocationExpression.ArgumentList.Arguments[2];
+            if (method.Parameters.Length > 2)
+            {
+                if (argument.NameColon is not null)
+                {
+                    var namedParameter = method.Parameters.FirstOrDefault(parameter =>
+                        string.Equals(parameter.Name, argument.NameColon.Name.Identifier.ValueText, StringComparison.Ordinal));
+                    if (namedParameter is not null && namedParameter.Ordinal < invocationExpression.ArgumentList.Arguments.Count)
+                    {
+                        argument = invocationExpression.ArgumentList.Arguments[namedParameter.Ordinal];
+                    }
+                }
+            }
+
+            return TryGetBooleanConstant(argument.Expression, semanticModel, cancellationToken, out setAsDefault);
+        }
+
+        private static bool TryGetStringConstant(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out string value)
+        {
+            var constantValue = semanticModel.GetConstantValue(expression, cancellationToken);
+            if (constantValue.HasValue && constantValue.Value is string text && !string.IsNullOrWhiteSpace(text))
+            {
+                value = text;
+                return true;
+            }
+
+            value = string.Empty;
             return false;
         }
 
@@ -3745,6 +4162,18 @@ namespace FastMoq.Analyzers
             replacement = string.Empty;
             omitArgument = false;
 
+            if (TryIsTimesSpecExpression(expression, semanticModel, cancellationToken, out var isAtLeastOnce))
+            {
+                if (isAtLeastOnce)
+                {
+                    omitArgument = true;
+                    return true;
+                }
+
+                replacement = expression.WithoutTrivia().ToString();
+                return true;
+            }
+
             if (expression is InvocationExpressionSyntax invocationExpression)
             {
                 if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
@@ -3801,6 +4230,39 @@ namespace FastMoq.Analyzers
                 default:
                     return false;
             }
+        }
+
+        private static bool TryIsTimesSpecExpression(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out bool isAtLeastOnce)
+        {
+            isAtLeastOnce = false;
+
+            if (expression is InvocationExpressionSyntax invocationExpression)
+            {
+                if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                    method is null)
+                {
+                    return false;
+                }
+
+                var containingType = (method.ReducedFrom ?? method).ContainingType;
+                if (containingType?.ToDisplayString() != "FastMoq.Providers.TimesSpec")
+                {
+                    return false;
+                }
+
+                isAtLeastOnce = method.Name == "AtLeastOnce" && invocationExpression.ArgumentList.Arguments.Count == 0;
+                return true;
+            }
+
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            if (symbol?.ContainingType?.ToDisplayString() != "FastMoq.Providers.TimesSpec")
+            {
+                return false;
+            }
+
+            isAtLeastOnce = symbol.Name == "AtLeastOnce";
+            return true;
         }
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -67,6 +67,19 @@ namespace FastMoq.Analyzers
         ProviderSpecific,
     }
 
+    internal readonly struct ProviderRegistrationCandidate
+    {
+        public ProviderRegistrationCandidate(string providerName, ITypeSymbol? providerType)
+        {
+            ProviderName = providerName;
+            ProviderType = providerType;
+        }
+
+        public string ProviderName { get; }
+
+        public ITypeSymbol? ProviderType { get; }
+    }
+
     internal static class FastMoqAnalysisHelpers
     {
         internal const string FastMoqMockerTypeName = "FastMoq.Mocker";
@@ -85,7 +98,9 @@ namespace FastMoq.Analyzers
         internal const string MoqProviderMetadataName = "FastMoq.Providers.MoqProvider.MoqMockingProvider";
         internal const string MoqProviderTypeName = "MoqMockingProvider";
         internal const string MoqProviderName = "moq";
+        internal const string NSubstituteProviderMetadataName = "FastMoq.Providers.NSubstituteProvider.NSubstituteMockingProvider";
         internal const string NSubstituteProviderName = "nsubstitute";
+        internal const string ReflectionProviderMetadataName = "FastMoq.Providers.ReflectionProvider.ReflectionMockingProvider";
         internal const string RegisterProviderSetAsDefaultPropertyName = "SetAsDefault";
         internal const string RegisterProviderSetAsDefaultParameterName = "setAsDefault";
         private const string FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqDefaultProviderAttribute";
@@ -3784,12 +3799,16 @@ namespace FastMoq.Analyzers
 
         public static bool IsProviderSelectedByDefault(Compilation compilation, string providerName, CancellationToken cancellationToken)
         {
-            if (TryGetEffectiveDefaultProviderName(compilation, cancellationToken, out var selectedProviderName))
+            if (TryGetExplicitDefaultProviderName(compilation, cancellationToken, out var selectedProviderName))
             {
-                return string.Equals(selectedProviderName, providerName, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(selectedProviderName, providerName, StringComparison.OrdinalIgnoreCase) ||
+                    (TryResolveRegisteredProviderType(compilation, selectedProviderName, cancellationToken, out var selectedProviderType) &&
+                    IsProviderNameForType(providerName, selectedProviderType));
             }
 
-            return false;
+            return TryGetImplicitDefaultProvider(compilation, cancellationToken, out var implicitProvider) &&
+                (string.Equals(GetCanonicalProviderName(implicitProvider), providerName, StringComparison.OrdinalIgnoreCase) ||
+                IsProviderNameForType(providerName, implicitProvider.ProviderType));
         }
 
         public static bool TryGetEffectiveDefaultProviderName(Compilation compilation, CancellationToken cancellationToken, out string providerName)
@@ -3833,32 +3852,127 @@ namespace FastMoq.Analyzers
 
         public static bool TryGetImplicitDefaultProviderName(Compilation compilation, CancellationToken cancellationToken, out string providerName)
         {
-            var registeredProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var assemblySymbol in EnumerateVisibleAssemblySymbols(compilation))
+            if (TryGetImplicitDefaultProvider(compilation, cancellationToken, out var implicitProvider))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                foreach (var registeredProviderName in GetAssemblyRegisteredProviderNames(assemblySymbol))
-                {
-                    registeredProviders.Add(registeredProviderName);
-                }
-            }
-
-            foreach (var sourceRegisteredProviderName in GetSourceRegisteredProviderNames(compilation, requireDefaultSelection: false, cancellationToken))
-            {
-                registeredProviders.Add(sourceRegisteredProviderName);
-            }
-
-            registeredProviders.Remove("reflection");
-            if (registeredProviders.Count == 1)
-            {
-                providerName = registeredProviders.Single();
+                providerName = GetCanonicalProviderName(implicitProvider);
                 return true;
             }
 
             providerName = string.Empty;
             return false;
+        }
+
+        private static bool TryGetImplicitDefaultProvider(Compilation compilation, CancellationToken cancellationToken, out ProviderRegistrationCandidate provider)
+        {
+            var registeredProviders = new List<ProviderRegistrationCandidate>();
+
+            foreach (var registration in GetAllVisibleProviderRegistrations(compilation, cancellationToken))
+            {
+                if (IsReflectionProviderRegistration(registration) ||
+                    registeredProviders.Any(existing => AreEquivalentProviderRegistrations(existing, registration)))
+                {
+                    continue;
+                }
+
+                registeredProviders.Add(registration);
+            }
+
+            if (registeredProviders.Count == 1)
+            {
+                provider = registeredProviders[0];
+                return true;
+            }
+
+            provider = new ProviderRegistrationCandidate(string.Empty, null);
+            return false;
+        }
+
+        private static bool TryResolveRegisteredProviderType(Compilation compilation, string providerName, CancellationToken cancellationToken, out ITypeSymbol? providerType)
+        {
+            providerType = null;
+
+            foreach (var registration in GetAllVisibleProviderRegistrations(compilation, cancellationToken))
+            {
+                if (!string.Equals(registration.ProviderName, providerName, StringComparison.OrdinalIgnoreCase) ||
+                    registration.ProviderType is null)
+                {
+                    continue;
+                }
+
+                if (providerType is null)
+                {
+                    providerType = registration.ProviderType;
+                    continue;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(providerType, registration.ProviderType))
+                {
+                    providerType = null;
+                    return false;
+                }
+            }
+
+            return providerType is not null;
+        }
+
+        private static IEnumerable<ProviderRegistrationCandidate> GetAllVisibleProviderRegistrations(Compilation compilation, CancellationToken cancellationToken)
+        {
+            foreach (var assemblySymbol in EnumerateVisibleAssemblySymbols(compilation))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var registration in GetAssemblyRegisteredProviders(assemblySymbol))
+                {
+                    yield return registration;
+                }
+            }
+
+            foreach (var registration in GetSourceProviderRegistrations(compilation, cancellationToken))
+            {
+                yield return registration;
+            }
+        }
+
+        private static bool IsReflectionProviderRegistration(ProviderRegistrationCandidate registration)
+        {
+            return IsProviderType(registration.ProviderType, ReflectionProviderMetadataName) ||
+                string.Equals(registration.ProviderName, "reflection", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool AreEquivalentProviderRegistrations(ProviderRegistrationCandidate left, ProviderRegistrationCandidate right)
+        {
+            return string.Equals(left.ProviderName, right.ProviderName, StringComparison.OrdinalIgnoreCase) ||
+                (left.ProviderType is not null &&
+                right.ProviderType is not null &&
+                SymbolEqualityComparer.Default.Equals(left.ProviderType, right.ProviderType));
+        }
+
+        private static string GetCanonicalProviderName(ProviderRegistrationCandidate registration)
+        {
+            if (IsProviderType(registration.ProviderType, MoqProviderMetadataName))
+            {
+                return MoqProviderName;
+            }
+
+            if (IsProviderType(registration.ProviderType, NSubstituteProviderMetadataName))
+            {
+                return NSubstituteProviderName;
+            }
+
+            return registration.ProviderName;
+        }
+
+        private static bool IsProviderNameForType(string providerName, ITypeSymbol? providerType)
+        {
+            return (string.Equals(providerName, MoqProviderName, StringComparison.OrdinalIgnoreCase) &&
+                IsProviderType(providerType, MoqProviderMetadataName)) ||
+                (string.Equals(providerName, NSubstituteProviderName, StringComparison.OrdinalIgnoreCase) &&
+                IsProviderType(providerType, NSubstituteProviderMetadataName));
+        }
+
+        private static bool IsProviderType(ITypeSymbol? providerType, string metadataName)
+        {
+            return string.Equals(providerType?.ToDisplayString(), metadataName, StringComparison.Ordinal);
         }
 
         public static bool HasAssemblyDefaultProvider(IAssemblySymbol assemblySymbol, string providerName)
@@ -3911,11 +4025,19 @@ namespace FastMoq.Analyzers
 
         public static IEnumerable<string> GetAssemblyRegisteredProviderNames(IAssemblySymbol assemblySymbol, bool requireDefaultSelection = false)
         {
+            foreach (var registration in GetAssemblyRegisteredProviders(assemblySymbol, requireDefaultSelection))
+            {
+                yield return registration.ProviderName;
+            }
+        }
+
+        private static IEnumerable<ProviderRegistrationCandidate> GetAssemblyRegisteredProviders(IAssemblySymbol assemblySymbol, bool requireDefaultSelection = false)
+        {
             foreach (var attribute in assemblySymbol.GetAttributes())
             {
-                if (TryGetAssemblyRegisteredProviderName(attribute, requireDefaultSelection, out var declaredProvider))
+                if (TryGetAssemblyRegisteredProvider(attribute, requireDefaultSelection, out var registration))
                 {
-                    yield return declaredProvider;
+                    yield return registration;
                 }
             }
         }
@@ -4053,7 +4175,7 @@ namespace FastMoq.Analyzers
 
         private static bool IsProviderSelectionInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, string providerName, bool requireDefaultSelection, CancellationToken cancellationToken)
         {
-            if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var registeredProviderName, out var selectsByDefault, out var isScopedSelection))
+            if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var registeredProviderName, out _, out var selectsByDefault, out var isScopedSelection, out _))
             {
                 return false;
             }
@@ -4071,6 +4193,28 @@ namespace FastMoq.Analyzers
             return !requireDefaultSelection || selectsByDefault;
         }
 
+        private static IEnumerable<ProviderRegistrationCandidate> GetSourceProviderRegistrations(Compilation compilation, CancellationToken cancellationToken)
+        {
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var root = syntaxTree.GetRoot(cancellationToken);
+
+                foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                {
+                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out var providerType, out _, out var isScopedSelection, out var isRegistration) ||
+                        isScopedSelection ||
+                        !isRegistration)
+                    {
+                        continue;
+                    }
+
+                    yield return new ProviderRegistrationCandidate(providerName, providerType);
+                }
+            }
+        }
+
         private static IEnumerable<string> GetSourceRegisteredProviderNames(Compilation compilation, bool requireDefaultSelection, CancellationToken cancellationToken)
         {
             foreach (var syntaxTree in compilation.SyntaxTrees)
@@ -4081,7 +4225,7 @@ namespace FastMoq.Analyzers
 
                 foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
                 {
-                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out var selectsByDefault, out var isScopedSelection))
+                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out _, out var selectsByDefault, out var isScopedSelection, out _))
                     {
                         continue;
                     }
@@ -4099,11 +4243,13 @@ namespace FastMoq.Analyzers
             }
         }
 
-        private static bool TryGetProviderRegistrationInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string providerName, out bool selectsByDefault, out bool isScopedSelection)
+        private static bool TryGetProviderRegistrationInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string providerName, out ITypeSymbol? providerType, out bool selectsByDefault, out bool isScopedSelection, out bool isRegistration)
         {
             providerName = string.Empty;
+            providerType = null;
             selectsByDefault = false;
             isScopedSelection = false;
+            isRegistration = false;
 
             if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
                 method is null ||
@@ -4138,6 +4284,12 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
+            isRegistration = true;
+            if (invocationExpression.ArgumentList.Arguments.Count > 1)
+            {
+                providerType = semanticModel.GetTypeInfo(invocationExpression.ArgumentList.Arguments[1].Expression, cancellationToken).Type;
+            }
+
             if (TryGetRegisterSetAsDefaultArgument(invocationExpression, semanticModel, cancellationToken, out var setAsDefault))
             {
                 selectsByDefault = setAsDefault;
@@ -4146,9 +4298,9 @@ namespace FastMoq.Analyzers
             return true;
         }
 
-        private static bool TryGetAssemblyRegisteredProviderName(AttributeData attribute, bool requireDefaultSelection, out string providerName)
+        private static bool TryGetAssemblyRegisteredProvider(AttributeData attribute, bool requireDefaultSelection, out ProviderRegistrationCandidate registration)
         {
-            providerName = string.Empty;
+            registration = new ProviderRegistrationCandidate(string.Empty, null);
             if (attribute.AttributeClass?.ToDisplayString() != FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE ||
                 attribute.ConstructorArguments.Length < 2 ||
                 attribute.ConstructorArguments[0].Value is not string declaredProvider ||
@@ -4170,7 +4322,19 @@ namespace FastMoq.Analyzers
                 }
             }
 
-            providerName = declaredProvider;
+            registration = new ProviderRegistrationCandidate(declaredProvider, attribute.ConstructorArguments[1].Value as ITypeSymbol);
+            return true;
+        }
+
+        private static bool TryGetAssemblyRegisteredProviderName(AttributeData attribute, bool requireDefaultSelection, out string providerName)
+        {
+            providerName = string.Empty;
+            if (!TryGetAssemblyRegisteredProvider(attribute, requireDefaultSelection, out var registration))
+            {
+                return false;
+            }
+
+            providerName = registration.ProviderName;
             return true;
         }
 

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -87,6 +87,7 @@ namespace FastMoq.Analyzers
         internal const string MoqProviderName = "moq";
         internal const string NSubstituteProviderName = "nsubstitute";
         internal const string RegisterProviderSetAsDefaultPropertyName = "SetAsDefault";
+        internal const string RegisterProviderSetAsDefaultParameterName = "setAsDefault";
         private const string FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqDefaultProviderAttribute";
         private const string FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqRegisterProviderAttribute";
         private const string FASTMOQ_MOCKER_TEST_BASE_METADATA_NAME = "MockerTestBase`1";
@@ -135,7 +136,106 @@ namespace FastMoq.Analyzers
             semanticModel = GetSemanticModelForNode(invocation, semanticModel);
             var symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
             method = symbolInfo.Symbol as IMethodSymbol ?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+            if (method is not null)
+            {
+                return true;
+            }
+
+            symbolInfo = semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken);
+            method = symbolInfo.Symbol as IMethodSymbol ?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+            if (method is not null)
+            {
+                return true;
+            }
+
+            method = semanticModel.GetMemberGroup(invocation.Expression, cancellationToken).OfType<IMethodSymbol>().FirstOrDefault();
             return method is not null;
+        }
+
+        public static bool TryGetFastMockVerifyWrapperMethodSymbol(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out IMethodSymbol? methodSymbol)
+        {
+            semanticModel = GetSemanticModelForNode(invocationExpression, semanticModel);
+
+            if (TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out methodSymbol) &&
+                methodSymbol is not null &&
+                GetFastMockVerifyWrapperKind(methodSymbol, semanticModel, cancellationToken) != FastMockVerifyWrapperKind.None)
+            {
+                return true;
+            }
+
+            methodSymbol = null;
+            if (invocationExpression.Expression is not IdentifierNameSyntax identifierName)
+            {
+                return false;
+            }
+
+            var importedStaticTypes = GetImportedStaticTypeSymbols(invocationExpression, semanticModel, cancellationToken);
+            if (importedStaticTypes.Count == 0)
+            {
+                return false;
+            }
+
+            var argumentCount = invocationExpression.ArgumentList.Arguments.Count;
+            var matchingMethods = importedStaticTypes
+                .SelectMany(typeSymbol => typeSymbol.GetMembers(identifierName.Identifier.ValueText).OfType<IMethodSymbol>())
+                .Where(candidate => candidate.IsStatic)
+                .Where(candidate => candidate.Name == "Verify")
+                .Where(candidate => candidate.Parameters.Length > 0 && IsFastMoqFastMockType(candidate.Parameters[0].Type))
+                .Where(candidate =>
+                {
+                    var requiredParameterCount = candidate.Parameters.Count(parameter => !parameter.IsOptional);
+                    return argumentCount >= requiredParameterCount && argumentCount <= candidate.Parameters.Length;
+                })
+                .Where(candidate => GetFastMockVerifyWrapperKind(candidate, semanticModel, cancellationToken) != FastMockVerifyWrapperKind.None)
+                .Distinct<IMethodSymbol>(SymbolEqualityComparer.Default)
+                .ToArray();
+
+            if (matchingMethods.Length != 1)
+            {
+                return false;
+            }
+
+            methodSymbol = matchingMethods[0];
+            return true;
+        }
+
+        private static HashSet<INamedTypeSymbol> GetImportedStaticTypeSymbols(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var importedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+            foreach (var scope in node.AncestorsAndSelf())
+            {
+                switch (scope)
+                {
+                    case CompilationUnitSyntax compilationUnit:
+                        AddImportedStaticTypes(compilationUnit.Usings, semanticModel, cancellationToken, importedTypes);
+                        break;
+                    case BaseNamespaceDeclarationSyntax namespaceDeclaration:
+                        AddImportedStaticTypes(namespaceDeclaration.Usings, semanticModel, cancellationToken, importedTypes);
+                        break;
+                }
+            }
+
+            return importedTypes;
+        }
+
+        private static void AddImportedStaticTypes(SyntaxList<UsingDirectiveSyntax> usingDirectives, SemanticModel semanticModel, CancellationToken cancellationToken, HashSet<INamedTypeSymbol> importedTypes)
+        {
+            foreach (var usingDirective in usingDirectives)
+            {
+                if (usingDirective.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.None) ||
+                    usingDirective.Name is null)
+                {
+                    continue;
+                }
+
+                var symbolInfo = semanticModel.GetSymbolInfo(usingDirective.Name, cancellationToken);
+                var typeSymbol = symbolInfo.Symbol as INamedTypeSymbol ?? symbolInfo.CandidateSymbols.OfType<INamedTypeSymbol>().FirstOrDefault();
+                if (typeSymbol is not null)
+                {
+                    importedTypes.Add(typeSymbol);
+                }
+            }
         }
 
         public static bool HasMoqProviderPackage(Compilation compilation)
@@ -823,26 +923,27 @@ namespace FastMoq.Analyzers
             return false;
         }
 
-        public static bool TryBuildFastMockVerifyWrapperUsageReplacement(ExpressionSyntax verifyTargetExpression, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement, out bool requiresProvidersNamespace)
+        public static bool TryBuildFastMockVerifyWrapperUsageReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string replacement, out bool requiresProvidersNamespace)
         {
             replacement = string.Empty;
             requiresProvidersNamespace = false;
 
-            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+            if (!TryGetFastMockVerifyWrapperMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
                 method is null ||
-                GetFastMockVerifyWrapperKind(method, semanticModel, cancellationToken) == FastMockVerifyWrapperKind.None)
+                GetFastMockVerifyWrapperKind(method, semanticModel, cancellationToken) == FastMockVerifyWrapperKind.None ||
+                !TryGetFastMockVerifyWrapperUsageTarget(invocationExpression, semanticModel, cancellationToken, out var verifyTargetExpression, out var firstVerificationArgumentIndex))
             {
                 return false;
             }
 
             if (TryResolveTrackedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var trackedOrigin) &&
-                TryBuildFastMockVerifyWrapperUsageReplacement(trackedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+                TryBuildFastMockVerifyWrapperUsageReplacement(trackedOrigin, semanticModel, invocationExpression, firstVerificationArgumentIndex, cancellationToken, out replacement))
             {
                 return true;
             }
 
             if (TryResolveDetachedMockOrigin(verifyTargetExpression, semanticModel, cancellationToken, out var detachedOrigin) &&
-                TryBuildFastMockVerifyWrapperUsageReplacement(detachedOrigin, semanticModel, invocationExpression, cancellationToken, out replacement))
+                TryBuildFastMockVerifyWrapperUsageReplacement(detachedOrigin, semanticModel, invocationExpression, firstVerificationArgumentIndex, cancellationToken, out replacement))
             {
                 requiresProvidersNamespace = true;
                 return true;
@@ -870,7 +971,13 @@ namespace FastMoq.Analyzers
                 }
 
                 var declarationSemanticModel = GetSemanticModelForNode(methodDeclaration, semanticModel);
-                var declarationKind = GetFastMockVerifyWrapperKind(methodDeclaration, methodSymbol.Parameters[0], declarationSemanticModel, cancellationToken);
+                if (declarationSemanticModel.GetDeclaredSymbol(methodDeclaration, cancellationToken) is not IMethodSymbol declaredMethodSymbol ||
+                    declaredMethodSymbol.Parameters.Length == 0)
+                {
+                    continue;
+                }
+
+                var declarationKind = GetFastMockVerifyWrapperKind(methodDeclaration, declaredMethodSymbol.Parameters[0], declarationSemanticModel, cancellationToken);
                 if (declarationKind == FastMockVerifyWrapperKind.ProviderSpecific)
                 {
                     return declarationKind;
@@ -1048,24 +1155,25 @@ namespace FastMoq.Analyzers
             return true;
         }
 
-        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
+        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, int firstVerificationArgumentIndex, CancellationToken cancellationToken, out string replacement)
         {
             replacement = string.Empty;
 
             var arguments = invocationExpression.ArgumentList.Arguments;
-            if (arguments.Count == 0 || arguments.Count > 2)
+            var verificationArgumentCount = arguments.Count - firstVerificationArgumentIndex;
+            if (verificationArgumentCount == 0 || verificationArgumentCount > 2)
             {
                 return false;
             }
 
             var replacementArguments = new List<string>
             {
-                arguments[0].WithoutTrivia().ToString(),
+                arguments[firstVerificationArgumentIndex].WithoutTrivia().ToString(),
             };
 
-            if (arguments.Count == 2)
+            if (verificationArgumentCount == 2)
             {
-                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
+                if (!TryConvertTimesArgument(arguments[firstVerificationArgumentIndex + 1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
                 {
                     return false;
                 }
@@ -1082,7 +1190,7 @@ namespace FastMoq.Analyzers
             return true;
         }
 
-        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(DetachedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken, out string replacement)
+        private static bool TryBuildFastMockVerifyWrapperUsageReplacement(DetachedMockOrigin origin, SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, int firstVerificationArgumentIndex, CancellationToken cancellationToken, out string replacement)
         {
             replacement = string.Empty;
             if (!origin.CanReuseFastMockExpression)
@@ -1091,7 +1199,8 @@ namespace FastMoq.Analyzers
             }
 
             var arguments = invocationExpression.ArgumentList.Arguments;
-            if (arguments.Count == 0 || arguments.Count > 2)
+            var verificationArgumentCount = arguments.Count - firstVerificationArgumentIndex;
+            if (verificationArgumentCount == 0 || verificationArgumentCount > 2)
             {
                 return false;
             }
@@ -1099,12 +1208,12 @@ namespace FastMoq.Analyzers
             var replacementArguments = new List<string>
             {
                 origin.FastMockExpression.WithoutTrivia().ToString(),
-                arguments[0].WithoutTrivia().ToString(),
+                arguments[firstVerificationArgumentIndex].WithoutTrivia().ToString(),
             };
 
-            if (arguments.Count == 2)
+            if (verificationArgumentCount == 2)
             {
-                if (!TryConvertTimesArgument(arguments[1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
+                if (!TryConvertTimesArgument(arguments[firstVerificationArgumentIndex + 1], semanticModel, cancellationToken, invocationExpression.SpanStart, out var convertedArgument, out var omitArgument))
                 {
                     return false;
                 }
@@ -1117,6 +1226,38 @@ namespace FastMoq.Analyzers
 
             var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, invocationExpression.SpanStart);
             replacement = $"MockingProviderRegistry.Default.Verify<{serviceType}>({string.Join(", ", replacementArguments)})";
+            return true;
+        }
+
+        private static bool TryGetFastMockVerifyWrapperUsageTarget(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out ExpressionSyntax verifyTargetExpression, out int firstVerificationArgumentIndex)
+        {
+            verifyTargetExpression = null!;
+            firstVerificationArgumentIndex = 0;
+
+            if (!TryGetFastMockVerifyWrapperMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            if (method.ReducedFrom is not null)
+            {
+                if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess)
+                {
+                    return false;
+                }
+
+                verifyTargetExpression = memberAccess.Expression;
+                return true;
+            }
+
+            if (invocationExpression.ArgumentList.Arguments.Count == 0)
+            {
+                return false;
+            }
+
+            verifyTargetExpression = invocationExpression.ArgumentList.Arguments[0].Expression;
+            firstVerificationArgumentIndex = 1;
             return true;
         }
 
@@ -4000,11 +4141,9 @@ namespace FastMoq.Analyzers
             if (TryGetRegisterSetAsDefaultArgument(invocationExpression, semanticModel, cancellationToken, out var setAsDefault))
             {
                 selectsByDefault = setAsDefault;
-                return true;
             }
 
-            providerName = string.Empty;
-            return false;
+            return true;
         }
 
         private static bool TryGetAssemblyRegisteredProviderName(AttributeData attribute, bool requireDefaultSelection, out string providerName)
@@ -4038,33 +4177,32 @@ namespace FastMoq.Analyzers
         private static bool TryGetRegisterSetAsDefaultArgument(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out bool setAsDefault)
         {
             setAsDefault = false;
-            if (invocationExpression.ArgumentList.Arguments.Count < 3)
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
             {
                 return false;
             }
 
-            var method = semanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol as IMethodSymbol;
-            method = method?.ReducedFrom ?? method;
-            if (method is null)
+            method = method.ReducedFrom ?? method;
+            var setAsDefaultParameter = method.Parameters.FirstOrDefault(parameter =>
+                string.Equals(parameter.Name, RegisterProviderSetAsDefaultParameterName, StringComparison.Ordinal));
+            if (setAsDefaultParameter is null)
             {
                 return false;
             }
 
-            var argument = invocationExpression.ArgumentList.Arguments[2];
-            if (method.Parameters.Length > 2)
+            ArgumentSyntax? argument = invocationExpression.ArgumentList.Arguments.FirstOrDefault(candidate =>
+                candidate.NameColon is not null &&
+                string.Equals(candidate.NameColon.Name.Identifier.ValueText, setAsDefaultParameter.Name, StringComparison.Ordinal));
+
+            if (argument is null && setAsDefaultParameter.Ordinal < invocationExpression.ArgumentList.Arguments.Count)
             {
-                if (argument.NameColon is not null)
-                {
-                    var namedParameter = method.Parameters.FirstOrDefault(parameter =>
-                        string.Equals(parameter.Name, argument.NameColon.Name.Identifier.ValueText, StringComparison.Ordinal));
-                    if (namedParameter is not null && namedParameter.Ordinal < invocationExpression.ArgumentList.Arguments.Count)
-                    {
-                        argument = invocationExpression.ArgumentList.Arguments[namedParameter.Ordinal];
-                    }
-                }
+                argument = invocationExpression.ArgumentList.Arguments[setAsDefaultParameter.Ordinal];
             }
 
-            return TryGetBooleanConstant(argument.Expression, semanticModel, cancellationToken, out setAsDefault);
+            return argument is not null &&
+                TryGetBooleanConstant(argument.Expression, semanticModel, cancellationToken, out setAsDefault);
         }
 
         private static bool TryGetStringConstant(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out string value)

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -101,6 +101,7 @@ namespace FastMoq.Analyzers
         internal const string NSubstituteProviderMetadataName = "FastMoq.Providers.NSubstituteProvider.NSubstituteMockingProvider";
         internal const string NSubstituteProviderName = "nsubstitute";
         internal const string ReflectionProviderMetadataName = "FastMoq.Providers.ReflectionProvider.ReflectionMockingProvider";
+        private const string IMOCKING_PROVIDER_TYPE = "FastMoq.Providers.IMockingProvider";
         internal const string RegisterProviderSetAsDefaultPropertyName = "SetAsDefault";
         internal const string RegisterProviderSetAsDefaultParameterName = "setAsDefault";
         private const string FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqDefaultProviderAttribute";
@@ -523,7 +524,7 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
-            foreach (var sourceExpression in GetTrackedMockSourceExpressions(symbol, semanticModel, cancellationToken))
+            foreach (var sourceExpression in GetSourceExpressions(symbol, semanticModel, cancellationToken))
             {
                 if (TryResolveTrackedMockOrigin(sourceExpression, semanticModel, cancellationToken, visitedSymbols, out origin))
                 {
@@ -536,7 +537,7 @@ namespace FastMoq.Analyzers
             return false;
         }
 
-        private static IEnumerable<ExpressionSyntax> GetTrackedMockSourceExpressions(ISymbol symbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+        private static IEnumerable<ExpressionSyntax> GetSourceExpressions(ISymbol symbol, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             switch (symbol)
             {
@@ -733,7 +734,7 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
-            foreach (var sourceExpression in GetTrackedMockSourceExpressions(symbol, semanticModel, cancellationToken))
+            foreach (var sourceExpression in GetSourceExpressions(symbol, semanticModel, cancellationToken))
             {
                 if (TryResolveDetachedMockOrigin(sourceExpression, semanticModel, cancellationToken, visitedSymbols, out origin))
                 {
@@ -4193,6 +4194,84 @@ namespace FastMoq.Analyzers
             return !requireDefaultSelection || selectsByDefault;
         }
 
+        private static bool TryResolveProviderRegistrationType(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out ITypeSymbol? providerType)
+        {
+            return TryResolveProviderRegistrationType(expression, semanticModel, cancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out providerType);
+        }
+
+        private static bool TryResolveProviderRegistrationType(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out ITypeSymbol? providerType)
+        {
+            expression = Unwrap(expression);
+            semanticModel = GetSemanticModelForNode(expression, semanticModel);
+
+            var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
+            if (TryGetConcreteProviderRegistrationType(typeInfo.Type, out providerType) ||
+                TryGetConcreteProviderRegistrationType(typeInfo.ConvertedType, out providerType))
+            {
+                return true;
+            }
+
+            if (expression is CastExpressionSyntax castExpression &&
+                TryResolveProviderRegistrationType(castExpression.Expression, semanticModel, cancellationToken, visitedSymbols, out providerType))
+            {
+                return true;
+            }
+
+            return TryResolveProviderRegistrationTypeFromSymbol(expression, semanticModel, cancellationToken, visitedSymbols, out providerType);
+        }
+
+        private static bool TryResolveProviderRegistrationTypeFromSymbol(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out ITypeSymbol? providerType)
+        {
+            semanticModel = GetSemanticModelForNode(expression, semanticModel);
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            if (symbol is null || !visitedSymbols.Add(symbol))
+            {
+                providerType = null;
+                return false;
+            }
+
+            ITypeSymbol? resolvedProviderType = null;
+            foreach (var sourceExpression in GetSourceExpressions(symbol, semanticModel, cancellationToken))
+            {
+                if (!TryResolveProviderRegistrationType(sourceExpression, semanticModel, cancellationToken, visitedSymbols, out var sourceProviderType) ||
+                    sourceProviderType is null)
+                {
+                    continue;
+                }
+
+                if (resolvedProviderType is null)
+                {
+                    resolvedProviderType = sourceProviderType;
+                    continue;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(resolvedProviderType, sourceProviderType))
+                {
+                    providerType = null;
+                    return false;
+                }
+            }
+
+            providerType = resolvedProviderType;
+            return providerType is not null;
+        }
+
+        private static bool TryGetConcreteProviderRegistrationType(ITypeSymbol? candidateType, out ITypeSymbol? providerType)
+        {
+            providerType = null;
+            if (candidateType is not INamedTypeSymbol namedType ||
+                namedType.TypeKind != TypeKind.Class ||
+                namedType.IsAbstract ||
+                !IsMatchingOrImplementingType(namedType, IMOCKING_PROVIDER_TYPE))
+            {
+                return false;
+            }
+
+            providerType = namedType;
+            return true;
+        }
+
         private static IEnumerable<ProviderRegistrationCandidate> GetSourceProviderRegistrations(Compilation compilation, CancellationToken cancellationToken)
         {
             foreach (var syntaxTree in compilation.SyntaxTrees)
@@ -4287,7 +4366,7 @@ namespace FastMoq.Analyzers
             isRegistration = true;
             if (invocationExpression.ArgumentList.Arguments.Count > 1)
             {
-                providerType = semanticModel.GetTypeInfo(invocationExpression.ArgumentList.Arguments[1].Expression, cancellationToken).Type;
+                TryResolveProviderRegistrationType(invocationExpression.ArgumentList.Arguments[1].Expression, semanticModel, cancellationToken, out providerType);
             }
 
             if (TryGetRegisterSetAsDefaultArgument(invocationExpression, semanticModel, cancellationToken, out var setAsDefault))

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ Welcome to the comprehensive FastMoq documentation! This documentation is design
 
 If you are coming from the last public `3.0.0` package, the biggest changes in the current line are:
 
-- provider-first architecture with explicit provider registration and selection
+- provider-first architecture with automatic effective-provider discovery plus explicit provider registration and selection when needed
 - new package split across the aggregate runtime, Azure SDK helpers, Azure Functions helpers, database helpers, web helpers, and provider-specific adapters
-- first-party Azure SDK and Azure Functions HTTP-trigger helpers, with analyzer assets included by default in the aggregate `FastMoq` package
+- first-party Azure SDK and Azure Functions HTTP-trigger helpers, with analyzer assets included by default in both `FastMoq` and `FastMoq.Core`
 - provider-neutral verification with `TimesSpec`, `Verify(...)`, and `VerifyLogged(...)`
 - fluent `Scenario.With(...).When(...).Then(...).Verify(...)` support for workflow-style tests
 - explicit policy surfaces for constructor fallback, method fallback, known-type resolution, and optional-parameter behavior
@@ -33,6 +33,8 @@ Perfect for developers new to FastMoq. Learn the basics and write your first tes
 - [Provider selection and setup](./getting-started/provider-selection.md)
 - [Provider capabilities matrix](./getting-started/provider-capabilities.md)
 - [Repo-native testing guide](./getting-started/testing-guide.md)
+- [Choose the narrowest harness for the test](./getting-started/testing-guide.md#choose-the-narrowest-harness)
+- [Local wrapper boundary for shared helpers](./getting-started/testing-guide.md#local-wrapper-boundary)
 - [Tracked vs standalone provider-first mocks](./getting-started/testing-guide.md#tracked-vs-standalone-fast-mocks)
 - [Typed `IServiceProvider` helpers](./getting-started/testing-guide.md#typed-iserviceprovider-helpers)
 - [Explicit constructor selection in tests](./getting-started/testing-guide.md#explicit-constructor-selection-in-tests)
@@ -135,6 +137,7 @@ Intentional v4 breaking changes, with migration notes for changed behavior.
 Direct routes:
 
 - Provider-first authoring: [Getting Started](./getting-started/README.md), [Testing Guide](./getting-started/testing-guide.md), and [API quick reference](./api/quick-reference.md)
+- Harness and wrapper decisions: [Choose The Narrowest Harness](./getting-started/testing-guide.md#choose-the-narrowest-harness) and [Local Wrapper Boundary](./getting-started/testing-guide.md#local-wrapper-boundary)
 - Migration cleanup: [Migration Guide](./migration/README.md), [Provider and compatibility guidance](./migration/provider-and-compatibility.md), and [API replacements and migration exceptions](./migration/api-replacements-and-exceptions.md)
 - Troubleshooting provider or package mismatches: [Provider selection](./getting-started/provider-selection.md), [Provider capabilities](./getting-started/provider-capabilities.md), and [Getting Started package choices](./getting-started/README.md#package-choices)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ Use this order when you are deciding which example or helper shape to copy into 
 2. Use tracked `IFastMock<T>` provider extensions such as `Setup(...)`, `SetupGet(...)`, `SetupSequence(...)`, or `AsNSubstitute()` when the selected provider package exposes them and the arrange step still needs provider-specific syntax.
 3. Use explicit `AsMoq()`, raw provider-native APIs, or compatibility wrappers only for the remaining gaps such as protected members, `out` or `ref` verification, or other provider-specific pockets.
 
+When a first-party FastMoq helper already exists for the dependency or framework primitive, prefer that helper over handwritten setup even when the handwritten version would still work.
+
 ## 📚 Documentation Structure
 
 ### 🚀 [Getting Started](./getting-started/README.md)
@@ -33,6 +35,7 @@ Perfect for developers new to FastMoq. Learn the basics and write your first tes
 - [Provider selection and setup](./getting-started/provider-selection.md)
 - [Provider capabilities matrix](./getting-started/provider-capabilities.md)
 - [Repo-native testing guide](./getting-started/testing-guide.md)
+- [Prefer FastMoq-owned setup when a first-party helper exists](./getting-started/testing-guide.md#prefer-fastmoq-owned-setup)
 - [Choose the narrowest harness for the test](./getting-started/testing-guide.md#choose-the-narrowest-harness)
 - [Local wrapper boundary for shared helpers](./getting-started/testing-guide.md#local-wrapper-boundary)
 - [Tracked vs standalone provider-first mocks](./getting-started/testing-guide.md#tracked-vs-standalone-fast-mocks)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -58,6 +58,8 @@ Read the repo README first if you are still deciding whether FastMoq is the righ
 
 For the repo-native testing conventions and framework-specific guidance used by this codebase, see the [FastMoq Testing Guide](./testing-guide.md).
 
+When you are deciding whether a test should stay plain, use direct `Mocker` usage, or move into a shared harness or wrapper layer, start with [Choose The Narrowest Harness](./testing-guide.md#choose-the-narrowest-harness) and [Local Wrapper Boundary](./testing-guide.md#local-wrapper-boundary).
+
 If you want examples that run directly in this repository instead of static snippets only, see [Executable Testing Examples](../samples/testing-examples.md).
 
 If you are updating older FastMoq usage from the last public `3.0.0` release, see [Migration Guide: 3.0.0 To The Current v4 Line](../migration/README.md).
@@ -126,7 +128,7 @@ Important package boundaries in the current v4 line:
 - `FastMoq` and `FastMoq.Core` both include the FastMoq analyzer assets by default so most test projects get migration guidance without extra setup
 - `FastMoq.Core` keeps the provider-neutral runtime separate from the shared Azure SDK, EF, Azure Functions, and web helper packages when you consume core directly
 - `FastMoq.Analyzers` remains useful when you want the diagnostics without taking either the aggregate or core runtime package
-- if a core-only test project stays on the legacy Moq-shaped path with `GetMock<T>()`, `VerifyLogger(...)`, `MockModel.Mock`, `SetupSet(...)`, `SetupAllProperties()`, or other Moq-specific compatibility flows, add `FastMoq.Provider.Moq` explicitly, then select `moq` at assembly scope instead of relying on the default `reflection` provider
+- if a core-only test project stays on the legacy Moq-shaped path with `GetMock<T>()`, `VerifyLogger(...)`, `MockModel.Mock`, `SetupSet(...)`, `SetupAllProperties()`, or other Moq-specific compatibility flows, add `FastMoq.Provider.Moq` explicitly for the extension methods and namespaces; a single visible Moq provider can be enough, but select `moq` at assembly scope when the suite should not depend on discovery remaining unambiguous
 - `FastMoq.Core` includes the built-in `reflection` provider and the bundled Moq compatibility runtime, but the Moq tracked-mock extension methods such as `Setup(...)` and `Protected()` still belong to the `FastMoq.Provider.Moq` package
 - provider-package extension methods still follow the provider-package docs and selection rules described in [Provider Selection and Setup](./provider-selection.md)
 - if you are wiring Azure SDK clients, pageable sequences, or token credentials through tests while consuming `FastMoq.Core` directly, add `FastMoq.Azure`
@@ -231,7 +233,7 @@ using Xunit; // Or the test framework of your choice
 
 `FastMoq.Extensions` is the shared core helper namespace. It is optional and includes helpers such as `VerifyLogged(...)`, `AddServiceProvider(...)`, `AddPropertyState(...)`, `AddPropertySetterCapture(...)`, and `CreateHttpClient(...)`.
 
-If you intentionally want Moq-specific tracked `.Setup(...)`, `SetupSequence(...)`, or `Protected()` syntax, add the provider package and register the provider explicitly before copying those examples:
+If you intentionally want Moq-specific tracked `.Setup(...)`, `SetupSequence(...)`, or `Protected()` syntax, add the provider package first. A single visible Moq provider can be enough, but select or register `moq` explicitly before copying those examples when the suite should not depend on discovery remaining unambiguous:
 
 ```bash
 dotnet add package FastMoq.Provider.Moq

--- a/docs/getting-started/provider-selection.md
+++ b/docs/getting-started/provider-selection.md
@@ -10,7 +10,7 @@ If you only remember four things from this page, make them these:
 
 1. `reflection` remains the neutral fallback when no non-reflection provider is discoverable, or when more than one non-reflection provider is discoverable.
 2. If exactly one non-reflection provider is discoverable and no explicit default was declared, FastMoq selects it automatically.
-3. If the test project uses any provider-specific compatibility or extension APIs, still declare the matching provider explicitly at assembly scope so the suite is predictable.
+3. If the test project uses provider-specific compatibility or extension APIs, FastMoq can still run with a single discoverable non-reflection provider, but declare the matching provider explicitly at assembly scope when you want the suite to stay deterministic as more providers become visible.
 4. You are not limited to the bundled providers. Any public concrete type that implements [IMockingProvider](https://help.fastmoq.com/api/FastMoq.Providers.IMockingProvider.html) and exposes either a public static `Instance` or a public parameterless constructor can participate in discovery automatically. Explicit registration is still useful when you want a friendly alias, an explicit assembly default, or a guaranteed name when a fallback full-type-name collision would otherwise make auto-registration ambiguous.
 
 ## Current defaults
@@ -28,7 +28,7 @@ Important boundary:
 
 - adding `FastMoq.Provider.Moq` gives you the Moq provider package and its extension methods
 - it becomes the effective default only when it is the only discoverable non-reflection provider and no explicit default was declared
-- if the test assembly uses provider-specific APIs, declare the matching provider explicitly as the default provider
+- if the test assembly uses provider-specific APIs, a single visible non-reflection provider can be enough, but declare the matching provider explicitly when the suite should not depend on discovery remaining unambiguous
 - selection can happen through [FastMoqDefaultProviderAttribute](https://help.fastmoq.com/api/FastMoq.Providers.FastMoqDefaultProviderAttribute.html), [FastMoqRegisterProviderAttribute](https://help.fastmoq.com/api/FastMoq.Providers.FastMoqRegisterProviderAttribute.html), `SetDefault(...)`, `Push(...)`, or `Register(..., setAsDefault: true)`
 - custom providers can participate in discovery automatically when the provider type is public, concrete, and creatable; explicit registration is still the right tool when you want a stable friendly alias instead of the fallback full type name, or when multiple discoverable providers would otherwise collide on that fallback name
 
@@ -97,11 +97,13 @@ Use this quick check before reading the rest of the page:
 - switch to `nsubstitute` only when the test project is intentionally written against NSubstitute behavior
 - add a custom provider when your team uses a different mocking library or needs provider behavior that the bundled packages do not cover; register it explicitly only when you want a custom alias or custom construction logic
 
-## Mandatory assembly default when the test assembly must not stay on `reflection`
+## Explicit assembly default when the suite must not depend on discovery
 
-If a migrated test project still uses any non-default provider-specific compatibility or extension surface, treat assembly-wide provider selection as required setup, not as an optional cleanup step.
+If a migrated test project still uses any non-default provider-specific compatibility or extension surface, treat assembly-wide provider selection as the clearest stabilization step whenever the suite should not depend on a single-provider discovery path remaining unambiguous.
 
 For example, `GetMock<T>()`, direct `Mock<T>` access, `VerifyLogger(...)`, and `Protected()` still mean `moq`, while `AsNSubstitute()` and `Received(...)` mean `nsubstitute`.
+
+If a single non-reflection provider is already the only visible provider, FastMoq can resolve it automatically. Use an explicit assembly default when you want deterministic bootstrap, shared repo-level policy, or stable behavior once more providers become visible.
 
 For the built-in `moq` provider, and for `nsubstitute` after its package is referenced, the shortest path is [FastMoqDefaultProviderAttribute](https://help.fastmoq.com/api/FastMoq.Providers.FastMoqDefaultProviderAttribute.html):
 
@@ -148,7 +150,8 @@ Use startup code instead when you need more than declarative assembly metadata. 
 
 Analyzer note:
 
-- `FMOQ0023` warns when legacy Moq-shaped FastMoq APIs remain in a project without explicit Moq onboarding. For core-only package graphs, that means adding `FastMoq.Provider.Moq` and selecting `moq` explicitly.
+- `FMOQ0009` warns when provider-specific FastMoq APIs remain in code that does not resolve the matching provider as the effective provider.
+- `FMOQ0023` warns when legacy Moq-shaped FastMoq APIs remain in a project that does not resolve `moq` as the effective provider. A single compile-time-visible Moq registration can satisfy that automatically, but add `FastMoq.Provider.Moq` if needed and select `moq` explicitly when multiple providers are visible.
 
 ### Assembly startup alternatives
 

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -16,6 +16,48 @@ Use these rules first:
 8. Use [AddKnownType(...)](xref:FastMoq.Mocker.AddKnownType(FastMoq.KnownTypeRegistration,System.Boolean)) when a framework-style type needs special resolution or post-processing behavior.
 9. Use [GetMockDbContext&lt;TContext&gt;()](xref:FastMoq.DbContextMockerExtensions.GetMockDbContext``1(FastMoq.Mocker)) when testing EF Core contexts. Do not hand-roll DbContext setup unless you need behavior outside FastMoq's helper.
 
+## Prefer FastMoq-Owned Setup
+
+When FastMoq already has a first-party helper for the dependency or framework primitive, prefer that helper over handwritten setup.
+
+That is true even when the handwritten setup is technically valid. The FastMoq-owned helper usually reduces repeated plumbing, keeps the dependency graph in one place, and makes the test easier for other FastMoq users to recognize.
+
+Use this decision table first:
+
+| If the test wants... | Prefer... | Usually avoid first... |
+| --- | --- | --- |
+| a tracked collaborator that you will arrange or verify | [GetOrCreateMock&lt;T&gt;()](xref:FastMoq.Mocker.GetOrCreateMock``1(FastMoq.MockRequestOptions)) | creating a mock and then re-registering `mock.Instance` with [AddType(...)](xref:FastMoq.Mocker.AddType``1(System.Func{FastMoq.Mocker,``0},System.Boolean,System.Object[])) |
+| a real fixed dependency instance | [AddType(...)](xref:FastMoq.Mocker.AddType``1(System.Func{FastMoq.Mocker,``0},System.Boolean,System.Object[])) with the concrete instance | wrapping that instance in extra local indirection before handing it back to `Mocker` |
+| FastMoq's built-in real `IFileSystem` | `GetFileSystem(...)` or `GetObject<IFileSystem>()` | creating a fresh `MockFileSystem` only to satisfy an `IFileSystem` slot when the built-in shared one would do |
+| typed DI or scope behavior for framework resolution | `CreateTypedServiceProvider(...)`, `AddServiceProvider(...)`, `CreateTypedServiceScope(...)`, or `AddServiceScope(...)` | ad hoc `new ServiceCollection().BuildServiceProvider()` setup when the typed helper can express the same shape |
+| a framework-style built-in type with special behavior | the matching built-in helper or [AddKnownType(...)](xref:FastMoq.Mocker.AddKnownType(FastMoq.KnownTypeRegistration,System.Boolean)) | treating that dependency like an ordinary manual registration first |
+
+### Keep one dependency model per service
+
+For one service in one test flow, pick one main model:
+
+- tracked mock
+- fixed concrete instance
+- built-in known type
+- typed provider registration
+
+Avoid switching the same service back and forth between those models unless the test intentionally rebuilds the graph for a separate scenario.
+
+For example, avoid this pattern:
+
+```csharp
+var dependency = Mocks.GetOrCreateMock<IMyService>();
+Mocks.AddType(dependency.Instance, replace: true);
+```
+
+That creates a tracked mock and then replaces resolution with the mock's instance as a fixed registration, which blurs the test's intent.
+
+### Reset and per-test state
+
+In [MockerTestBase&lt;TComponent&gt;](xref:FastMoq.MockerTestBase`1), each test already starts from a fresh `Mocker`. Before adding extra setup only to reset state, check whether the current harness already gives you a clean per-test instance.
+
+Use extra per-test instance creation only when the test truly needs an intentionally separate state boundary.
+
 ## Choose The Narrowest Harness
 
 Do not default every test to the heaviest FastMoq surface. Start with the smallest harness that matches the behavior under test.

--- a/docs/getting-started/testing-guide.md
+++ b/docs/getting-started/testing-guide.md
@@ -16,6 +16,24 @@ Use these rules first:
 8. Use [AddKnownType(...)](xref:FastMoq.Mocker.AddKnownType(FastMoq.KnownTypeRegistration,System.Boolean)) when a framework-style type needs special resolution or post-processing behavior.
 9. Use [GetMockDbContext&lt;TContext&gt;()](xref:FastMoq.DbContextMockerExtensions.GetMockDbContext``1(FastMoq.Mocker)) when testing EF Core contexts. Do not hand-roll DbContext setup unless you need behavior outside FastMoq's helper.
 
+## Choose The Narrowest Harness
+
+Do not default every test to the heaviest FastMoq surface. Start with the smallest harness that matches the behavior under test.
+
+| If the test needs... | Prefer... | Why |
+| --- | --- | --- |
+| plain constructor or pure method behavior with no FastMoq-managed resolution | direct construction plus a plain fake, stub, or explicit dependency instance | keeps the test local and makes non-FastMoq behavior obvious |
+| a few DI-managed collaborators without a reusable base class | direct `Mocker` usage | good fit when you want FastMoq resolution without introducing a harness type |
+| repeated component tests where FastMoq should create the subject and own the dependency graph | [MockerTestBase&lt;TComponent&gt;](xref:FastMoq.MockerTestBase`1) | keeps creation, tracked verification, and shared setup in one place |
+| framework-owned HTTP, ASP.NET, Azure Functions, or service-provider plumbing | the matching first-party helper package | avoids hand-rolled framework shims that analyzers now flag directly |
+| real host, container, database, or transport contracts | a separate integration or contract test with explicit real infrastructure | keeps the infrastructure boundary visible instead of hiding it behind partial mocks |
+
+Practical rules:
+
+- keep plain DI tests plain when direct construction is clearer than a reusable harness
+- use FastMoq to remove repeated plumbing, not to obscure the real boundary under test
+- keep real infrastructure tests thin and explicit instead of turning them into half-real component tests
+
 ## Core Mental Model
 
 FastMoq has three distinct resolution paths:
@@ -25,6 +43,26 @@ FastMoq has three distinct resolution paths:
 3. Auto-mock / auto-create: default mock creation and constructor injection when no explicit mapping exists.
 
 That distinction matters because the API choice communicates intent.
+
+## Local Wrapper Boundary
+
+Repo-local wrappers can still be useful, but they should compress repeated setup rather than create another verification abstraction on top of FastMoq.
+
+Keep or add a local wrapper when it:
+
+- builds the same request, context, or provider shape across many tests
+- re-points an existing suite toward first-party FastMoq helpers with lower call-site churn
+- standardizes repeated setup that would otherwise stay verbose and mechanical
+
+Avoid wrapper layers when they:
+
+- only forward to `Mocks.Verify(...)`, `MockingProviderRegistry.Default.Verify(...)`, or `VerifyNoOtherCalls(...)`
+- route provider-neutral verification back through `AsMoq().Verify(...)` or provider-specific `Times` adapters
+- hide whether the handle being verified is tracked or detached
+
+Analyzer note:
+
+- `FMOQ0031` and `FMOQ0032` are intentionally opinionated here: they discourage verification-only wrappers because those wrappers blur tracked-versus-detached intent without adding behavior
 
 ### Equality intent in matcher-style expressions
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -73,7 +73,7 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 
 | ID | Guidance |
 | --- | --- |
-| `FMOQ0001` | Use `GetObject<T>()` or `.Instance` instead of `.Object` on tracked FastMoq mocks |
+| `FMOQ0001` | Use `.Instance` when you already have `IFastMock<T>`, or `GetObject<T>()` / `GetRequiredObject<T>()` when the code only needs the resolved dependency instead of tracked `.Object` |
 | `FMOQ0002` | Use provider-first `Reset()` instead of provider-native reset on tracked FastMoq mocks |
 | `FMOQ0003` | Prefer `VerifyLogged(...)` over `VerifyLogger(...)` when the assertion can stay provider safe |
 | `FMOQ0004` | Keep provider-first retrieval consistent by converting leftover `GetMock<T>()` calls in files that already use `GetOrCreateMock<T>()` |
@@ -98,11 +98,16 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0023` | Add explicit Moq onboarding when legacy Moq-shaped FastMoq APIs remain in core-only projects |
 | `FMOQ0024` | Prefer `Mocker.Verify<T>(...)` over provider-native `Verify(...)` on tracked FastMoq mocks |
 | `FMOQ0025` | Remove or rewrite bare tracked `Verify()` calls so assertions stay explicit |
-| `FMOQ0026` | Avoid storing tracked mocks as `Mock<T>` aliases when they are only used for verification |
+| `FMOQ0026` | Avoid `Mock<T>` aliases that only exist for `Verify(...)`; keep an `IFastMock<T>` handle or verify directly with `Mocker.Verify<T>(...)` |
 | `FMOQ0027` | Avoid raw `new Mock<T>()` creation inside FastMoq test infrastructure; use tracked or standalone provider-first mocks instead |
 | `FMOQ0028` | Add missing helper packages such as `FastMoq.Web` or `FastMoq.AzureFunctions` before applying helper-based migration guidance |
 | `FMOQ0029` | Prefer `AddFunctionContextInvocationId(...)` over raw `FunctionContext.InvocationId` setup |
 | `FMOQ0030` | Prefer `AddLoggerFactory(...)` over direct output-helper-backed `ILoggerFactory`, `ILogger`, or `ILogger<T>` registration |
+| `FMOQ0031` | Avoid `IFastMock<T>` helper wrappers that only forward to FastMoq verification APIs; keep tracked versus detached verification explicit at the call site |
+| `FMOQ0032` | Avoid `IFastMock<T>` helper wrappers that route verification back through `AsMoq().Verify(...)` or provider-specific `Times` adapters |
+| `FMOQ0033` | In `MockerTestBase`-based tests, reuse `GetFileSystem()` instead of creating a fresh `MockFileSystem` for an `IFileSystem` slot |
+| `FMOQ0034` | Inside provider-first `Verify(...)`, replace mechanical `It.*` matchers with `FastArg` equivalents so the assertion stays provider-neutral |
+| `FMOQ0035` | Flag remaining Moq-specific matchers inside provider-first `Verify(...)` when no direct `FastArg` rewrite exists |
 
 For a successful v4 migration, use this boundary:
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -45,12 +45,17 @@ The goal is provider-centric tests by default, not removal of all provider-speci
 
 If your test project references `FastMoq` or `FastMoq.Core`, the FastMoq Roslyn analyzers ship with it by default. That means common migration leftovers such as `.Object`, provider-native `Reset()`, `VerifyLogger(...)`, safe standalone `GetMock<T>()` usage, legacy `GetRequiredMock<T>()` usage, legacy `CreateMock(...)` / `CreateDetachedMock(...)` / `AddMock(...)` usage, and obvious mixed `GetMock<T>()` / `GetOrCreateMock<T>()` usage can be surfaced while you modernize tests. If you want those diagnostics without either runtime package, `FastMoq.Analyzers` remains available as a standalone package.
 
+For migration planning, keep these boundaries clear:
+
+- choose the narrowest harness that matches the test intent: keep plain constructor tests plain, use direct `Mocker` usage for DI-heavy unit and component tests, use `MockerTestBase<T>` when FastMoq should create the subject and own the dependency graph, and keep real host or infrastructure tests thin and explicit
+- local wrappers are useful when they remove repeated setup or re-point a suite toward first-party helpers with lower churn, but avoid wrappers that hide verification boundaries or route provider-neutral verification back through provider-specific APIs
+
 The analyzer pack now has two roles:
 
 - migration guidance for mechanical provider-first rewrites and compatibility cleanup
 - low-noise authoring guidance for new tests where FastMoq already has a clearer first-party pattern
 
-Warnings are the default for compatibility and obsolete-surface cleanup that is usually actionable immediately. That includes `.Object`, provider-native `Reset()`, `VerifyLogger(...)`, `MockOptional`, `Initialize<T>(...)`, `Strict`, safe standalone `GetMock<T>()` replacement candidates, legacy `GetRequiredMock<T>()` compatibility retrieval, legacy Moq mock-creation and lifecycle helpers that need manual migration, mixed `GetMock<T>()` leftovers in files that already use `GetOrCreateMock<T>()`, and provider-specific FastMoq APIs without an explicit provider selection.
+Warnings are the default for compatibility and obsolete-surface cleanup that is usually actionable immediately. That includes `.Object`, provider-native `Reset()`, `VerifyLogger(...)`, `MockOptional`, `Initialize<T>(...)`, `Strict`, safe standalone `GetMock<T>()` replacement candidates, legacy `GetRequiredMock<T>()` compatibility retrieval, legacy Moq mock-creation and lifecycle helpers that need manual migration, mixed `GetMock<T>()` leftovers in files that already use `GetOrCreateMock<T>()`, and provider-specific FastMoq APIs when the matching effective provider is not resolvable.
 
 Current examples include:
 
@@ -81,7 +86,7 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0006` | Replace `Initialize<T>(...)` compatibility wrappers with direct FastMoq APIs |
 | `FMOQ0007` | Replace the `Strict` compatibility alias with explicit `Behavior` settings or `UseStrictPreset()` |
 | `FMOQ0008` | Use `TimesSpec` in shared helper signatures instead of raw Moq `Times` |
-| `FMOQ0009` | Select a provider before using provider-specific FastMoq APIs |
+| `FMOQ0009` | Resolve the matching provider before using provider-specific FastMoq APIs |
 | `FMOQ0010` | Prefer typed provider escape hatches such as `AsMoq()` or `AsNSubstitute()` over raw native mock access |
 | `FMOQ0011` | Prefer `FastMoq.Web` helpers over hand-rolled `HttpContext`, `ControllerContext`, or `IHttpContextAccessor` setup |
 | `FMOQ0012` | Prefer `WhenHttpRequest(...)` or `WhenHttpRequestJson(...)` over Moq-specific HTTP compatibility helpers when the test only needs request and response behavior |
@@ -95,7 +100,7 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0020` | Prefer `AddPropertySetterCapture(...)` over simple `SetupSet(...)` setter-observation flows |
 | `FMOQ0021` | Prefer `AddPropertyState(...)` over simple `SetupAllProperties()` property-state flows |
 | `FMOQ0022` | Avoid rewriting a tracked dependency to `AddType(...)` when the same file still depends on tracked resolution or property helpers for that service |
-| `FMOQ0023` | Add explicit Moq onboarding when legacy Moq-shaped FastMoq APIs remain in core-only projects |
+| `FMOQ0023` | Resolve Moq provider selection when legacy Moq-shaped FastMoq APIs remain in use |
 | `FMOQ0024` | Prefer `Mocker.Verify<T>(...)` over provider-native `Verify(...)` on tracked FastMoq mocks |
 | `FMOQ0025` | Remove or rewrite bare tracked `Verify()` calls so assertions stay explicit |
 | `FMOQ0026` | Avoid `Mock<T>` aliases that only exist for `Verify(...)`; keep an `IFastMock<T>` handle or verify directly with `Mocker.Verify<T>(...)` |
@@ -103,8 +108,8 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0028` | Add missing helper packages such as `FastMoq.Web` or `FastMoq.AzureFunctions` before applying helper-based migration guidance |
 | `FMOQ0029` | Prefer `AddFunctionContextInvocationId(...)` over raw `FunctionContext.InvocationId` setup |
 | `FMOQ0030` | Prefer `AddLoggerFactory(...)` over direct output-helper-backed `ILoggerFactory`, `ILogger`, or `ILogger<T>` registration |
-| `FMOQ0031` | Avoid `IFastMock<T>` helper wrappers that only forward to FastMoq verification APIs; keep tracked versus detached verification explicit at the call site |
-| `FMOQ0032` | Avoid `IFastMock<T>` helper wrappers that route verification back through `AsMoq().Verify(...)` or provider-specific `Times` adapters |
+| `FMOQ0031` | Avoid `IFastMock<T>` helper wrappers that only forward to FastMoq verification APIs; keep tracked versus detached verification explicit at the call site and prefer direct rewrites at wrapper call sites when the replacement is mechanical |
+| `FMOQ0032` | Avoid `IFastMock<T>` helper wrappers that route verification back through `AsMoq().Verify(...)` or provider-specific `Times` adapters; prefer direct provider-first rewrites at wrapper call sites when the replacement is mechanical |
 | `FMOQ0033` | In `MockerTestBase`-based tests, reuse `GetFileSystem()` instead of creating a fresh `MockFileSystem` for an `IFileSystem` slot |
 | `FMOQ0034` | Inside provider-first `Verify(...)`, replace mechanical `It.*` matchers with `FastArg` equivalents so the assertion stays provider-neutral |
 | `FMOQ0035` | Flag remaining Moq-specific matchers inside provider-first `Verify(...)` when no direct `FastArg` rewrite exists |
@@ -195,7 +200,7 @@ Typical approach:
 
 1. Upgrade to v4.
 1. Run the test suite without rewriting test code.
-1. If legacy Moq-shaped tests fail, select `moq` explicitly for the test assembly.
+1. If legacy Moq-shaped tests fail because `moq` is not resolving as the effective provider, select `moq` explicitly for the test assembly.
 1. Keep existing `GetMock<T>()`, `VerifyLogger(...)`, and other compatibility surfaces where they are already working.
 1. Defer broader provider-neutral cleanup until the suite is stable.
 
@@ -277,7 +282,7 @@ Open these only when you hit the relevant problem. That keeps this page short wi
 ### Stabilize-first order
 
 1. Upgrade to v4 and run the suite unchanged.
-1. If legacy Moq-shaped tests fail, select `moq` explicitly for the test assembly, typically with `[assembly: FastMoqDefaultProvider("moq")]`, `[assembly: FastMoqRegisterProvider("moq", typeof(MoqMockingProvider), SetAsDefault = true)]`, or an equivalent bootstrap hook.
+1. If legacy Moq-shaped tests fail because `moq` is not resolving as the effective provider, select `moq` explicitly for the test assembly, typically with `[assembly: FastMoqDefaultProvider("moq")]`, `[assembly: FastMoqRegisterProvider("moq", typeof(MoqMockingProvider), SetAsDefault = true)]`, or an equivalent bootstrap hook.
 1. Audit `Strict` usage and decide whether each case means fail-on-unconfigured only or a full strict preset. Use [API replacements and migration exceptions](./api-replacements-and-exceptions.md#strict) and [Testing Guide: Strict vs Presets](../getting-started/testing-guide.md#strict-vs-presets) when the replacement is unclear.
 1. Replace new `MockOptional` usage with explicit `OptionalParameterResolution`, `InvocationOptions`, or `MockerTestBase<TComponent>` component-construction overrides. See [API replacements and migration exceptions](./api-replacements-and-exceptions.md#obsolete-mockoptional) and [Testing Guide: Optional constructor and method parameters](../getting-started/testing-guide.md#optional-constructor-and-method-parameters) when the right replacement is unclear.
 1. Stop once the suite is stable unless you are already touching tests for other work.

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -919,11 +919,12 @@ Current guidance:
 - call `Mocks.Verify<T>(...)` directly when the mock is tracked by the current `Mocker`
 - call `MockingProviderRegistry.Default.Verify(...)` directly when the handle is detached
 - do not add a new `IFastMock<T>.Verify(...)` helper layer just to hide that distinction
+- when a repo-local `IFastMock<T>.Verify(...)` wrapper still exists temporarily, prefer rewriting the call site directly to `Mocks.Verify<T>(...)` or `MockingProviderRegistry.Default.Verify(...)` when that translation is mechanical
 
 Why:
 
-- `FMOQ0031` covers wrappers that only forward to FastMoq's own verification APIs
-- `FMOQ0032` covers wrappers that route verification back through `AsMoq().Verify(...)`, Moq `Verify(...)`, or `TimesSpec` to `Times` adapters
+- `FMOQ0031` covers wrappers that only forward to FastMoq's own verification APIs, and their direct wrapper call sites when the rewrite is mechanical
+- `FMOQ0032` covers wrappers that route verification back through `AsMoq().Verify(...)`, Moq `Verify(...)`, or `TimesSpec` to `Times` adapters, and their direct wrapper call sites when the rewrite is mechanical
 - those wrappers hide tracked-versus-detached intent and spread another verification surface through the suite without adding new behavior
 
 ### Shared file system in `MockerTestBase`

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -10,7 +10,7 @@ These are small migration edges that cause disproportionate churn in provider-fi
 
 | Legacy habit | Preferred v4 move | Why it trips people up |
 | --- | --- | --- |
-| `mock.Object` or `GetMock<T>().Object` | `fastMock.Instance` or `Mocks.GetObject<T>()` | `GetOrCreateMock<T>()` returns `IFastMock<T>`, not a raw `Mock<T>` |
+| `mock.Object` or `GetMock<T>().Object` | `fastMock.Instance`, `Mocks.GetObject<T>()`, or `Mocks.GetRequiredObject<T>()` | `GetOrCreateMock<T>()` returns `IFastMock<T>`, not a raw `Mock<T>` |
 | `mock.Reset()` | `fastMock.Reset()` | The provider-first handle already has a reset surface; `AsMoq()` is only needed when you truly need raw Moq APIs |
 | `TimesSpec.Never` during bulk conversion | `TimesSpec.Never()` or preferably `TimesSpec.NeverCalled` | The method call is easy to miss, and `NeverCalled` avoids the missing-parentheses mistake entirely |
 | one unkeyed mock for two keyed constructor dependencies | keyed `MockRequestOptions.ServiceKey`, `AddKeyedType(...)`, or explicit constructor injection | a single type-based double cannot catch public or private or primary or secondary swaps |
@@ -52,6 +52,73 @@ void AssertLogged(Mock<ILogger> logger, Func<Times> times)
 // Deliberate migration boundary
 void AssertLogged(Mocker mocker, TimesSpec times)
 ```
+
+### `.Object` on tracked FastMoq mocks
+
+Old pattern:
+
+```csharp
+var logger = Mocks.GetMock<ILogger<OrderService>>().Object;
+```
+
+Current guidance when the code only needs the dependency instance:
+
+```csharp
+var logger = Mocks.GetObject<ILogger<OrderService>>();
+```
+
+Or, when the code already has a tracked handle:
+
+```csharp
+var loggerMock = Mocks.GetOrCreateMock<ILogger<OrderService>>();
+var logger = loggerMock.Instance;
+```
+
+If the old call site used `GetRequiredTrackedMock<T>()` and only needs the instance, use `GetRequiredObject<T>()` instead.
+
+Why:
+
+- use `.Instance` when you already have an `IFastMock<T>` handle
+- use `GetObject<T>()` or `GetRequiredObject<T>()` when the code is retrieving the dependency from `Mocker` only to get the instance
+- keep `AsMoq().Object` only for a deliberate local raw-Moq compatibility pocket
+
+### Verification-only `Mock<T>` aliases
+
+Old pattern:
+
+```csharp
+private Mocker Mocks { get; } = new();
+private Mock<IOrderGateway> GatewayMock => Mocks.GetOrCreateMock<IOrderGateway>().AsMoq();
+
+void AssertSent()
+{
+    GatewayMock.Verify(x => x.Send("alpha"));
+}
+```
+
+Current guidance:
+
+```csharp
+private Mocker Mocks { get; } = new();
+
+void AssertSent()
+{
+    Mocks.Verify<IOrderGateway>(x => x.Send("alpha"), TimesSpec.Once);
+}
+```
+
+Or, when you still want a reusable tracked handle for arrangement:
+
+```csharp
+private Mocker Mocks { get; } = new();
+private IFastMock<IOrderGateway> Gateway => Mocks.GetOrCreateMock<IOrderGateway>();
+```
+
+Why:
+
+- a `Mock<T>` alias that only exists for later `Verify(...)` calls keeps the test on the Moq surface without adding behavior
+- keep verification explicit with `Mocker.Verify<T>(...)`
+- keep a `Mock<T>` alias only when the symbol also needs Moq-specific setup or other raw `Mock<T>` behavior such as `Protected()` or `SetupSet(...)`
 
 ## Old to new guidance
 
@@ -829,6 +896,66 @@ Why:
 - provider-specific convenience now belongs in provider packages instead of core
 - raw `NativeMock` access is still available, but it is no longer the best primary guidance when a typed provider extension exists
 
+### `IFastMock<T>` verify wrappers
+
+Old helper patterns:
+
+```csharp
+internal static void Verify<T>(this IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+    where T : class
+    => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+```
+
+Or a provider-specific wrapper:
+
+```csharp
+internal static void Verify<T, TResult>(this IFastMock<T> fastMock, Expression<Func<T, TResult>> expression, TimesSpec times)
+    where T : class
+    => fastMock.AsMoq().Verify(expression, times.ToMoq());
+```
+
+Current guidance:
+
+- call `Mocks.Verify<T>(...)` directly when the mock is tracked by the current `Mocker`
+- call `MockingProviderRegistry.Default.Verify(...)` directly when the handle is detached
+- do not add a new `IFastMock<T>.Verify(...)` helper layer just to hide that distinction
+
+Why:
+
+- `FMOQ0031` covers wrappers that only forward to FastMoq's own verification APIs
+- `FMOQ0032` covers wrappers that route verification back through `AsMoq().Verify(...)`, Moq `Verify(...)`, or `TimesSpec` to `Times` adapters
+- those wrappers hide tracked-versus-detached intent and spread another verification surface through the suite without adding new behavior
+
+### Shared file system in `MockerTestBase`
+
+Old pattern:
+
+```csharp
+class SampleTests : MockerTestBase<SampleService>
+{
+    public SampleTests() : base(mocker => new SampleService(new MockFileSystem().FileSystem))
+    {
+    }
+}
+```
+
+Current guidance:
+
+```csharp
+class SampleTests : MockerTestBase<SampleService>
+{
+    public SampleTests() : base(mocker => new SampleService(mocker.GetFileSystem()))
+    {
+    }
+}
+```
+
+Why:
+
+- `FMOQ0033` warns when a `MockerTestBase`-based flow creates a fresh `MockFileSystem` only to satisfy an `IFileSystem` slot
+- `GetFileSystem()` keeps constructor injection and later `IFileSystem` resolution on the same shared in-memory file system
+- keep a separate `MockFileSystem` only when the collaborator really needs the concrete `MockFileSystem` type or the test intentionally needs an independent file system instance
+
 ## Expected migration exceptions
 
 Some migrated tests should intentionally stay on raw Moq. That is normal in v4.
@@ -926,6 +1053,12 @@ Inside provider-first verification expressions, translate matcher helpers this w
 - `It.IsAny<T>()` becomes `FastArg.Any<T>()`
 - `It.Is<T>(predicate)` becomes `FastArg.Is<T>(predicate)`
 - `It.IsAny<Expression<Func<T, bool>>>()` becomes `FastArg.AnyExpression<T>()`
+
+Analyzer notes:
+
+- `FMOQ0024` moves tracked verification off provider-native `Verify(...)` and onto provider-first `Verify(...)`
+- `FMOQ0034` rewrites the mechanical matcher cases above so the assertion stays provider-neutral
+- `FMOQ0035` flags unsupported Moq matcher helpers that stay inside provider-first `Verify(...)` without offering a code fix; in those cases, rewrite the assertion shape or keep the matcher on a deliberate local Moq-only verification path
 
 ### Cache and property-setter edge case
 

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -320,3 +320,37 @@ If a suite already has local `SetupClaimsPrincipal(...)`, `CreateControllerConte
 1. Simplify or remove the wrapper later only if the direct FastMoq call sites are actually clearer.
 
 That approach keeps the migration low-risk. After v4 migration, those local helpers often become thin wrappers rather than remaining hand-rolled infrastructure.
+
+If the suite already exposes a local `CreateHttpRequest(...)` helper, use the same rule. Prefer building the underlying request with `CreateHttpContext(...)`, `SetRequestHeader(...)`, `SetRequestBody(...)`, and `SetRequestJsonBody(...)`, then return `httpContext.Request` from the local wrapper if that is still the clearest call-site shape.
+
+Keep only the repo-specific parts local. For example, if the app stamps custom encoded principal headers, tenant headers, or other product-specific request metadata, keep that serialization in the local helper but stop hand-rolling the `DefaultHttpContext`, header collection, and request body wiring.
+
+```csharp
+using FastMoq.Web.Extensions;
+
+private static HttpRequest CreateHttpRequest(
+    Mocker mocks,
+    IServiceProvider? services = null,
+    string? requestBody = null,
+    ClaimsPrincipal? principal = null)
+{
+    var httpContext = principal is null
+        ? mocks.CreateHttpContext(static _ => { })
+        : mocks.CreateHttpContext(principal, static _ => { });
+
+    if (services is not null)
+    {
+        httpContext.RequestServices = services;
+    }
+
+    if (requestBody is not null)
+    {
+        httpContext.SetRequestBody(requestBody, contentType: "application/json");
+    }
+
+    // Keep app-specific request headers local to the suite.
+    return httpContext.Request;
+}
+```
+
+That keeps the common ASP.NET Core request mechanics on the FastMoq side while still leaving room for suite-specific headers or claim serialization that FastMoq should not hard-code.

--- a/docs/migration/provider-and-compatibility.md
+++ b/docs/migration/provider-and-compatibility.md
@@ -12,13 +12,13 @@ The current v4 repository behavior differs from `3.0.0` in one important way:
 
 - `FastMoq.Core` now bundles both `reflection` and `moq`
 - `reflection` is the default provider if you do nothing
-- tests carried forward from previous FastMoq versions that rely on `GetMock<T>()`, direct `Mock<T>` access, `Protected()`, or `VerifyLogger(...)` should select `moq` explicitly for the test assembly
+- tests carried forward from previous FastMoq versions that rely on `GetMock<T>()`, direct `Mock<T>` access, `Protected()`, or `VerifyLogger(...)` usually should select `moq` explicitly for the test assembly when the suite should not depend on single-provider discovery remaining unambiguous
 
 This is easy to miss during migration because package installation, extension-method availability, and active-provider selection are three separate things:
 
 - installing a provider package gives you its implementation and extension methods
 - importing its namespace makes those extension methods visible
-- declaring or setting the default provider is what actually makes FastMoq use it for new mocks
+- declaring or setting the default provider is what makes FastMoq use it for new mocks when discovery does not already resolve the intended effective provider
 
 ### Package-to-namespace quick map
 
@@ -53,13 +53,17 @@ Use this rule during migration:
 
 Most test projects should start with `FastMoq` or `FastMoq.Core`. `FastMoq.Abstractions` is mainly for custom-provider or advanced extension work, while `FastMoq.Analyzers` only contributes diagnostics and code fixes at build time.
 
-Installing `FastMoq.Core` plus `FastMoq.Provider.Moq` is not enough by itself. The Moq provider still needs to be selected as the default for that test assembly.
+Installing `FastMoq.Core` plus `FastMoq.Provider.Moq` is not enough by itself when the suite still needs deterministic Moq selection. The provider package adds extension methods and registration metadata, but the effective provider still has to resolve to `moq`. A single visible non-reflection provider can satisfy that automatically; explicit selection is the safer path when the suite should not depend on discovery.
 
 FastMoq is also not limited to the bundled providers. If your suite uses another mocking library, you can implement `IMockingProvider` and register your own provider instead of adopting `moq` or `nsubstitute`.
 
 If you need a provider-by-provider answer for what is supported today, see [Provider Capabilities](../getting-started/provider-capabilities.md).
 
-Treat explicit assembly-default selection as mandatory whenever the migrated test project still uses any non-default provider-specific compatibility or extension surface.
+Treat explicit assembly-default selection as the safest stabilization step whenever the migrated test project still uses any non-default provider-specific compatibility or extension surface and the suite should not depend on discovery.
+
+Analyzer note:
+
+- `FMOQ0009` and `FMOQ0023` use effective-provider semantics rather than explicit-only semantics, so a single visible provider can satisfy them automatically even when the repo still chooses to declare an assembly default for determinism.
 
 Current fallback rule of thumb:
 

--- a/docs/whats-new/README.md
+++ b/docs/whats-new/README.md
@@ -30,7 +30,7 @@ FastMoq `4.1.0` updates the published v4 line to match the broader package split
 
 Consumer impact:
 
-- the aggregate `FastMoq` package now pulls together the core runtime, shared Azure SDK helpers, Azure Functions HTTP-trigger helpers, database helpers, web support, provider integrations, and analyzer assets by default
+- the aggregate `FastMoq` package now pulls together the core runtime, shared Azure SDK helpers, Azure Functions HTTP-trigger helpers, database helpers, web support, provider integrations, and analyzer assets by default, while `FastMoq.Core` also carries the analyzer assets in the split-package path
 - `FastMoq.Azure` is the first-party package for `PageableBuilder`, token and default credential helpers, Azure-oriented configuration or service-provider helpers, and common Azure client registration
 - `FastMoq.AzureFunctions` is the first-party package for typed `FunctionContext.InstanceServices` setup, concrete `HttpRequestData` and `HttpResponseData` builders, and body readers for request or response assertions
 - the docs now steer consumers more directly between the aggregate package path and split-package installs based on which helpers a test project actually needs
@@ -70,7 +70,7 @@ At a high level, the current line adds:
 - a provider-first architecture with explicit provider registration and selection
 - a new package split for abstractions, Azure SDK helpers, Azure Functions helpers, database helpers, web helpers, and provider-specific adapters
 - first-party Azure testing helpers for storage-client registration and Azure Functions worker or HTTP-trigger setup
-- analyzer guidance that can be consumed as a standalone package or through the aggregate `FastMoq` package by default
+- analyzer guidance that can be consumed as a standalone package or through `FastMoq` or `FastMoq.Core` by default
 - provider-neutral verification and scenario-building APIs for newer tests
 - explicit policy surfaces for constructor fallback, method fallback, built-in known types, and optional-parameter resolution
 - expanded repo-native documentation, migration guidance, and executable examples
@@ -227,7 +227,7 @@ Compared to `3.0.0`, the current line also updates the supported target framewor
 
 - libraries now target `net8.0`, `net9.0`, and `net10.0`
 - older packaging based on per-project `.nuspec` files was removed in favor of SDK-style package metadata in the project files
-- the aggregate `FastMoq` package now ships analyzer assets by default while the split-package path keeps analyzers opt-in
+- both `FastMoq` and `FastMoq.Core` now ship analyzer assets by default, while `FastMoq.Analyzers` remains available as the standalone diagnostics-only option
 - solution and test coverage expanded to include provider-specific packages and verification matrices
 
 ## Recommended reading order


### PR DESCRIPTION
## Summary
Align the shipped analyzer guidance with the migration documentation and close the public catalog gap.

## What changed
- tighten FMOQ0001 and FMOQ0026 descriptor wording so the diagnostics explain the actual migration decision
- extend the public analyzer catalog and migration guidance through FMOQ0035
- add an analyzer test that fails if a public diagnostic ID is missing from the migration guide catalog

## Validation
- `dotnet test FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj`
- `scripts/Generate-ApiDocs.ps1`