### PR TITLE
Add SetupLoggerCallback migration analyzer and reset fix

### DIFF
--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -31,6 +31,7 @@ namespace FastMoq.Analyzers.Tests
             { new TimesSpecHelperBoundaryAnalyzer(), DiagnosticDescriptors.UseTimesSpecAtHelperBoundary },
             { new OptionsSetupAnalyzer(), DiagnosticDescriptors.PreferSetupOptionsHelper },
             { new LoggerFactoryRegistrationAnalyzer(), DiagnosticDescriptors.PreferLoggerFactoryHelpers },
+            { new LoggerSetupCallbackAnalyzer(), DiagnosticDescriptors.PreferSetupLoggerCallbackHelper },
             { new SetupSetAnalyzer(), DiagnosticDescriptors.PreferPropertySetterCaptureHelper },
             { new SetupAllPropertiesAnalyzer(), DiagnosticDescriptors.PreferPropertyStateHelper },
             { new TrackedMockVerificationAnalyzer(), DiagnosticDescriptors.UseProviderFirstVerify },
@@ -70,6 +71,7 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.UseTimesSpecAtHelperBoundary, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferSetupOptionsHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferLoggerFactoryHelpers, DiagnosticSeverity.Info },
+            { DiagnosticDescriptors.PreferSetupLoggerCallbackHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferPropertySetterCaptureHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.PreferPropertyStateHelper, DiagnosticSeverity.Info },
             { DiagnosticDescriptors.UseProviderFirstVerify, DiagnosticSeverity.Warning },
@@ -271,6 +273,74 @@ class Sample
     {
         var mock = Mocks.GetMock<IService>();
         Mocks.GetOrCreateMock<IService>().Reset();
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task TrackedMockResetAnalyzer_ShouldNotReport_WhenResetAlreadyUsesProviderFirstFastMock()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class Sample
+{
+    private interface IService
+    {
+    }
+
+    void Execute(Mocker Mocks)
+    {
+        var mock = Mocks.GetOrCreateMock<IService>();
+        mock.Reset();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockResetAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.UseProviderFirstReset);
+        }
+
+        [Fact]
+        public async Task TrackedMockResetAnalyzer_ShouldPreserveReusableFastMockReceiver_WhenRewritingProviderNativeReset()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    private interface IService
+    {
+    }
+
+    void Execute(Mocker Mocks)
+    {
+        var mock = Mocks.GetOrCreateMock<IService>();
+        mock.AsMoq().Reset();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new TrackedMockResetAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UseProviderFirstReset));
+            Assert.Equal(DiagnosticIds.UseProviderFirstReset, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new TrackedMockResetAnalyzer(), codeFixProvider, DiagnosticIds.UseProviderFirstReset);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    private interface IService
+    {
+    }
+
+    void Execute(Mocker Mocks)
+    {
+        var mock = Mocks.GetOrCreateMock<IService>();
+        mock.Reset();
     }
 }");
 
@@ -2399,6 +2469,192 @@ sealed class OutputAwareService : IOutputAwareService
 
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerFactoryRegistrationAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreferLoggerFactoryHelpers);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_AllItLoggerCallbackSetup()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((_, _) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                var level = (LogLevel)invocation.Arguments[0];
+                var state = invocation.Arguments[2]?.ToString() ?? string.Empty;
+                var exception = invocation.Arguments[3] as Exception;
+
+                output.WriteLine($""[{level}] {state}"");
+
+                if (exception != null)
+                {
+                    output.WriteLine($""[Exception] {exception.GetType().Name}: {exception.Message}"");
+                }
+            }));
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper));
+            Assert.Equal(DiagnosticIds.PreferSetupLoggerCallbackHelper, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new LoggerSetupCallbackAnalyzer(), codeFixProvider, DiagnosticIds.PreferSetupLoggerCallbackHelper);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.SetupLoggerCallback((capturedLogLevel, capturedEventId, capturedMessage, capturedException) =>
+        {
+            var level = capturedLogLevel;
+            var state = capturedMessage ?? string.Empty;
+            var exception = capturedException;
+
+            output.WriteLine($""[{level}] {state}"");
+
+            if (exception != null)
+            {
+                output.WriteLine($""[Exception] {exception.GetType().Name}: {exception.Message}"");
+            }
+        });
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_MixedFastArgAndItLoggerCallbackSetup()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                FastArg.Any<LogLevel>(),
+                FastArg.Any<EventId>(),
+                It.Is<It.IsAnyType>((_, _) => true),
+                FastArg.Any<Exception>(),
+                FastArg.Any<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                var level = (LogLevel)invocation.Arguments[0];
+                var state = invocation.Arguments[2]?.ToString() ?? string.Empty;
+                var exception = invocation.Arguments[3] as Exception;
+
+                output.WriteLine($""[{level}] {state}"");
+
+                if (exception != null)
+                {
+                    output.WriteLine($""[Exception] {exception.GetType().Name}: {exception.Message}"");
+                }
+            }));
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper));
+            Assert.Equal(DiagnosticIds.PreferSetupLoggerCallbackHelper, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new LoggerSetupCallbackAnalyzer(), codeFixProvider, DiagnosticIds.PreferSetupLoggerCallbackHelper);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.SetupLoggerCallback((capturedLogLevel, capturedEventId, capturedMessage, capturedException) =>
+        {
+            var level = capturedLogLevel;
+            var state = capturedMessage ?? string.Empty;
+            var exception = capturedException;
+
+            output.WriteLine($""[{level}] {state}"");
+
+            if (exception != null)
+            {
+                output.WriteLine($""[Exception] {exception.GetType().Name}: {exception.Message}"");
+            }
+        });
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldNotReport_WhenCallbackUsesRawStructuredLoggerState()
+        {
+            const string SOURCE = @"
+using System;
+using System.Collections.Generic;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                if (invocation.Arguments[2] is IEnumerable<KeyValuePair<string, object>> properties)
+                {
+                    foreach (var property in properties)
+                    {
+                    }
+                }
+            }));
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2691,6 +2691,72 @@ class Sample
         }
 
         [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldNotReport_WhenCallbackResultIsAssigned()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    object Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        var setup = mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                output.WriteLine(invocation.Arguments[2]?.ToString() ?? string.Empty);
+            }));
+
+        return setup;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldNotReport_WhenCallbackResultIsReturned()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    object Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        return mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                output.WriteLine(invocation.Arguments[2]?.ToString() ?? string.Empty);
+            }));
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper);
+        }
+
+        [Fact]
         public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_NullableExceptionMatcher()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2658,6 +2658,203 @@ class Sample
         }
 
         [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_NullableExceptionMatcher()
+        {
+            const string SOURCE = @"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                output.WriteLine(invocation.Arguments[2]?.ToString() ?? string.Empty);
+            }));
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper));
+            Assert.Equal(DiagnosticIds.PreferSetupLoggerCallbackHelper, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new LoggerSetupCallbackAnalyzer(), codeFixProvider, DiagnosticIds.PreferSetupLoggerCallbackHelper);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.SetupLoggerCallback((capturedLogLevel, capturedEventId, capturedMessage, capturedException) =>
+        {
+            output.WriteLine(capturedMessage ?? string.Empty);
+        });
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_TypedCallbackWithStateToString()
+        {
+            const string SOURCE = @"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback((LogLevel logLevel, EventId eventId, object state, Exception? exception) =>
+            {
+                output.WriteLine($""[{logLevel}] {state?.ToString() ?? string.Empty}""
+                );
+
+                if (exception is not null)
+                {
+                    output.WriteLine(exception.Message);
+                }
+            });
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper));
+            Assert.Equal(DiagnosticIds.PreferSetupLoggerCallbackHelper, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new LoggerSetupCallbackAnalyzer(), codeFixProvider, DiagnosticIds.PreferSetupLoggerCallbackHelper);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.SetupLoggerCallback((capturedLogLevel, capturedEventId, capturedMessage, capturedException) =>
+        {
+            output.WriteLine($""[{capturedLogLevel}] {capturedMessage ?? string.Empty}""
+            );
+
+            if (capturedException is not null)
+            {
+                output.WriteLine(capturedException.Message);
+            }
+        });
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_TypedCallbackWithFormatterInvocation()
+        {
+            const string SOURCE = @"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback((LogLevel logLevel, EventId eventId, object state, Exception? exception, Delegate formatter) =>
+            {
+                var message = formatter.DynamicInvoke(state, exception);
+                output.WriteLine($""[{logLevel}] {message}""
+                );
+
+                if (exception is not null)
+                {
+                    output.WriteLine(exception.Message);
+                }
+            });
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper));
+            Assert.Equal(DiagnosticIds.PreferSetupLoggerCallbackHelper, diagnostic.Id);
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(SOURCE, new LoggerSetupCallbackAnalyzer(), codeFixProvider, DiagnosticIds.PreferSetupLoggerCallbackHelper);
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+#nullable enable
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FastMoq.Extensions;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.SetupLoggerCallback((capturedLogLevel, capturedEventId, capturedMessage, capturedException) =>
+        {
+            var message = capturedMessage;
+            output.WriteLine($""[{capturedLogLevel}] {message}""
+            );
+
+            if (capturedException is not null)
+            {
+                output.WriteLine(capturedException.Message);
+            }
+        });
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task KeyedDependencyAnalyzer_ShouldNotReport_WhenKeyedMockOptionsAreUsed()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -2658,6 +2658,39 @@ class Sample
         }
 
         [Fact]
