### PR TITLE
Add logger provider overloads and serialize log capture

### DIFF
--- a/FastMoq.Core/Extensions/LoggingTestExtensions.cs
+++ b/FastMoq.Core/Extensions/LoggingTestExtensions.cs
@@ -77,6 +77,28 @@ namespace FastMoq.Extensions
         }
 
         /// <summary>
+        /// Creates a logger factory that adds a custom <see cref="ILoggerProvider" /> while still forwarding captured log entries into the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="provider">A custom logger provider that processes all logged entries alongside FastMoq capture.</param>
+        /// <param name="configureLogging">Optional logging builder customization applied before the FastMoq capture provider is added.</param>
+        /// <returns>A logger factory that routes log entries to <paramref name="provider" /> and <see cref="Mocker.LogEntries" />.</returns>
+        /// <remarks>
+        /// Use this when test composition needs a first-class logging provider, such as xUnit output forwarding or custom filtering, without giving up FastMoq verification.
+        /// </remarks>
+        public static ILoggerFactory CreateLoggerFactory(this Mocker mocker, ILoggerProvider provider, Action<ILoggingBuilder>? configureLogging = null)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(provider);
+
+            return CreateLoggerFactoryCore(mocker, mocker.LoggingCallback, builder =>
+            {
+                configureLogging?.Invoke(builder);
+                builder.AddProvider(provider);
+            });
+        }
+
+        /// <summary>
         /// Creates and registers a logger factory along with direct <see cref="ILogger" /> and <see cref="ILogger{TCategoryName}" /> resolution support.
         /// </summary>
         /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
@@ -133,6 +155,26 @@ namespace FastMoq.Extensions
             ArgumentNullException.ThrowIfNull(lineWriter);
 
             var loggerFactory = mocker.CreateLoggerFactory(lineWriter, configureLogging);
+            return mocker.AddLoggerFactory(loggerFactory, replace);
+        }
+
+        /// <summary>
+        /// Creates and registers a logger factory that adds a custom <see cref="ILoggerProvider" /> while still forwarding captured entries into the current <see cref="Mocker" /> instance.
+        /// </summary>
+        /// <param name="mocker">The current <see cref="Mocker" /> instance.</param>
+        /// <param name="provider">A custom logger provider that processes all logged entries alongside FastMoq capture.</param>
+        /// <param name="configureLogging">Optional logging builder customization applied before the FastMoq capture provider is added.</param>
+        /// <param name="replace">True to replace existing logger registrations.</param>
+        /// <returns>The current <see cref="Mocker" /> instance.</returns>
+        /// <remarks>
+        /// Use this when you want direct <see cref="ILogger" /> and <see cref="ILogger{TCategoryName}" /> resolution backed by a custom provider and FastMoq verification together.
+        /// </remarks>
+        public static Mocker AddLoggerFactory(this Mocker mocker, ILoggerProvider provider, Action<ILoggingBuilder>? configureLogging = null, bool replace = false)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+            ArgumentNullException.ThrowIfNull(provider);
+
+            var loggerFactory = mocker.CreateLoggerFactory(provider, configureLogging);
             return mocker.AddLoggerFactory(loggerFactory, replace);
         }
 