+        public async Task LoggerSetupCallbackAnalyzer_ShouldNotReport_WhenCallbackIsNotTerminalInChain()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+class Sample
+{
+    void Execute(Mocker mocks, Xunit.ITestOutputHelper output)
+    {
+        mocks.GetOrCreateMock<ILogger>()
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                output.WriteLine(invocation.Arguments[2]?.ToString() ?? string.Empty);
+            }))
+            .Verifiable();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerSetupCallbackAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.PreferSetupLoggerCallbackHelper);
+        }
+
+        [Fact]
         public async Task LoggerSetupCallbackAnalyzer_ShouldReportAndFix_NullableExceptionMatcher()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers/Analyzers/LoggerSetupCallbackAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/LoggerSetupCallbackAnalyzer.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    /// <summary>
+    /// Detects tracked ILogger setup callbacks that only mirror normalized log output and can move to Mocker.SetupLoggerCallback(...).
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class LoggerSetupCallbackAnalyzer : DiagnosticAnalyzer
+    {
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PreferSetupLoggerCallbackHelper);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax) context.Node;
+            if (!FastMoqAnalysisHelpers.TryBuildSetupLoggerCallbackReplacement(invocationExpression, context.SemanticModel, context.CancellationToken, out _))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.PreferSetupLoggerCallbackHelper,
+                FastMoqAnalysisHelpers.GetTargetNameLocation(invocationExpression.Expression),
+                "SetupLoggerCallback(...)"));
+        }
+    }
+}

--- a/FastMoq.Analyzers/Analyzers/TrackedMockResetAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/TrackedMockResetAnalyzer.cs
@@ -25,12 +25,19 @@ namespace FastMoq.Analyzers.Analyzers
                 return;
             }
 
+            if (FastMoqAnalysisHelpers.TryGetMethodSymbol(invocationExpression, context.SemanticModel, context.CancellationToken, out var method) &&
+                method is not null &&
+                FastMoqAnalysisHelpers.IsFastMoqResetMethod(method))
+            {
+                return;
+            }
+
             if (!FastMoqAnalysisHelpers.TryResolveTrackedMockOrigin(memberAccess.Expression, context.SemanticModel, context.CancellationToken, out var origin))
             {
                 return;
             }
 
-            var replacement = FastMoqAnalysisHelpers.BuildResetReplacement(origin, context.SemanticModel, invocationExpression.SpanStart);
+            var replacement = FastMoqAnalysisHelpers.BuildResetReplacement(origin, context.SemanticModel, invocationExpression.SpanStart, context.CancellationToken);
             context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.UseProviderFirstReset,
                 memberAccess.Name.GetLocation(),

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -25,6 +25,7 @@ namespace FastMoq.Analyzers.CodeFixes
             DiagnosticIds.UseProviderFirstObjectAccess,
             DiagnosticIds.UseProviderFirstReset,
             DiagnosticIds.UseVerifyLogged,
+            DiagnosticIds.PreferSetupLoggerCallbackHelper,
             DiagnosticIds.UseProviderFirstVerify,
             DiagnosticIds.AvoidFastMockVerifyHelperWrappers,
             DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers,
@@ -106,6 +107,23 @@ namespace FastMoq.Analyzers.CodeFixes
                                 "Use VerifyLogged(...)",
                                 cancellationToken => ReplaceInvocationAsync(document, invocationExpression, BuildVerifyLoggedReplacementAsync, cancellationToken),
                                 nameof(DiagnosticIds.UseVerifyLogged)),
+                            diagnostic);
+                        break;
+                    }
+
+                case DiagnosticIds.PreferSetupLoggerCallbackHelper:
+                    {
+                        var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                        if (invocationExpression is null)
+                        {
+                            return;
+                        }
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Use SetupLoggerCallback(...)",
+                                cancellationToken => ReplaceSetupLoggerCallbackInvocationAsync(document, invocationExpression, cancellationToken),
+                                nameof(DiagnosticIds.PreferSetupLoggerCallbackHelper)),
                             diagnostic);
                         break;
                     }
@@ -780,7 +798,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 return null;
             }
 
-            return FastMoqAnalysisHelpers.BuildResetReplacement(origin, semanticModel, invocationExpression.SpanStart);
+            return FastMoqAnalysisHelpers.BuildResetReplacement(origin, semanticModel, invocationExpression.SpanStart, cancellationToken);
         }
 
         private static string? BuildVerifyLoggedReplacementAsync(Document document, SemanticModel semanticModel, SyntaxNode syntaxNode, CancellationToken cancellationToken)
@@ -842,6 +860,14 @@ namespace FastMoq.Analyzers.CodeFixes
                 : null;
         }
 
+        private static string? BuildSetupLoggerCallbackReplacementAsync(Document document, SemanticModel semanticModel, SyntaxNode syntaxNode, CancellationToken cancellationToken)
+        {
+            return syntaxNode is InvocationExpressionSyntax invocationExpression &&
+                FastMoqAnalysisHelpers.TryBuildSetupLoggerCallbackReplacement(invocationExpression, semanticModel, cancellationToken, out var replacement)
+                ? replacement
+                : null;
+        }
+
         private static async Task<Document> ReplaceSetupOptionsInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -873,6 +899,28 @@ namespace FastMoq.Analyzers.CodeFixes
             }
 
             var replacementText = BuildLoggerFactoryHelperReplacementAsync(document, semanticModel, invocationExpression, cancellationToken);
+            if (replacementText is null)
+            {
+                return document;
+            }
+
+            var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
+                .WithTriviaFrom(invocationExpression);
+            var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
+
+            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions"));
+        }
+
+        private static async Task<Document> ReplaceSetupLoggerCallbackInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return document;
+            }
+
+            var replacementText = BuildSetupLoggerCallbackReplacementAsync(document, semanticModel, invocationExpression, cancellationToken);
             if (replacementText is null)
             {
                 return document;

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -123,6 +123,15 @@ namespace FastMoq.Analyzers
             isEnabledByDefault: true,
             description: "Prefer AddLoggerFactory(...) over direct AddType<ILoggerFactory>(new ...output-helper...), AddType<ILogger>(new ...output-helper...), or AddType<ILogger<T>>(new ...output-helper...) registrations when the logger registration only mirrors logs into xUnit-style output helpers.");
 
+        public static readonly DiagnosticDescriptor PreferSetupLoggerCallbackHelper = new(
+            DiagnosticIds.PreferSetupLoggerCallbackHelper,
+            "Prefer SetupLoggerCallback for normalized logger mirroring",
+            "Use '{0}' instead of provider-specific ILogger.Log<TState> setup when the callback only needs normalized log output",
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Prefer Mocker.SetupLoggerCallback(...) over tracked ILogger.Log<TState> Setup(...).Callback(...) chains when the callback only consumes log level, event id, formatted message text, or exception data. Keep the Moq compatibility path when the test needs raw structured logger state.");
+
         public static readonly DiagnosticDescriptor PreferPropertySetterCaptureHelper = new(
             DiagnosticIds.PreferPropertySetterCaptureHelper,
             "Prefer provider-neutral property setter capture",

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -179,5 +179,10 @@ namespace FastMoq.Analyzers
         /// Avoid Moq-specific matcher helpers inside provider-first Verify expressions when no direct FastArg rewrite exists.
         /// </summary>
         public const string AvoidUnsupportedMoqMatcherInProviderFirstVerify = "FMOQ0035";
+
+        /// <summary>
+        /// Prefer provider-neutral logger callback capture over provider-specific ILogger.Log setup when the callback only needs normalized output.
+        /// </summary>
+        public const string PreferSetupLoggerCallbackHelper = "FMOQ0036";
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -1766,6 +1766,7 @@ namespace FastMoq.Analyzers
             callbackMethod = callbackMethod.ReducedFrom ?? callbackMethod;
             if (callbackMethod.Name != "Callback" ||
                 invocationExpression.Parent is MemberAccessExpressionSyntax ||
+                invocationExpression.Parent is not ExpressionStatementSyntax ||
                 invocationExpression.Expression is not MemberAccessExpressionSyntax callbackAccess ||
                 callbackAccess.Expression is not InvocationExpressionSyntax setupInvocation ||
                 setupInvocation.Expression is not MemberAccessExpressionSyntax setupAccess ||

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -291,6 +291,22 @@ namespace FastMoq.Analyzers
                    namedType.OriginalDefinition.ToDisplayString() == "FastMoq.Providers.IFastMock<T>";
         }
 
+        public static bool IsFastMoqResetMethod(IMethodSymbol method)
+        {
+            method = method.ReducedFrom ?? method;
+            if (method.Name != "Reset" || method.Parameters.Length != 0)
+            {
+                return false;
+            }
+
+            if (method.ContainingType.ToDisplayString() == "FastMoq.Providers.IFastMock")
+            {
+                return true;
+            }
+
+            return method.ContainingType.AllInterfaces.Any(item => item.ToDisplayString() == "FastMoq.Providers.IFastMock");
+        }
+
         public static bool IsFastMoqMockerMethod(IMethodSymbol method, string methodName)
         {
             method = method.ReducedFrom ?? method;
@@ -764,6 +780,22 @@ namespace FastMoq.Analyzers
             var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
             var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
             return symbol is ILocalSymbol or IFieldSymbol or IPropertySymbol or IParameterSymbol;
+
+        }
+
+        private static bool CanReuseTrackedFastMockExpression(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            expression = Unwrap(expression);
+            semanticModel = GetSemanticModelForNode(expression, semanticModel);
+
+            if (!IsFastMoqFastMockType(semanticModel.GetTypeInfo(expression, cancellationToken).Type))
+            {
+                return false;
+            }
+
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            return symbol is ILocalSymbol or IFieldSymbol or IPropertySymbol or IParameterSymbol;
         }
 
         private static bool TryGetRegistryCreateMockServiceType(InvocationExpressionSyntax invocationExpression, IMethodSymbol method, SemanticModel semanticModel, CancellationToken cancellationToken, out ITypeSymbol serviceType)
@@ -858,8 +890,13 @@ namespace FastMoq.Analyzers
             };
         }
 