--- a/FastMoq.Core/Models/ObservableLogEntries.cs
+++ b/FastMoq.Core/Models/ObservableLogEntries.cs
@@ -10,6 +10,7 @@ namespace FastMoq.Models
     /// </summary>
     public class ObservableLogEntries : IReadOnlyCollection<LogEntry>, INotifyCollectionChanged, INotifyPropertyChanged
     {
+        private readonly object syncRoot = new();
         private readonly ObservableCollection<LogEntry> internalCollection = [];
         private readonly ReadOnlyObservableCollection<LogEntry> readOnlyCollection;
 
@@ -23,7 +24,10 @@ namespace FastMoq.Models
 
         internal void Add(LogEntry item)
         {
-            internalCollection.Add(item);
+            lock (syncRoot)
+            {
+                internalCollection.Add(item);
+            }
         }
 
         /// <summary>

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -980,11 +980,11 @@ namespace FastMoq.Tests
 
         private sealed class CallbackLoggerProvider(Action<LogLevel, EventId, string, Exception?> callback) : ILoggerProvider
         {
-            private readonly Action<LogLevel, EventId, string, Exception?> callback = callback;
+            private readonly Action<LogLevel, EventId, string, Exception?> _callback = callback;
 
             public ILogger CreateLogger(string categoryName)
             {
-                return new CallbackLogger(callback);
+                return new CallbackLogger(_callback);
             }
 
             public void Dispose()
@@ -993,7 +993,7 @@ namespace FastMoq.Tests
 
             private sealed class CallbackLogger(Action<LogLevel, EventId, string, Exception?> callback) : ILogger
             {
-                private readonly Action<LogLevel, EventId, string, Exception?> callback = callback;
+                private readonly Action<LogLevel, EventId, string, Exception?> _callback = callback;
 
                 public IDisposable BeginScope<TState>(TState state) where TState : notnull
                 {
@@ -1014,7 +1014,7 @@ namespace FastMoq.Tests
                         return;
                     }
 
-                    callback(logLevel, eventId, formatter(state, exception) ?? state?.ToString() ?? string.Empty, exception);
+                    _callback(logLevel, eventId, formatter(state, exception) ?? state?.ToString() ?? string.Empty, exception);
                 }
             }
 

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -19,6 +19,7 @@ using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace FastMoq.Tests
 {
@@ -346,6 +347,35 @@ namespace FastMoq.Tests
         }
 
         [Fact]
+        public void AddLoggerFactory_WithProvider_ShouldRegisterCustomProviderAndPreserveVerification()
+        {
+            using var providerScope = PushProviderScope("reflection");
+            var providerEntries = new List<string>();
+            using var provider = new CallbackLoggerProvider((logLevel, eventId, message, exception) =>
+            {
+                providerEntries.Add($"{logLevel}:{eventId.Id}:{message}:{exception?.Message}");
+            });
+            var mocker = new Mocker();
+
+            mocker.AddLoggerFactory(provider, replace: true);
+
+            var loggerFactory = mocker.GetObject<ILoggerFactory>();
+            var logger = mocker.GetObject<ILogger<ServiceProviderHelperTests>>();
+
+            loggerFactory.Should().NotBeNull();
+            logger.Should().NotBeNull();
+
+            loggerFactory!.CreateLogger("fastmoq.provider").LogInformation("provider logger");
+            logger!.LogError(12, new InvalidOperationException("provider boom"), "provider typed logger");
+
+            providerEntries.Should().HaveCount(2);
+            providerEntries[0].Should().Contain("Information:0:provider logger");
+            providerEntries[1].Should().Contain("Error:12:provider typed logger:provider boom");
+            mocker.VerifyLogged(LogLevel.Information, "provider logger");
+            mocker.VerifyLogged(LogLevel.Error, "provider typed logger", new InvalidOperationException("provider boom"), 12, TimesSpec.Once);
+        }
+
+        [Fact]
         public void CreateLoggerFactory_ShouldSupportTypedServiceProviderComposition()
         {
             using var providerScope = PushProviderScope("reflection");
@@ -408,6 +438,44 @@ namespace FastMoq.Tests
 
             mocker.VerifyLogged(LogLevel.Information, "line sink factory");
             mocker.VerifyLogged(LogLevel.Error, "line sink typed", new InvalidOperationException("line sink boom"), 12, TimesSpec.Once);
+        }
+
+        [Fact]
+        public void CreateLoggerFactory_WithProvider_ShouldComposeCustomProviderAndLoggingConfiguration()
+        {
+            using var providerScope = PushProviderScope("reflection");
+            var providerEntries = new List<string>();
+            using var provider = new CallbackLoggerProvider((logLevel, eventId, message, exception) =>
+            {
+                providerEntries.Add($"{logLevel}:{eventId.Id}:{message}:{exception?.Message}");
+            });
+            var mocker = new Mocker();
+            var loggerFactory = mocker.CreateLoggerFactory(provider, builder => builder.SetMinimumLevel(LogLevel.Error));
+            var logger = loggerFactory.CreateLogger("provider-filtered");
+
+            logger.LogInformation("filtered out");
+            logger.LogError(42, new InvalidOperationException("filtered boom"), "captured error");
+
+            providerEntries.Should().HaveCount(1);
+            providerEntries[0].Should().Contain("Error:42:captured error:filtered boom");
+            mocker.LogEntries.Should().ContainSingle(entry => entry.Message == "captured error");
+            mocker.VerifyLogged(LogLevel.Error, "captured error", new InvalidOperationException("filtered boom"), 42, TimesSpec.Once);
+        }
+
+        [Fact]
+        public async Task CreateLoggerFactory_ShouldCaptureConcurrentWrites()
+        {
+            using var providerScope = PushProviderScope("reflection");
+            var mocker = new Mocker();
+            var logger = mocker.CreateLoggerFactory().CreateLogger("concurrency");
+            const int writeCount = 256;
+
+            await Task.WhenAll(Enumerable.Range(0, writeCount).Select(index =>
+                Task.Run(() => logger.LogInformation("parallel log {Index}", index))));
+
+            mocker.LogEntries.Should().HaveCount(writeCount);
+            mocker.VerifyLogged(LogLevel.Information, "parallel log 0", TimesSpec.Once);
+            mocker.VerifyLogged(LogLevel.Information, $"parallel log {writeCount - 1}", TimesSpec.Once);
         }
 
         [Fact]
@@ -907,6 +975,56 @@ namespace FastMoq.Tests
             public void Dispose()
             {
                 IsDisposed = true;
+            }
+        }
+
+        private sealed class CallbackLoggerProvider(Action<LogLevel, EventId, string, Exception?> callback) : ILoggerProvider
+        {
+            private readonly Action<LogLevel, EventId, string, Exception?> callback = callback;
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return new CallbackLogger(callback);
+            }
+
+            public void Dispose()
+            {
+            }
+
+            private sealed class CallbackLogger(Action<LogLevel, EventId, string, Exception?> callback) : ILogger
+            {
+                private readonly Action<LogLevel, EventId, string, Exception?> callback = callback;
+
+                public IDisposable BeginScope<TState>(TState state) where TState : notnull
+                {
+                    return NoOpDisposable.Instance;
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return logLevel != LogLevel.None;
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                {
+                    ArgumentNullException.ThrowIfNull(formatter);
+
+                    if (!IsEnabled(logLevel))
+                    {
+                        return;
+                    }
+
+                    callback(logLevel, eventId, formatter(state, exception) ?? state?.ToString() ?? string.Empty, exception);
+                }
+            }
+
+            private sealed class NoOpDisposable : IDisposable
+            {
+                public static NoOpDisposable Instance { get; } = new();
+
+                public void Dispose()
+                {
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add `ILoggerProvider` overloads for `CreateLoggerFactory(...)` and `AddLoggerFactory(...)`
- keep FastMoq log capture and `VerifyLogged(...)` working when a custom provider is composed into the logger pipeline
- serialize `ObservableLogEntries.Add(...)` so concurrent logger writes do not drop captured entries
- add focused tests for the new provider overloads and the concurrent-write regression

## Validation
- `dotnet test "c:\Users\chriswin\source\repos\FastMoq\FastMoq.Tests\FastMoq.Tests.csproj" --filter "FullyQualifiedName~ServiceProviderHelperTests.AddLoggerFactory|FullyQualifiedName~ServiceProviderHelperTests.CreateLoggerFactory"`