-        public static string BuildResetReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, int position)
+        public static string BuildResetReplacement(TrackedMockOrigin origin, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
+            if (CanReuseTrackedFastMockExpression(origin.TrackedMockExpression, semanticModel, cancellationToken))
+            {
+                return $"{origin.TrackedMockExpression.WithoutTrivia()}.Reset()";
+            }
+
             var mockerExpression = origin.MockerExpression.WithoutTrivia().ToString();
             var serviceType = GetMinimalTypeName(origin.ServiceType, semanticModel, position);
             return origin.Kind == TrackedMockOriginKind.GetRequiredTrackedMock
@@ -1694,6 +1731,451 @@ namespace FastMoq.Analyzers
 
             replacement = $"{memberAccessExpression.Expression.WithoutTrivia()}.AddLoggerFactory({lineWriterExpression}{replaceArgument})";
             return true;
+        }
+
+        public static bool TryBuildSetupLoggerCallbackReplacement(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string replacement)
+        {
+            replacement = string.Empty;
+
+            if (!TryGetTrackedLoggerSetupCallbackInvocation(invocationExpression, semanticModel, cancellationToken, out var origin, out var callbackLambda) ||
+                !TryBuildSetupLoggerCallbackLambda(callbackLambda, out var lambdaText))
+            {
+                return false;
+            }
+
+            replacement = $"{origin.MockerExpression.WithoutTrivia()}.SetupLoggerCallback({lambdaText})";
+            return true;
+        }
+
+        private static bool TryGetTrackedLoggerSetupCallbackInvocation(
+            InvocationExpressionSyntax invocationExpression,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            out TrackedMockOrigin origin,
+            out LambdaExpressionSyntax callbackLambda)
+        {
+            origin = default;
+            callbackLambda = null!;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var callbackMethod) ||
+                callbackMethod is null)
+            {
+                return false;
+            }
+
+            callbackMethod = callbackMethod.ReducedFrom ?? callbackMethod;
+            if (callbackMethod.Name != "Callback" ||
+                invocationExpression.Expression is not MemberAccessExpressionSyntax callbackAccess ||
+                callbackAccess.Expression is not InvocationExpressionSyntax setupInvocation ||
+                setupInvocation.Expression is not MemberAccessExpressionSyntax setupAccess ||
+                invocationExpression.ArgumentList.Arguments.Count != 1 ||
+                !TryResolveTrackedMockOrigin(setupAccess.Expression, semanticModel, cancellationToken, out origin) ||
+                !IsLoggerRegistrationType(origin.ServiceType) ||
+                !TryGetTrackedLoggerLogSetupInvocation(setupInvocation, semanticModel, cancellationToken, out var logInvocation) ||
+                !IsMatchAllTrackedLoggerSetup(logInvocation, semanticModel, cancellationToken) ||
+                !TryGetInvocationActionLambda(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, out callbackLambda))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryGetTrackedLoggerLogSetupInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out InvocationExpressionSyntax logInvocation)
+        {
+            logInvocation = null!;
+
+            if (!TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.Name is not "Setup" and not "SetupGet" ||
+                invocationExpression.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            var candidateExpression = Unwrap(invocationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateExpression is not LambdaExpressionSyntax lambdaExpression ||
+                UnwrapLambdaBody(lambdaExpression) is not InvocationExpressionSyntax candidateLogInvocation ||
+                !TryGetMethodSymbol(candidateLogInvocation, semanticModel, cancellationToken, out var logMethod) ||
+                logMethod is null)
+            {
+                return false;
+            }
+
+            logMethod = logMethod.ReducedFrom ?? logMethod;
+            if (logMethod.Name != "Log" ||
+                candidateLogInvocation.ArgumentList.Arguments.Count != 5 ||
+                !IsMatchingOrImplementingType(logMethod.ContainingType, ILOGGER_TYPE))
+            {
+                return false;
+            }
+
+            logInvocation = candidateLogInvocation;
+            return true;
+        }
+
+        private static SyntaxNode UnwrapLambdaBody(LambdaExpressionSyntax lambdaExpression)
+        {
+            return lambdaExpression.Body is ExpressionSyntax expression
+                ? Unwrap(expression)
+                : lambdaExpression.Body;
+        }
+
+        private static bool IsMatchAllTrackedLoggerSetup(InvocationExpressionSyntax logInvocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var arguments = logInvocation.ArgumentList.Arguments;
+            return arguments.Count == 5 &&
+                IsAnyLogLevelMatcher(arguments[0].Expression, semanticModel, cancellationToken) &&
+                IsAnyEventIdMatcher(arguments[1].Expression, semanticModel, cancellationToken) &&
+                IsAnyLoggerStateMatcher(arguments[2].Expression, semanticModel, cancellationToken) &&
+                IsAnyExceptionMatcher(arguments[3].Expression, semanticModel, cancellationToken) &&
+                IsAnyLoggerFormatterMatcher(arguments[4].Expression, semanticModel, cancellationToken);
+        }
+
+        private static bool IsAnyLogLevelMatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+            IsTypedAnyMatcher(expression, "Microsoft.Extensions.Logging.LogLevel", semanticModel, cancellationToken);
+
+        private static bool IsAnyEventIdMatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+            IsTypedAnyMatcher(expression, "Microsoft.Extensions.Logging.EventId", semanticModel, cancellationToken);
+
+        private static bool IsAnyExceptionMatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+            IsTypedAnyMatcher(expression, "System.Exception", semanticModel, cancellationToken);
+
+        private static bool IsAnyLoggerFormatterMatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            expression = StripCasts(expression);
+
+            return expression is InvocationExpressionSyntax invocationExpression &&
+                TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) &&
+                method is not null &&
+                ((IsMoqItMethod(method) && method.Name == "IsAny" && invocationExpression.ArgumentList.Arguments.Count == 0) ||
+                 (IsFastArgAnyMethod(method) && invocationExpression.ArgumentList.Arguments.Count == 0));
+        }
+
+        private static bool IsAnyLoggerStateMatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            expression = StripCasts(expression);
+            if (expression is not InvocationExpressionSyntax invocationExpression ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (!IsMoqItMethod(method) || method.TypeArguments.Length != 1 || method.TypeArguments[0].Name != "IsAnyType")
+            {
+                return false;
+            }
+
+            if (method.Name == "IsAny")
+            {
+                return invocationExpression.ArgumentList.Arguments.Count == 0;
+            }
+
+            if (method.Name != "Is" || invocationExpression.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            return invocationExpression.ArgumentList.Arguments[0].Expression is LambdaExpressionSyntax lambdaExpression &&
+                IsTrivialTrueLambda(lambdaExpression);
+        }
+
+        private static bool IsTypedAnyMatcher(ExpressionSyntax expression, string expectedTypeName, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            expression = StripCasts(expression);
+            if (expression is not InvocationExpressionSyntax invocationExpression ||
+                !TryGetMethodSymbol(invocationExpression, semanticModel, cancellationToken, out var method) ||
+                method is null)
+            {
+                return false;
+            }
+
+            method = method.ReducedFrom ?? method;
+            if (method.TypeArguments.Length != 1 ||
+                method.TypeArguments[0].ToDisplayString() != expectedTypeName ||
+                invocationExpression.ArgumentList.Arguments.Count != 0)
+            {
+                return false;
+            }
+
+            return (IsMoqItMethod(method) && method.Name == "IsAny") || IsFastArgAnyMethod(method);
+        }
+
+        private static ExpressionSyntax StripCasts(ExpressionSyntax expression)
+        {
+            expression = Unwrap(expression);
+            while (expression is CastExpressionSyntax castExpression)
+            {
+                expression = Unwrap(castExpression.Expression);
+            }
+
+            return expression;
+        }
+
+        private static bool IsFastArgAnyMethod(IMethodSymbol method)
+        {
+            method = method.ReducedFrom ?? method;
+            return method.Name == "Any" && method.ContainingType.ToDisplayString() == "FastMoq.Providers.FastArg";
+        }
+
+        private static bool IsTrivialTrueLambda(LambdaExpressionSyntax lambdaExpression)
+        {
+            var bodyExpression = lambdaExpression.Body as ExpressionSyntax;
+            if (bodyExpression is null)
+            {
+                return false;
+            }
+
+            return Unwrap(bodyExpression).IsKind(SyntaxKind.TrueLiteralExpression);
+        }
+
+        private static bool TryGetInvocationActionLambda(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out LambdaExpressionSyntax lambdaExpression)
+        {
+            lambdaExpression = null!;
+            expression = Unwrap(expression);
+
+            if (expression is LambdaExpressionSyntax directLambda &&
+                GetLambdaParameterCount(directLambda) == 1)
+            {
+                lambdaExpression = directLambda;
+                return true;
+            }
+
+            if (expression is not ObjectCreationExpressionSyntax objectCreationExpression ||
+                objectCreationExpression.ArgumentList?.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            var createdType = semanticModel.GetTypeInfo(objectCreationExpression, cancellationToken).Type;
+            if (createdType is not null &&
+                (createdType.Name != "InvocationAction" ||
+                 createdType.ContainingNamespace.ToDisplayString() != "Moq"))
+            {
+                return false;
+            }
+
+            var candidateLambda = Unwrap(objectCreationExpression.ArgumentList.Arguments[0].Expression);
+            if (candidateLambda is not LambdaExpressionSyntax resolvedLambda ||
+                GetLambdaParameterCount(resolvedLambda) != 1)
+            {
+                return false;
+            }
+
+            lambdaExpression = resolvedLambda;
+            return true;
+        }
+
+        private static int GetLambdaParameterCount(LambdaExpressionSyntax lambdaExpression)
+        {
+            return lambdaExpression switch
+            {
+                SimpleLambdaExpressionSyntax => 1,
+                ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.ParameterList.Parameters.Count,
+                _ => 0,
+            };
+        }
+
+        private static bool TryBuildSetupLoggerCallbackLambda(LambdaExpressionSyntax callbackLambda, out string lambdaText)
+        {
+            lambdaText = string.Empty;
+
+            var callbackParameterName = callbackLambda switch
+            {
+                SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Parameter.Identifier.ValueText,
+                ParenthesizedLambdaExpressionSyntax parenthesizedLambda when parenthesizedLambda.ParameterList.Parameters.Count == 1 => parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText,
+                _ => string.Empty,
+            };
+
+            if (string.IsNullOrEmpty(callbackParameterName))
+            {
+                return false;
+            }
+
+            var usedIdentifiers = new HashSet<string>(callbackLambda.Body.DescendantTokens().Where(token => token.IsKind(SyntaxKind.IdentifierToken)).Select(token => token.ValueText), StringComparer.Ordinal);
+            var logLevelName = CreateUniqueIdentifier("capturedLogLevel", usedIdentifiers);
+            var eventIdName = CreateUniqueIdentifier("capturedEventId", usedIdentifiers);
+            var messageName = CreateUniqueIdentifier("capturedMessage", usedIdentifiers);
+            var exceptionName = CreateUniqueIdentifier("capturedException", usedIdentifiers);
+
+            var rewriter = new InvocationActionLoggerCallbackRewriter(callbackParameterName, logLevelName, eventIdName, messageName, exceptionName);
+            var rewrittenBody = rewriter.Visit(callbackLambda.Body);
+            if (rewrittenBody is null || rewriter.HasUnsupportedReferences)
+            {
+                return false;
+            }
+
+            lambdaText = $"({logLevelName}, {eventIdName}, {messageName}, {exceptionName}) => {rewrittenBody}";
+            return true;
+        }
+
+        private static string CreateUniqueIdentifier(string baseName, ISet<string> usedIdentifiers)
+        {
+            var candidate = baseName;
+            var suffix = 1;
+            while (usedIdentifiers.Contains(candidate))
+            {
+                candidate = baseName + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                suffix++;
+            }
+
+            usedIdentifiers.Add(candidate);
+            return candidate;
+        }
+
+        private sealed class InvocationActionLoggerCallbackRewriter : CSharpSyntaxRewriter
+        {
+            private readonly string callbackParameterName;
+            private readonly string logLevelName;
+            private readonly string eventIdName;
+            private readonly string messageName;
+            private readonly string exceptionName;
+
+            public InvocationActionLoggerCallbackRewriter(string callbackParameterName, string logLevelName, string eventIdName, string messageName, string exceptionName)
+            {
+                this.callbackParameterName = callbackParameterName;
+                this.logLevelName = logLevelName;
+                this.eventIdName = eventIdName;
+                this.messageName = messageName;
+                this.exceptionName = exceptionName;
+            }
+
+            public bool HasUnsupportedReferences { get; private set; }
+
+            public override SyntaxNode? VisitCastExpression(CastExpressionSyntax node)
+            {
+                if (TryGetInvocationArgumentIndex(node.Expression, out var argumentIndex))
+                {
+                    switch (argumentIndex)
+                    {
+                        case 0:
+                            return Identifier(logLevelName, node);
+                        case 1:
+                            return Identifier(eventIdName, node);
+                        case 3:
+                            return Identifier(exceptionName, node);
+                    }
+                }
+
+                return base.VisitCastExpression(node);
+            }
+
+            public override SyntaxNode? VisitBinaryExpression(BinaryExpressionSyntax node)
+            {
+                if (node.IsKind(SyntaxKind.AsExpression) &&
+                    TryGetInvocationArgumentIndex(node.Left, out var argumentIndex) &&
+                    argumentIndex == 3)
+                {
+                    return Identifier(exceptionName, node);
+                }
+
+                return base.VisitBinaryExpression(node);
+            }
+
+            public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                if (node.Expression is MemberAccessExpressionSyntax memberAccess &&
+                    memberAccess.Name.Identifier.ValueText == nameof(ToString) &&
+                    TryGetInvocationArgumentIndex(memberAccess.Expression, out var argumentIndex) &&
+                    argumentIndex == 2 &&
+                    node.ArgumentList.Arguments.Count == 0)
+                {
+                    return Identifier(messageName, node);
+                }
+
+                return base.VisitInvocationExpression(node);
+            }
+
+            public override SyntaxNode? VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)
+            {
+                if (TryGetInvocationArgumentIndex(node.Expression, out var argumentIndex) &&
+                    argumentIndex == 2 &&
+                    node.WhenNotNull is InvocationExpressionSyntax invocationExpression &&
+                    invocationExpression.Expression is MemberBindingExpressionSyntax memberBinding &&
+                    memberBinding.Name.Identifier.ValueText == nameof(ToString) &&
+                    invocationExpression.ArgumentList.Arguments.Count == 0)
+                {
+                    return Identifier(messageName, node);
+                }
+
+                return base.VisitConditionalAccessExpression(node);
+            }
+
+            public override SyntaxNode? VisitElementAccessExpression(ElementAccessExpressionSyntax node)
+            {
+                if (TryGetInvocationArgumentIndex(node, out var argumentIndex))
+                {
+                    switch (argumentIndex)
+                    {
+                        case 0:
+                            return Identifier(logLevelName, node);
+                        case 1:
+                            return Identifier(eventIdName, node);
+                        case 3:
+                            return Identifier(exceptionName, node);
+                        case 2:
+                            HasUnsupportedReferences = true;
+                            return node;
+                    }
+                }
+
+                return base.VisitElementAccessExpression(node);
+            }
+
+            public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                if (node.Identifier.ValueText == callbackParameterName)
+                {
+                    HasUnsupportedReferences = true;
+                }
+
+                return base.VisitIdentifierName(node);
+            }
+
+            private bool TryGetInvocationArgumentIndex(ExpressionSyntax expression, out int argumentIndex)
+            {
+                expression = StripCasts(expression);
+                if (expression is not ElementAccessExpressionSyntax elementAccessExpression ||
+                    elementAccessExpression.ArgumentList.Arguments.Count != 1 ||
+                    elementAccessExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||
+                    memberAccessExpression.Name.Identifier.ValueText != "Arguments" ||
+                    Unwrap(memberAccessExpression.Expression) is not IdentifierNameSyntax identifierName ||
+                    identifierName.Identifier.ValueText != callbackParameterName ||
+                    !TryGetIntegerLiteral(elementAccessExpression.ArgumentList.Arguments[0].Expression, out argumentIndex))
+                {
+                    argumentIndex = -1;
+                    return false;
+                }
+
+                return true;
+            }
+
+            private static bool TryGetIntegerLiteral(ExpressionSyntax expression, out int value)
+            {
+                expression = Unwrap(expression);
+                if (expression is LiteralExpressionSyntax literalExpression &&
+                    literalExpression.IsKind(SyntaxKind.NumericLiteralExpression) &&
+                    literalExpression.Token.Value is int intValue)
+                {
+                    value = intValue;
+                    return true;
+                }
+
+                value = 0;
+                return false;
+            }
+
+            private static IdentifierNameSyntax Identifier(string identifierName, SyntaxNode source)
+            {
+                return SyntaxFactory.IdentifierName(identifierName).WithTriviaFrom(source);
+            }
         }
 
         private static bool TryGetLoggerFactoryHelperInvocation(

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -1773,7 +1773,7 @@ namespace FastMoq.Analyzers
                 !IsLoggerRegistrationType(origin.ServiceType) ||
                 !TryGetTrackedLoggerLogSetupInvocation(setupInvocation, semanticModel, cancellationToken, out var logInvocation) ||
                 !IsMatchAllTrackedLoggerSetup(logInvocation, semanticModel, cancellationToken) ||
-                !TryGetInvocationActionLambda(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, out callbackLambda))
+                !TryGetSupportedLoggerCallbackLambda(invocationExpression.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken, out callbackLambda))
             {
                 return false;
             }
@@ -1899,13 +1899,19 @@ namespace FastMoq.Analyzers
 
             method = method.ReducedFrom ?? method;
             if (method.TypeArguments.Length != 1 ||
-                method.TypeArguments[0].ToDisplayString() != expectedTypeName ||
+                !IsTypeNameMatch(method.TypeArguments[0], expectedTypeName) ||
                 invocationExpression.ArgumentList.Arguments.Count != 0)
             {
                 return false;
             }
 
             return (IsMoqItMethod(method) && method.Name == "IsAny") || IsFastArgAnyMethod(method);
+        }
+
+        private static bool IsTypeNameMatch(ITypeSymbol typeSymbol, string expectedTypeName)
+        {
+            var actualTypeName = typeSymbol.ToDisplayString();
+            return actualTypeName == expectedTypeName || actualTypeName == expectedTypeName + "?";
         }
 
         private static ExpressionSyntax StripCasts(ExpressionSyntax expression)
@@ -1936,15 +1942,13 @@ namespace FastMoq.Analyzers
             return Unwrap(bodyExpression).IsKind(SyntaxKind.TrueLiteralExpression);
         }
 
-        private static bool TryGetInvocationActionLambda(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out LambdaExpressionSyntax lambdaExpression)
+        private static bool TryGetSupportedLoggerCallbackLambda(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out LambdaExpressionSyntax lambdaExpression)
         {
             lambdaExpression = null!;
             expression = Unwrap(expression);
 
-            if (expression is LambdaExpressionSyntax directLambda &&
-                GetLambdaParameterCount(directLambda) == 1)
+            if (TryGetDirectLoggerCallbackLambda(expression, out lambdaExpression))
             {
-                lambdaExpression = directLambda;
                 return true;
             }
 
@@ -1963,14 +1967,28 @@ namespace FastMoq.Analyzers
             }
 
             var candidateLambda = Unwrap(objectCreationExpression.ArgumentList.Arguments[0].Expression);
-            if (candidateLambda is not LambdaExpressionSyntax resolvedLambda ||
-                GetLambdaParameterCount(resolvedLambda) != 1)
+            if (!TryGetDirectLoggerCallbackLambda(candidateLambda, out lambdaExpression))
             {
                 return false;
             }
 
-            lambdaExpression = resolvedLambda;
             return true;
+        }
+
+        private static bool TryGetDirectLoggerCallbackLambda(ExpressionSyntax expression, out LambdaExpressionSyntax lambdaExpression)
+        {
+            if (expression is LambdaExpressionSyntax directLambda)
+            {
+                var parameterCount = GetLambdaParameterCount(directLambda);
+                if (parameterCount is 1 or 4 or 5)
+                {
+                    lambdaExpression = directLambda;
+                    return true;
+                }
+            }
+
+            lambdaExpression = null!;
+            return false;
         }
 
         private static int GetLambdaParameterCount(LambdaExpressionSyntax lambdaExpression)
@@ -1984,6 +2002,24 @@ namespace FastMoq.Analyzers
         }
 
         private static bool TryBuildSetupLoggerCallbackLambda(LambdaExpressionSyntax callbackLambda, out string lambdaText)
+        {
+            lambdaText = string.Empty;
+
+            var parameterCount = GetLambdaParameterCount(callbackLambda);
+            if (parameterCount == 1)
+            {
+                return TryBuildInvocationActionLoggerCallbackLambda(callbackLambda, out lambdaText);
+            }
+
+            if (parameterCount is 4 or 5)
+            {
+                return TryBuildTypedLoggerCallbackLambda(callbackLambda, parameterCount, out lambdaText);
+            }
+
+            return false;
+        }
+
+        private static bool TryBuildInvocationActionLoggerCallbackLambda(LambdaExpressionSyntax callbackLambda, out string lambdaText)
         {
             lambdaText = string.Empty;
 
@@ -2014,6 +2050,65 @@ namespace FastMoq.Analyzers
 
             lambdaText = $"({logLevelName}, {eventIdName}, {messageName}, {exceptionName}) => {rewrittenBody}";
             return true;
+        }
+
+        private static bool TryBuildTypedLoggerCallbackLambda(LambdaExpressionSyntax callbackLambda, int parameterCount, out string lambdaText)
+        {
+            lambdaText = string.Empty;
+            if (!TryGetLambdaParameterNames(callbackLambda, out var parameterNames) || parameterNames.Count != parameterCount)
+            {
+                return false;
+            }
+
+            var usedIdentifiers = new HashSet<string>(callbackLambda.Body.DescendantTokens().Where(token => token.IsKind(SyntaxKind.IdentifierToken)).Select(token => token.ValueText), StringComparer.Ordinal);
+            var logLevelName = CreateUniqueIdentifier("capturedLogLevel", usedIdentifiers);
+            var eventIdName = CreateUniqueIdentifier("capturedEventId", usedIdentifiers);
+            var messageName = CreateUniqueIdentifier("capturedMessage", usedIdentifiers);
+            var exceptionName = CreateUniqueIdentifier("capturedException", usedIdentifiers);
+
+            var rewriter = new TypedLoggerCallbackRewriter(
+                parameterNames[0],
+                parameterNames[1],
+                parameterNames[2],
+                parameterNames[3],
+                parameterCount == 5 ? parameterNames[4] : string.Empty,
+                logLevelName,
+                eventIdName,
+                messageName,
+                exceptionName);
+            var rewrittenBody = rewriter.Visit(callbackLambda.Body);
+            if (rewrittenBody is null || rewriter.HasUnsupportedReferences)
+            {
+                return false;
+            }
+
+            lambdaText = $"({logLevelName}, {eventIdName}, {messageName}, {exceptionName}) => {rewrittenBody}";
+            return true;
+        }
+
+        private static bool TryGetLambdaParameterNames(LambdaExpressionSyntax lambdaExpression, out IReadOnlyList<string> parameterNames)
+        {
+            switch (lambdaExpression)
+            {
+                case SimpleLambdaExpressionSyntax simpleLambda:
+                    parameterNames = [simpleLambda.Parameter.Identifier.ValueText];
+                    return !string.IsNullOrEmpty(parameterNames[0]);
+
+                case ParenthesizedLambdaExpressionSyntax parenthesizedLambda:
+                    var names = parenthesizedLambda.ParameterList.Parameters.Select(parameter => parameter.Identifier.ValueText).ToArray();
+                    if (names.Any(string.IsNullOrEmpty))
+                    {
+                        parameterNames = Array.Empty<string>();
+                        return false;
+                    }
+
+                    parameterNames = names;
+                    return true;
+
+                default:
+                    parameterNames = Array.Empty<string>();
+                    return false;
+            }
         }
 
         private static string CreateUniqueIdentifier(string baseName, ISet<string> usedIdentifiers)
@@ -2173,6 +2268,170 @@ namespace FastMoq.Analyzers
             }
 
             private static IdentifierNameSyntax Identifier(string identifierName, SyntaxNode source)
+            {
+                return SyntaxFactory.IdentifierName(identifierName).WithTriviaFrom(source);
+            }
+        }
+
+        private sealed class TypedLoggerCallbackRewriter : CSharpSyntaxRewriter
+        {
+            private readonly string logLevelParameterName;
+            private readonly string eventIdParameterName;
+            private readonly string stateParameterName;
+            private readonly string exceptionParameterName;
+            private readonly string formatterParameterName;
+            private readonly string logLevelName;
+            private readonly string eventIdName;
+            private readonly string messageName;
+            private readonly string exceptionName;
+
+            public TypedLoggerCallbackRewriter(
+                string logLevelParameterName,
+                string eventIdParameterName,
+                string stateParameterName,
+                string exceptionParameterName,
+                string formatterParameterName,
+                string logLevelName,
+                string eventIdName,
+                string messageName,
+                string exceptionName)
+            {
+                this.logLevelParameterName = logLevelParameterName;
+                this.eventIdParameterName = eventIdParameterName;
+                this.stateParameterName = stateParameterName;
+                this.exceptionParameterName = exceptionParameterName;
+                this.formatterParameterName = formatterParameterName;
+                this.logLevelName = logLevelName;
+                this.eventIdName = eventIdName;
+                this.messageName = messageName;
+                this.exceptionName = exceptionName;
+            }
+
+            public bool HasUnsupportedReferences { get; private set; }
+
+            public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                if (IsStateToStringInvocation(node) || IsFormatterMessageInvocation(node))
+                {
+                    return Identifier(messageName, node);
+                }
+
+                if (node.Expression is MemberAccessExpressionSyntax memberAccess &&
+                    memberAccess.Name.Identifier.ValueText == nameof(ToString) &&
+                    (IsStateParameterReference(memberAccess.Expression) || IsFormatterMessageInvocation(memberAccess.Expression)) &&
+                    node.ArgumentList.Arguments.Count == 0)
+                {
+                    return Identifier(messageName, node);
+                }
+
+                return base.VisitInvocationExpression(node);
+            }
+
+            public override SyntaxNode? VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)
+            {
+                if (IsStateToStringConditionalAccess(node) || IsFormatterMessageConditionalAccess(node))
+                {
+                    return Identifier(messageName, node);
+                }
+
+                return base.VisitConditionalAccessExpression(node);
+            }
+
+            public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                var identifierName = node.Identifier.ValueText;
+                if (identifierName == logLevelParameterName)
+                {
+                    return Identifier(logLevelName, node);
+                }
+
+                if (identifierName == eventIdParameterName)
+                {
+                    return Identifier(eventIdName, node);
+                }
+
+                if (identifierName == exceptionParameterName)
+                {
+                    return Identifier(exceptionName, node);
+                }
+
+                if (identifierName == stateParameterName || (!string.IsNullOrEmpty(formatterParameterName) && identifierName == formatterParameterName))
+                {
+                    HasUnsupportedReferences = true;
+                }
+
+                return base.VisitIdentifierName(node);
+            }
+
+            private bool IsStateToStringInvocation(InvocationExpressionSyntax node)
+            {
+                return node.Expression is MemberAccessExpressionSyntax memberAccess &&
+                    memberAccess.Name.Identifier.ValueText == nameof(ToString) &&
+                    IsStateParameterReference(memberAccess.Expression) &&
+                    node.ArgumentList.Arguments.Count == 0;
+            }
+
+            private bool IsStateToStringConditionalAccess(ConditionalAccessExpressionSyntax node)
+            {
+                return IsStateParameterReference(node.Expression) &&
+                    node.WhenNotNull is InvocationExpressionSyntax invocationExpression &&
+                    invocationExpression.Expression is MemberBindingExpressionSyntax memberBinding &&
+                    memberBinding.Name.Identifier.ValueText == nameof(ToString) &&
+                    invocationExpression.ArgumentList.Arguments.Count == 0;
+            }
+
+            private bool IsFormatterMessageInvocation(ExpressionSyntax expression)
+            {
+                if (string.IsNullOrEmpty(formatterParameterName))
+                {
+                    return false;
+                }
+
+                expression = StripCasts(expression);
+                if (expression is not InvocationExpressionSyntax invocationExpression || invocationExpression.ArgumentList.Arguments.Count != 2)
+                {
+                    return false;
+                }
+
+                if (!IsStateParameterReference(invocationExpression.ArgumentList.Arguments[0].Expression) ||
+                    !IsExceptionParameterReference(invocationExpression.ArgumentList.Arguments[1].Expression))
+                {
+                    return false;
+                }
+
+                if (invocationExpression.Expression is IdentifierNameSyntax identifierName)
+                {
+                    return identifierName.Identifier.ValueText == formatterParameterName;
+                }
+
+                return invocationExpression.Expression is MemberAccessExpressionSyntax memberAccess &&
+                    memberAccess.Name.Identifier.ValueText == nameof(Delegate.DynamicInvoke) &&
+                    memberAccess.Expression is IdentifierNameSyntax formatterIdentifier &&
+                    formatterIdentifier.Identifier.ValueText == formatterParameterName;
+            }
+
+            private bool IsFormatterMessageConditionalAccess(ConditionalAccessExpressionSyntax node)
+            {
+                return IsFormatterMessageInvocation(node.Expression) &&
+                    node.WhenNotNull is InvocationExpressionSyntax invocationExpression &&
+                    invocationExpression.Expression is MemberBindingExpressionSyntax memberBinding &&
+                    memberBinding.Name.Identifier.ValueText == nameof(ToString) &&
+                    invocationExpression.ArgumentList.Arguments.Count == 0;
+            }
+
+            private bool IsStateParameterReference(ExpressionSyntax expression)
+            {
+                expression = StripCasts(expression);
+                return expression is IdentifierNameSyntax identifierName && identifierName.Identifier.ValueText == stateParameterName;
+            }
+
+            private bool IsExceptionParameterReference(ExpressionSyntax expression)
+            {
+                expression = StripCasts(expression);
+                return expression is IdentifierNameSyntax identifierName && identifierName.Identifier.ValueText == exceptionParameterName;
+            }
+
+            private IdentifierNameSyntax Identifier(string identifierName, SyntaxNode source)
             {
                 return SyntaxFactory.IdentifierName(identifierName).WithTriviaFrom(source);
             }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -1765,6 +1765,7 @@ namespace FastMoq.Analyzers
 
             callbackMethod = callbackMethod.ReducedFrom ?? callbackMethod;
             if (callbackMethod.Name != "Callback" ||
+                invocationExpression.Parent is MemberAccessExpressionSyntax ||
                 invocationExpression.Expression is not MemberAccessExpressionSyntax callbackAccess ||
                 callbackAccess.Expression is not InvocationExpressionSyntax setupInvocation ||
                 setupInvocation.Expression is not MemberAccessExpressionSyntax setupAccess ||

--- a/FastMoq.Core/Extensions/LoggingTestExtensions.cs
+++ b/FastMoq.Core/Extensions/LoggingTestExtensions.cs
@@ -161,6 +161,47 @@ namespace FastMoq.Extensions
             return mocker;
         }
 
+        /// <summary>
+        /// Registers an additional callback that receives log entries captured through the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="callback">A callback that receives each captured log entry after FastMoq records it.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        /// <remarks>
+        /// Use this when the test already relies on FastMoq-managed logger capture and also needs to mirror normalized log output to a local sink.
+        /// The callback observes formatted message text and exception data; it does not expose raw provider-specific logger state.
+        /// </remarks>
+        /// <example>
+        /// <code language="csharp"><![CDATA[
+        /// Mocks.SetupLoggerCallback((logLevel, eventId, message, exception) =>
+        /// {
+        ///     output.WriteLine($"[{logLevel}] {message}");
+        /// });
+        /// ]]></code>
+        /// </example>
+        public static Mocker SetupLoggerCallback(this Mocker mocker, Action<LogLevel, EventId, string, Exception?> callback)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(callback);
+
+            mocker.AppendLoggingCallback(callback);
+            return mocker;
+        }
+
+        /// <summary>
+        /// Registers an additional callback that receives formatted log entries captured through the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="callback">A callback that receives each captured log entry after FastMoq records it.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        public static Mocker SetupLoggerCallback(this Mocker mocker, Action<LogLevel, EventId, string> callback)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(callback);
+
+            return mocker.SetupLoggerCallback((logLevel, eventId, message, _) => callback(logLevel, eventId, message));
+        }
+
         private static ILoggerFactory CreateLoggerFactoryCore(Mocker mocker, Action<LogLevel, EventId, string, Exception?> callback, Action<ILoggingBuilder>? configureLogging)
         {
             ArgumentNullException.ThrowIfNull(mocker);

--- a/FastMoq.Core/Mocker.cs
+++ b/FastMoq.Core/Mocker.cs
@@ -106,7 +106,7 @@ namespace FastMoq
         internal Dictionary<Type, IInstanceModel> typeMap = new();
         private readonly ObservableExceptionLog exceptionLog = new();
         private readonly ObservableLogEntries logEntries = new();
-        private readonly Action<LogLevel, EventId, string, Exception?> externalLoggingCallback;
+        private Action<LogLevel, EventId, string, Exception?> externalLoggingCallback;
         /// <summary>
         /// Tracks constructor-selection history for created instances.
         /// </summary>
@@ -330,6 +330,13 @@ namespace FastMoq
         {
             logEntries.Add(new LogEntry(logLevel, eventId, message, exception));
             externalLoggingCallback(logLevel, eventId, message, exception);
+        }
+
+        internal void AppendLoggingCallback(Action<LogLevel, EventId, string, Exception?> loggingCallback)
+        {
+            ArgumentNullException.ThrowIfNull(loggingCallback);
+
+            externalLoggingCallback += loggingCallback;
         }
 
         internal void EnableExplicitLoggerCapture()

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -335,6 +335,64 @@ namespace FastMoq.Tests
             mocker.VerifyLogged(LogLevel.Error, "provider error", new InvalidOperationException("provider boom"), 12, TimesSpec.Once);
         }
 
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
+        public void SetupLoggerCallback_ShouldMirrorCapturedEntries_WithoutBreakingStoredLogs(string providerName)
+        {
+            using var providerScope = PushProvider(providerName);
+            var mocker = new Mocker();
+            var exception = new InvalidOperationException("provider callback boom");
+            LogLevel? capturedLevel = null;
+            EventId? capturedEventId = null;
+            string? capturedMessage = null;
+            Exception? capturedException = null;
+
+            mocker.SetupLoggerCallback((logLevel, eventId, message, loggedException) =>
+            {
+                capturedLevel = logLevel;
+                capturedEventId = eventId;
+                capturedMessage = message;
+                capturedException = loggedException;
+            });
+
+            var logger = mocker.GetObject<ILogger<NullLogger>>();
+            logger.LogError(12, exception, "provider callback");
+
+            capturedLevel.Should().Be(LogLevel.Error);
+            capturedEventId.Should().Be(new EventId(12));
+            capturedMessage.Should().Contain("provider callback");
+            capturedException.Should().BeSameAs(exception);
+            mocker.LogEntries.Should().Contain(entry =>
+                entry.LogLevel == LogLevel.Error &&
+                entry.EventId.Id == 12 &&
+                entry.Message.Contains("provider callback", StringComparison.Ordinal) &&
+                entry.Exception == exception);
+        }
+
+        [Theory]
+        [InlineData("moq")]
+        [InlineData("nsubstitute")]
+        public void SetupLoggerCallbackThreeParameterOverload_ShouldCaptureFormattedMessages(string providerName)
+        {
+            using var providerScope = PushProvider(providerName);
+            var mocker = new Mocker();
+            LogLevel? capturedLevel = null;
+            string? capturedMessage = null;
+
+            mocker.SetupLoggerCallback((logLevel, _, message) =>
+            {
+                capturedLevel = logLevel;
+                capturedMessage = message;
+            });
+
+            var logger = mocker.GetObject<ILogger<NullLogger>>();
+            logger.LogInformation("provider callback info");
+
+            capturedLevel.Should().Be(LogLevel.Information);
+            capturedMessage.Should().Contain("provider callback info");
+        }
+
         [Fact]
         public void VerifyLogged_ShouldFailFast_ForProviderWithoutLoggerCapture()
         {

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -356,7 +356,7 @@ namespace FastMoq.Tests
                 capturedException = loggedException;
             });
 
-            var logger = mocker.GetObject<ILogger<NullLogger>>();
+            var logger = mocker.GetRequiredObject<ILogger<NullLogger>>();
             logger.LogError(12, exception, "provider callback");
 
             capturedLevel.Should().Be(LogLevel.Error);
@@ -386,7 +386,7 @@ namespace FastMoq.Tests
                 capturedMessage = message;
             });
 
-            var logger = mocker.GetObject<ILogger<NullLogger>>();
+            var logger = mocker.GetRequiredObject<ILogger<NullLogger>>();
             logger.LogInformation("provider callback info");
 
             capturedLevel.Should().Be(LogLevel.Information);

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1646,7 +1646,7 @@ public class OrderProcessingServiceTests : MockerTestBase<OrderProcessingService
         // Setup logging callback to capture scope information
         var logEntries = new List<(LogLevel Level, string Message, object[] Args)>();
         
-        Mocks.SetupLoggerCallback<ILogger<OrderProcessingService>>((level, eventId, message) =>
+        Mocks.SetupLoggerCallback((level, eventId, message) =>
         {
             logEntries.Add((level, message, new object[0]));
         });
@@ -1661,7 +1661,9 @@ public class OrderProcessingServiceTests : MockerTestBase<OrderProcessingService
 }
 ```
 
-### Advanced Logging Scenarios
+### Advanced Logging Scenarios (Moq Compatibility)
+
+When the test needs raw structured logger state instead of the normalized message and exception that FastMoq captures provider-neutrally, keep this on the Moq compatibility path. `FastArg` does not replace the `It.IsAnyType` portion because that placeholder stands in for the generic `TState` closed by `ILogger.Log<TState>`, not just a normal argument matcher.
 
 ```csharp
 public class LoggingAdvancedTests : MockerTestBase<OrderProcessingService>

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1646,9 +1646,9 @@ public class OrderProcessingServiceTests : MockerTestBase<OrderProcessingService
         // Setup logging callback to capture scope information
         var logEntries = new List<(LogLevel Level, string Message, object[] Args)>();
         
-        Mocks.SetupLoggerCallback((level, eventId, message) =>
+        Mocks.SetupLoggerCallback((level, _, message) =>
         {
-            logEntries.Add((level, message, new object[0]));
+            logEntries.Add((level, message, Array.Empty<object>()));
         });
 
         // Act

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -591,6 +591,8 @@ Prefer `Mocks.VerifyLogged(...)` for new code. It is provider-safe because FastM
 
 If the test suite needs a first-party registration story for `ILoggerFactory`, `ILogger`, or `ILogger<T>`, use `Mocks.AddLoggerFactory()` for direct FastMoq resolution, or `Mocks.CreateLoggerFactory()` when you want to plug the same callback-backed factory into a typed `IServiceProvider` recipe. When the test also needs to mirror log output to a local sink after `Mocker` already exists, use the sink-aware overloads such as `Mocks.AddLoggerFactory(output.WriteLine, replace: true)` or `Mocks.CreateLoggerFactory((logLevel, eventId, message, exception) => ...)` instead of maintaining a private logger wrapper.
 
+When the test already relies on FastMoq-managed logger mocks and only needs to mirror the normalized captured entries to a local sink, use `Mocks.SetupLoggerCallback((logLevel, eventId, message, exception) => ...)` instead of rebuilding the logger mock with provider-specific `ILogger.Log<TState>` setup code.
+
 Use `GetOrCreateMock<ILogger<T>>().AsMoq().VerifyLogger(...)` only when you intentionally want the legacy Moq-specific behavior. That API is a compatibility shim and is planned to leave core in v5.
 
 ## Troubleshooting

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -63,6 +63,7 @@ Current examples include:
 - `FMOQ0011` for preferring `FastMoq.Web` helpers over hand-rolled `HttpContext`, `ControllerContext`, or `IHttpContextAccessor` registration via `AddType(...)`
 - `FMOQ0012` for preferring `WhenHttpRequest(...)` or `WhenHttpRequestJson(...)` over Moq-specific HTTP compatibility helpers when the test only needs request and response behavior, including a code fix for common tracked `HttpMessageHandler` `Protected().Setup("SendAsync", ...)` setups
 - `FMOQ0030` for preferring `AddLoggerFactory(...)` over direct output-helper-backed `AddType<ILoggerFactory>(...)`, `AddType<ILogger>(...)`, and `AddType<ILogger<T>>(...)` registrations when the existing logger wiring only exists to mirror logs into xUnit-style output
+- `FMOQ0036` for preferring `SetupLoggerCallback(...)` over tracked `ILogger.Log<TState>` setup chains when the callback only mirrors normalized log output
 
 Tune guidance severity in `.editorconfig` if a suite wants quieter or stricter defaults:
 
@@ -113,6 +114,7 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0033` | In `MockerTestBase`-based tests, reuse `GetFileSystem()` instead of creating a fresh `MockFileSystem` for an `IFileSystem` slot |
 | `FMOQ0034` | Inside provider-first `Verify(...)`, replace mechanical `It.*` matchers with `FastArg` equivalents so the assertion stays provider-neutral |
 | `FMOQ0035` | Flag remaining Moq-specific matchers inside provider-first `Verify(...)` when no direct `FastArg` rewrite exists |
+| `FMOQ0036` | Prefer `SetupLoggerCallback(...)` over tracked `ILogger.Log<TState>` setup when the callback only needs normalized message or exception output |
 
 For a successful v4 migration, use this boundary:
 

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -241,6 +241,44 @@ Analyzer note:
 - `FMOQ0003` points shared helper cleanup and leaf test rewrites toward `VerifyLogged(...)`.
 - if the same helper also registered loggers manually, prefer `AddLoggerFactory()` or `CreateLoggerFactory()` from the finalized helper surface instead of preserving a private logger wrapper.
 
+### `ILogger.Log<TState>` callback setup vs `SetupLoggerCallback(...)`
+
+Old Moq-oriented pattern:
+
+```csharp
+Mocks.GetOrCreateMock<ILogger>()
+    .Setup(x => x.Log(
+        It.IsAny<LogLevel>(),
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((_, _) => true),
+        It.IsAny<Exception>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+    .Callback(new InvocationAction(invocation =>
+    {
+        var message = invocation.Arguments[2]?.ToString() ?? string.Empty;
+        output.WriteLine(message);
+    }));
+```
+
+Current guidance:
+
+```csharp
+Mocks.SetupLoggerCallback((logLevel, eventId, message, exception) =>
+{
+    output.WriteLine(message);
+});
+```
+
+Why:
+
+- `SetupLoggerCallback(...)` keeps the test on FastMoq's provider-neutral logger capture path.
+- `FastArg` does not replace the `It.IsAnyType` portion here because that placeholder stands in for the generic `TState` closed by `ILogger.Log<TState>`, not just a normal argument matcher.
+- keep the Moq compatibility path only when the callback intentionally inspects raw structured logger state rather than normalized message and exception output.
+
+Analyzer note:
+
+- `FMOQ0036` points safe tracked `ILogger.Log<TState>` setup callbacks toward `SetupLoggerCallback(...)`.
+
 ### `IOptions<T>` setup and real instances
 
 Old patterns often looked like this:

--- a/docs/migration/api-replacements-and-exceptions.md
+++ b/docs/migration/api-replacements-and-exceptions.md
@@ -263,7 +263,7 @@ Mocks.GetOrCreateMock<ILogger>()
 Current guidance:
 
 ```csharp
-Mocks.SetupLoggerCallback((logLevel, eventId, message, exception) =>
+Mocks.SetupLoggerCallback((_, _, message, _) =>
 {
     output.WriteLine(message);
 });

--- a/docs/migration/framework-and-web-helpers.md
+++ b/docs/migration/framework-and-web-helpers.md
@@ -200,6 +200,7 @@ Analyzer note:
 - `FMOQ0003` prefers `VerifyLogged(...)` over legacy `VerifyLogger(...)` when the assertion can stay provider-safe.
 - `FMOQ0019` prefers `SetupOptions(...)` over repeated manual `IOptions<T>` setup.
 - `FMOQ0030` prefers `AddLoggerFactory(...)` over direct `AddType<ILoggerFactory>(new ...output-helper...)`, `AddType<ILogger>(new ...output-helper...)`, and `AddType<ILogger<T>>(new ...output-helper...)` registrations when the logger registration is just mirroring logs into an xUnit-style output helper. The diagnostic is advisory only because repo-local logger wrappers can carry extra formatting, filtering, or scope behavior that FastMoq cannot prove is safe to rewrite automatically.
+- `FMOQ0036` prefers `SetupLoggerCallback(...)` over tracked `GetOrCreateMock<ILogger...>().Setup(x => x.Log(...)).Callback(...)` chains when the callback only reads normalized level, event id, message text, or exception output. It intentionally does not rewrite callbacks that inspect raw structured logger state.
 
 ## Web test helpers
 


### PR DESCRIPTION
## Summary
- add `Mocker.SetupLoggerCallback(...)` overloads and provider tests for mirroring normalized log output
- add `FMOQ0036` with analyzer, code fix, docs, and regression coverage for migrating safe `ILogger.Log<TState>` callback setups to `SetupLoggerCallback(...)`
- tighten `FMOQ0002` so already-provider-first `IFastMock.Reset()` calls are ignored and reusable `IFastMock` receivers are preserved when rewriting provider-native reset usage
- fix the missing null guard on the three-parameter `SetupLoggerCallback` overload found during review

## Validation
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj" --filter "FullyQualifiedName~MigrationAnalyzerTests"`
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj" --filter "FullyQualifiedName~AnalyzerDocumentationTests|FullyQualifiedName~LoggerSetupCallbackAnalyzer|FullyQualifiedName~TrackedMockResetAnalyzer"`
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Tests\FastMoq.Tests.csproj" --filter "FullyQualifiedName~ProviderTests.SetupLoggerCallback|FullyQualifiedName~ProviderTests.VerifyLogged"`

## Review
- no blocking findings remained after fixing the public API null-guard gap in `SetupLoggerCallback`