### PR TITLE
Fix provider-first release blocker regressions

### DIFF
--- a/FastMoq.Abstractions/Providers/FastArgExpressionParser.cs
+++ b/FastMoq.Abstractions/Providers/FastArgExpressionParser.cs
@@ -217,7 +217,7 @@ namespace FastMoq.Providers
         {
             ArgumentNullException.ThrowIfNull(expression);
 
-            if (expression.Body is not MethodCallExpression methodCallExpression)
+            if (TryExtractMethodCall(expression.Body) is not MethodCallExpression methodCallExpression)
             {
                 throw new NotSupportedException("Only direct method call expressions are supported by the FastMoq matcher parser.");
             }
@@ -230,6 +230,41 @@ namespace FastMoq.Providers
             }
 
             return new FastInvocationMatcher(methodCallExpression.Method, arguments);
+        }
+
+        private static MethodCallExpression? TryExtractMethodCall(Expression expression)
+        {
+            ArgumentNullException.ThrowIfNull(expression);
+
+            expression = StripConvert(expression);
+            if (expression is MethodCallExpression methodCallExpression)
+            {
+                return methodCallExpression;
+            }
+
+            if (expression is not BlockExpression blockExpression || blockExpression.Expressions.Count == 0)
+            {
+                return null;
+            }
+
+            var leadingExpression = StripConvert(blockExpression.Expressions[0]);
+            if (leadingExpression is not MethodCallExpression blockMethodCallExpression)
+            {
+                return null;
+            }
+
+            for (var index = 1; index < blockExpression.Expressions.Count; index++)
+            {
+                var trailingExpression = StripConvert(blockExpression.Expressions[index]);
+                if (trailingExpression is DefaultExpression { Type: not null } defaultExpression && defaultExpression.Type == typeof(void))
+                {
+                    continue;
+                }
+
+                return null;
+            }
+
+            return blockMethodCallExpression;
         }
 
         /// <summary>

--- a/FastMoq.Abstractions/Providers/IMethodVerifyingMockingProvider.cs
+++ b/FastMoq.Abstractions/Providers/IMethodVerifyingMockingProvider.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+namespace FastMoq.Providers
+{
+    /// <summary>
+    /// Optional provider capability for verifying a selected method while treating every argument as a wildcard matcher.
+    /// </summary>
+    public interface IMethodVerifyingMockingProvider
+    {
+        /// <summary>
+        /// Verifies that the specified method was invoked on the mock while treating every argument as a wildcard matcher.
+        /// </summary>
+        /// <typeparam name="T">The mocked type.</typeparam>
+        /// <param name="mock">The mock to verify.</param>
+        /// <param name="method">The method to verify.</param>
+        /// <param name="times">The expected invocation count.</param>
+        void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class;
+    }
+}

--- a/FastMoq.Abstractions/Providers/IMockingProvider.cs
+++ b/FastMoq.Abstractions/Providers/IMockingProvider.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace FastMoq.Providers
 {
@@ -58,21 +57,6 @@ namespace FastMoq.Providers
         /// <param name="expression">The invocation expression to verify.</param>
         /// <param name="times">The expected invocation count.</param>
         void Verify<T>(IFastMock<T> mock, Expression<Action<T>> expression, TimesSpec? times = null) where T : class;
-
-        /// <summary>
-        /// Verifies that the specified method was invoked on the mock while treating every argument as a wildcard matcher.
-        /// </summary>
-        /// <typeparam name="T">The mocked type.</typeparam>
-        /// <param name="mock">The mock to verify.</param>
-        /// <param name="method">The method to verify.</param>
-        /// <param name="times">The expected invocation count.</param>
-        /// <exception cref="NotSupportedException">
-        /// Thrown when the current provider does not implement wildcard method verification.
-        /// </exception>
-        void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
-        {
-            throw new NotSupportedException("The current mocking provider does not support VerifyMethod<T>. Implement IMockingProvider.VerifyMethod<T> to enable wildcard method verification.");
-        }
 
         /// <summary>
         /// Verifies that no unexpected invocations remain on the mock.

--- a/FastMoq.Abstractions/Providers/IMockingProvider.cs
+++ b/FastMoq.Abstractions/Providers/IMockingProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace FastMoq.Providers
 {
@@ -57,6 +58,15 @@ namespace FastMoq.Providers
         /// <param name="expression">The invocation expression to verify.</param>
         /// <param name="times">The expected invocation count.</param>
         void Verify<T>(IFastMock<T> mock, Expression<Action<T>> expression, TimesSpec? times = null) where T : class;
+
+        /// <summary>
+        /// Verifies that the specified method was invoked on the mock while treating every argument as a wildcard matcher.
+        /// </summary>
+        /// <typeparam name="T">The mocked type.</typeparam>
+        /// <param name="mock">The mock to verify.</param>
+        /// <param name="method">The method to verify.</param>
+        /// <param name="times">The expected invocation count.</param>
+        void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class;
 
         /// <summary>
         /// Verifies that no unexpected invocations remain on the mock.

--- a/FastMoq.Abstractions/Providers/IMockingProvider.cs
+++ b/FastMoq.Abstractions/Providers/IMockingProvider.cs
@@ -66,7 +66,13 @@ namespace FastMoq.Providers
         /// <param name="mock">The mock to verify.</param>
         /// <param name="method">The method to verify.</param>
         /// <param name="times">The expected invocation count.</param>
-        void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class;
+        /// <exception cref="NotSupportedException">
+        /// Thrown when the current provider does not implement wildcard method verification.
+        /// </exception>
+        void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+        {
+            throw new NotSupportedException("The current mocking provider does not support VerifyMethod<T>. Implement IMockingProvider.VerifyMethod<T> to enable wildcard method verification.");
+        }
 
         /// <summary>
         /// Verifies that no unexpected invocations remain on the mock.

--- a/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
+++ b/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
@@ -99,9 +99,11 @@ namespace FastMoq.AzureFunctions.Extensions
             ArgumentNullException.ThrowIfNull(mocker);
             ArgumentNullException.ThrowIfNull(instanceServices);
 
+            EnsureFunctionContextKnownTypeCanBeUpdated(mocker, replace);
             mocker.AddServiceProvider(instanceServices, replace);
             AddOrUpdateFunctionContextKnownTypeRegistration(
                 mocker,
+                replace,
                 configureMock: fastMock => ConfigureFunctionContextInstanceServices(fastMock, instanceServices),
                 applyObjectDefaults: functionContext => AssignFunctionContextInstanceServices(functionContext, instanceServices));
 
@@ -145,8 +147,10 @@ namespace FastMoq.AzureFunctions.Extensions
             ArgumentNullException.ThrowIfNull(mocker);
             ArgumentException.ThrowIfNullOrWhiteSpace(invocationId);
 
+            EnsureFunctionContextKnownTypeCanBeUpdated(mocker, replace);
             AddOrUpdateFunctionContextKnownTypeRegistration(
                 mocker,
+                replace,
                 configureMock: fastMock => ConfigureFunctionContextInvocationId(fastMock, invocationId));
 
             if (mocker.Contains(typeof(FunctionContext)))
@@ -159,6 +163,7 @@ namespace FastMoq.AzureFunctions.Extensions
 
         private static void AddOrUpdateFunctionContextKnownTypeRegistration(
             Mocker mocker,
+            bool replace,
             Action<IFastMock>? configureMock = null,
             Action<FunctionContext>? applyObjectDefaults = null)
         {
@@ -175,6 +180,21 @@ namespace FastMoq.AzureFunctions.Extensions
             };
 
             mocker.AddKnownType(mergedRegistration, replace: existingRegistration is not null);
+        }
+
+        private static void EnsureFunctionContextKnownTypeCanBeUpdated(Mocker mocker, bool replace)
+        {
+            ArgumentNullException.ThrowIfNull(mocker);
+
+            if (replace)
+            {
+                return;
+            }
+
+            if (mocker.KnownTypeRegistrations.Any(registration => registration.ServiceType == typeof(FunctionContext)))
+            {
+                typeof(FunctionContext).ThrowAlreadyExists();
+            }
         }
 
         private static Action<Mocker, Type, IFastMock>? ComposeFunctionContextConfigureMock(

--- a/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
+++ b/FastMoq.AzureFunctions/Extensions/FunctionContextTestExtensions.cs
@@ -179,7 +179,7 @@ namespace FastMoq.AzureFunctions.Extensions
                 ApplyObjectDefaults = ComposeFunctionContextObjectDefaults(existingRegistration?.ApplyObjectDefaults, applyObjectDefaults),
             };
 
-            mocker.AddKnownType(mergedRegistration, replace: existingRegistration is not null);
+            mocker.AddKnownType(mergedRegistration, replace);
         }
 
         private static void EnsureFunctionContextKnownTypeCanBeUpdated(Mocker mocker, bool replace)

--- a/FastMoq.Core/Extensions/MethodResultExtensions.cs
+++ b/FastMoq.Core/Extensions/MethodResultExtensions.cs
@@ -223,7 +223,8 @@ namespace FastMoq.Extensions
 
             var proxy = DispatchProxy.Create<TService, MethodResultProxy<TService>>();
             var proxyController = (MethodResultProxy<TService>) (object) proxy;
-            proxyController.Initialize(currentInstance, mocker.TryGetTrackedMock<TService>(out var trackedMock) && ReferenceEquals(trackedMock.Instance, currentInstance));
+            var shouldForwardConfiguredCallsToInner = mocker.TryGetTrackedMock<TService>(out var trackedMock) && ReferenceEquals(trackedMock.Instance, currentInstance);
+            proxyController.Initialize(currentInstance, shouldForwardConfiguredCallsToInner, shouldForwardConfiguredCallsToInner && mocker.ShouldCreateStrictMocks());
             proxyController.AddBehavior(callExpression, () => resultFactory()!, helperName);
 
             mocker.AddType<TService>(proxy, replace);
@@ -254,7 +255,8 @@ namespace FastMoq.Extensions
 
             var proxy = DispatchProxy.Create<TService, MethodResultProxy<TService>>();
             var proxyController = (MethodResultProxy<TService>) (object) proxy;
-            proxyController.Initialize(currentInstance, mocker.TryGetTrackedMock<TService>(out var trackedMock) && ReferenceEquals(trackedMock.Instance, currentInstance));
+            var shouldForwardConfiguredCallsToInner = mocker.TryGetTrackedMock<TService>(out var trackedMock) && ReferenceEquals(trackedMock.Instance, currentInstance);
+            proxyController.Initialize(currentInstance, shouldForwardConfiguredCallsToInner, shouldForwardConfiguredCallsToInner && mocker.ShouldCreateStrictMocks());
             proxyController.AddBehavior(callExpression, () =>
             {
                 behavior();
@@ -272,13 +274,15 @@ namespace FastMoq.Extensions
 
         private TService? _inner;
         private bool _forwardConfiguredCallsToInner;
+        private bool _suppressConfiguredInnerExceptions;
 
-        public void Initialize(TService inner, bool forwardConfiguredCallsToInner)
+        public void Initialize(TService inner, bool forwardConfiguredCallsToInner, bool suppressConfiguredInnerExceptions)
         {
             ArgumentNullException.ThrowIfNull(inner);
 
             _inner = inner;
             _forwardConfiguredCallsToInner = forwardConfiguredCallsToInner;
+            _suppressConfiguredInnerExceptions = suppressConfiguredInnerExceptions;
         }
 
         public void AddBehavior(LambdaExpression callExpression, Func<object?> resultFactory, string helperName)
@@ -314,7 +318,13 @@ namespace FastMoq.Extensions
 
                 if (_forwardConfiguredCallsToInner)
                 {
-                    _ = InvokeInner(targetMethod, actualArguments);
+                    try
+                    {
+                        _ = InvokeInner(targetMethod, actualArguments);
+                    }
+                    catch when (_suppressConfiguredInnerExceptions)
+                    {
+                    }
                 }
 
                 return registration.ResultFactory();

--- a/FastMoq.Core/Mocker.ProviderVerify.cs
+++ b/FastMoq.Core/Mocker.ProviderVerify.cs
@@ -239,7 +239,12 @@ namespace FastMoq
             if (model.FastMock is IFastMock<T> typed)
             {
                 var provider = MockingProviderRegistry.ResolveProvider(typed);
-                provider.VerifyMethod(typed, method, times);
+                if (provider is not IMethodVerifyingMockingProvider methodVerifyingProvider)
+                {
+                    throw new NotSupportedException($"The current mocking provider '{provider.GetType().FullName}' does not support wildcard method verification. Implement {nameof(IMethodVerifyingMockingProvider)} to enable VerifyAnyArgs for non-void methods.");
+                }
+
+                methodVerifyingProvider.VerifyMethod(typed, method, times);
             }
         }
 
@@ -265,7 +270,12 @@ namespace FastMoq
             {
                 var method = VerificationExpressionBuilder.GetSelectedMethod(typed.Instance, methodSelector);
                 var provider = MockingProviderRegistry.ResolveProvider(typed);
-                provider.VerifyMethod(typed, method, times);
+                if (provider is not IMethodVerifyingMockingProvider methodVerifyingProvider)
+                {
+                    throw new NotSupportedException($"The current mocking provider '{provider.GetType().FullName}' does not support wildcard method verification. Implement {nameof(IMethodVerifyingMockingProvider)} to enable VerifyAnyArgs for non-void methods.");
+                }
+
+                methodVerifyingProvider.VerifyMethod(typed, method, times);
             }
         }
 

--- a/FastMoq.Core/Mocker.ProviderVerify.cs
+++ b/FastMoq.Core/Mocker.ProviderVerify.cs
@@ -234,7 +234,13 @@ namespace FastMoq
         /// </remarks>
         public void VerifyAnyArgs<T>(string methodName, TimesSpec? times = null, params Type[] parameterTypes) where T : class
         {
-            Verify(VerificationExpressionBuilder.BuildAnyArgsExpression<T>(methodName, parameterTypes), times);
+            var method = VerificationExpressionBuilder.GetSelectedMethod<T>(methodName, parameterTypes);
+            var model = GetMockModelFast(typeof(T));
+            if (model.FastMock is IFastMock<T> typed)
+            {
+                var provider = MockingProviderRegistry.ResolveProvider(typed);
+                provider.VerifyMethod(typed, method, times);
+            }
         }
 
         /// <summary>
@@ -259,7 +265,7 @@ namespace FastMoq
             {
                 var method = VerificationExpressionBuilder.GetSelectedMethod(typed.Instance, methodSelector);
                 var provider = MockingProviderRegistry.ResolveProvider(typed);
-                provider.Verify(typed, VerificationExpressionBuilder.BuildAnyArgsExpression<T>(method), times);
+                provider.VerifyMethod(typed, method, times);
             }
         }
 

--- a/FastMoq.Core/Providers/MockingProviderRegistry.cs
+++ b/FastMoq.Core/Providers/MockingProviderRegistry.cs
@@ -284,7 +284,8 @@ namespace FastMoq.Providers
         {
             ArgumentNullException.ThrowIfNull(mock);
 
-            ResolveProvider(mock).Verify(mock, VerificationExpressionBuilder.BuildAnyArgsExpression<T>(methodName, parameterTypes), times);
+            var method = VerificationExpressionBuilder.GetSelectedMethod<T>(methodName, parameterTypes);
+            ResolveProvider(mock).VerifyMethod(mock, method, times);
         }
 
         /// <summary>
@@ -298,7 +299,7 @@ namespace FastMoq.Providers
             ArgumentNullException.ThrowIfNull(methodSelector);
 
             var method = VerificationExpressionBuilder.GetSelectedMethod(mock.Instance, methodSelector);
-            ResolveProvider(mock).Verify(mock, VerificationExpressionBuilder.BuildAnyArgsExpression<T>(method), times);
+            ResolveProvider(mock).VerifyMethod(mock, method, times);
         }
 
         /// <summary>

--- a/FastMoq.Core/Providers/MockingProviderRegistry.cs
+++ b/FastMoq.Core/Providers/MockingProviderRegistry.cs
@@ -285,7 +285,13 @@ namespace FastMoq.Providers
             ArgumentNullException.ThrowIfNull(mock);
 
             var method = VerificationExpressionBuilder.GetSelectedMethod<T>(methodName, parameterTypes);
-            ResolveProvider(mock).VerifyMethod(mock, method, times);
+            var provider = ResolveProvider(mock);
+            if (provider is not IMethodVerifyingMockingProvider methodVerifyingProvider)
+            {
+                throw new NotSupportedException($"The current mocking provider '{provider.GetType().FullName}' does not support wildcard method verification. Implement {nameof(IMethodVerifyingMockingProvider)} to enable VerifyAnyArgs for non-void methods.");
+            }
+
+            methodVerifyingProvider.VerifyMethod(mock, method, times);
         }
 
         /// <summary>
@@ -299,7 +305,13 @@ namespace FastMoq.Providers
             ArgumentNullException.ThrowIfNull(methodSelector);
 
             var method = VerificationExpressionBuilder.GetSelectedMethod(mock.Instance, methodSelector);
-            ResolveProvider(mock).VerifyMethod(mock, method, times);
+            var provider = ResolveProvider(mock);
+            if (provider is not IMethodVerifyingMockingProvider methodVerifyingProvider)
+            {
+                throw new NotSupportedException($"The current mocking provider '{provider.GetType().FullName}' does not support wildcard method verification. Implement {nameof(IMethodVerifyingMockingProvider)} to enable VerifyAnyArgs for non-void methods.");
+            }
+
+            methodVerifyingProvider.VerifyMethod(mock, method, times);
         }
 
         /// <summary>

--- a/FastMoq.Core/Providers/Reflection/ReflectionMockingProvider.cs
+++ b/FastMoq.Core/Providers/Reflection/ReflectionMockingProvider.cs
@@ -11,7 +11,7 @@ namespace FastMoq.Providers.ReflectionProvider
     /// Does NOT support: strict mode, call base, property auto-setup, protected members.
     /// Intended as a fallback / baseline provider so FastMoq can operate without external mocking libraries.
     /// </summary>
-    internal sealed class ReflectionMockingProvider : IMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
+    internal sealed class ReflectionMockingProvider : IMockingProvider, IMethodVerifyingMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
     {
         public static readonly ReflectionMockingProvider Instance = new();
         private ReflectionMockingProvider() { }

--- a/FastMoq.Core/Providers/Reflection/ReflectionMockingProvider.cs
+++ b/FastMoq.Core/Providers/Reflection/ReflectionMockingProvider.cs
@@ -108,6 +108,69 @@ namespace FastMoq.Providers.ReflectionProvider
             MarkVerified(records);
         }
 
+        public void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            var records = GetInvocations(mock.Instance)
+                .Where(record => MethodsMatch(record.Method, method))
+                .ToList();
+
+            times ??= default;
+            if (times.Value.Mode == TimesSpecMode.Never)
+            {
+                if (records.Count > 0)
+                {
+                    throw new InvalidOperationException($"Expected no calls to {method.Name} but found {records.Count}.");
+                }
+
+                return;
+            }
+
+            if (times.Value.Mode == TimesSpecMode.Exactly)
+            {
+                var expected = times.Value.Count ?? throw new InvalidOperationException("TimesSpec.Exactly requires a count.");
+                if (records.Count != expected)
+                {
+                    throw new InvalidOperationException($"Expected exactly {expected} call(s) to {method.Name} but found {records.Count}.");
+                }
+
+                MarkVerified(records);
+                return;
+            }
+
+            if (times.Value.Mode == TimesSpecMode.AtLeast)
+            {
+                var minimum = times.Value.Count ?? throw new InvalidOperationException("TimesSpec.AtLeast requires a count.");
+                if (records.Count < minimum)
+                {
+                    throw new InvalidOperationException($"Expected at least {minimum} call(s) to {method.Name} but found {records.Count}.");
+                }
+
+                MarkVerified(records);
+                return;
+            }
+
+            if (times.Value.Mode == TimesSpecMode.AtMost)
+            {
+                var maximum = times.Value.Count ?? throw new InvalidOperationException("TimesSpec.AtMost requires a count.");
+                if (records.Count > maximum)
+                {
+                    throw new InvalidOperationException($"Expected at most {maximum} call(s) to {method.Name} but found {records.Count}.");
+                }
+
+                MarkVerified(records);
+                return;
+            }
+
+            if (records.Count == 0)
+            {
+                throw new InvalidOperationException($"Expected at least one call to {method.Name} but none were recorded.");
+            }
+
+            MarkVerified(records);
+        }
+
         public void VerifyNoOtherCalls(IFastMock mock)
         {
             var inv = GetInvocations(mock.Instance);
@@ -137,6 +200,37 @@ namespace FastMoq.Providers.ReflectionProvider
         {
             foreach (var r in list) r.Verified = true;
         }
+
+        private static bool MethodsMatch(MethodInfo actualMethod, MethodInfo expectedMethod)
+        {
+            if (actualMethod == expectedMethod)
+            {
+                return true;
+            }
+
+            if (actualMethod.Name != expectedMethod.Name || actualMethod.ReturnType != expectedMethod.ReturnType)
+            {
+                return false;
+            }
+
+            var actualParameters = actualMethod.GetParameters();
+            var expectedParameters = expectedMethod.GetParameters();
+            if (actualParameters.Length != expectedParameters.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < actualParameters.Length; index++)
+            {
+                if (actualParameters[index].ParameterType != expectedParameters[index].ParameterType)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         private sealed record InvocationRecord(MethodInfo Method, object?[] Arguments)
         {
             public bool Verified { get; set; }

--- a/FastMoq.Core/Providers/VerificationExpressionBuilder.cs
+++ b/FastMoq.Core/Providers/VerificationExpressionBuilder.cs
@@ -14,6 +14,11 @@ namespace FastMoq.Providers
 
         internal static Expression<Action<T>> BuildAnyArgsExpression<T>(string methodName, params Type[] parameterTypes) where T : class
         {
+            return BuildAnyArgsExpression<T>(GetSelectedMethod<T>(methodName, parameterTypes));
+        }
+
+        internal static MethodInfo GetSelectedMethod<T>(string methodName, params Type[] parameterTypes) where T : class
+        {
             ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
 
             var serviceType = typeof(T);
@@ -27,8 +32,7 @@ namespace FastMoq.Providers
                 throw new InvalidOperationException($"Type '{serviceType.FullName}' does not contain an instance method named '{methodName}'.");
             }
 
-            var selectedMethod = SelectMethod(serviceType, methodName, methods, parameterTypes);
-            return BuildAnyArgsExpression<T>(selectedMethod);
+            return SelectMethod(serviceType, methodName, methods, parameterTypes);
         }
 
         internal static Expression<Action<T>> BuildAnyArgsExpression<T>(MethodInfo method) where T : class

--- a/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
+++ b/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
@@ -8,7 +8,7 @@ namespace FastMoq.Providers.MoqProvider
     /// <summary>
     /// Provider implementation that adapts Moq to the provider-neutral FastMoq abstractions.
     /// </summary>
-    public sealed class MoqMockingProvider : IMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
+    public sealed class MoqMockingProvider : IMockingProvider, IMethodVerifyingMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
     {
         private static readonly MethodInfo ItIsAnyMethodDefinition = typeof(It)
             .GetMethods(BindingFlags.Public | BindingFlags.Static)

--- a/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
+++ b/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
@@ -10,12 +10,21 @@ namespace FastMoq.Providers.MoqProvider
     /// </summary>
     public sealed class MoqMockingProvider : IMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
     {
+        private static readonly MethodInfo ItIsAnyMethodDefinition = typeof(It)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == nameof(It.IsAny) &&
+                method.IsGenericMethodDefinition &&
+                method.GetParameters().Length == 0);
         private static readonly MethodInfo SetupLoggerCallbackGenericMethod = typeof(MoqMockingProvider)
             .GetMethod(nameof(SetupLoggerCallbackGeneric), BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Could not resolve {nameof(SetupLoggerCallbackGeneric)} for logger setup dispatch.");
         private static readonly MethodInfo ConfigureMockPropertyGenericMethod = typeof(MoqMockingProvider)
             .GetMethod(nameof(TryConfigureMockPropertyGeneric), BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Could not resolve {nameof(TryConfigureMockPropertyGeneric)} for property setup dispatch.");
+        private static readonly MethodInfo VerifyMethodWithReturnGenericMethod = typeof(MoqMockingProvider)
+            .GetMethod(nameof(VerifyMethodWithReturnGeneric), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Could not resolve {nameof(VerifyMethodWithReturnGeneric)} for wildcard method verification.");
         private static readonly ConcurrentDictionary<Type, Action<Mock, Action<LogLevel, EventId, string, Exception?>>> LoggerSetupDispatchCache = new();
         private static readonly ConcurrentDictionary<Type, Func<Mock, PropertyInfo, object?, bool>> PropertySetupDispatchCache = new();
 
@@ -204,16 +213,15 @@ namespace FastMoq.Providers.MoqProvider
                 return;
             }
 
-            times ??= default;
-            var matchingInvocations = moqMock.Invocations
-                .Where(invocation => MethodsMatch(invocation.Method, method))
-                .ToList();
-
-            AssertExpectedInvocationCount(method.Name, matchingInvocations.Count, times.Value);
-            if (times.Value.Mode != TimesSpecMode.Never && matchingInvocations.Count > 0)
+            if (method.ReturnType == typeof(void))
             {
-                MarkInvocationsVerified(matchingInvocations);
+                moqMock.Verify(BuildAnyArgsActionExpression<T>(method), times.ToMoq());
+                return;
             }
+
+            VerifyMethodWithReturnGenericMethod
+                .MakeGenericMethod(typeof(T), method.ReturnType)
+                .Invoke(null, [moqMock, method, times]);
         }
 
         /// <summary>
@@ -358,95 +366,73 @@ namespace FastMoq.Providers.MoqProvider
             dispatcher(logger, callback);
         }
 
-        private static void AssertExpectedInvocationCount(string methodName, int count, TimesSpec times)
+        private static Expression<Action<T>> BuildAnyArgsActionExpression<T>(MethodInfo method) where T : class
         {
-            if (times.Mode == TimesSpecMode.Never)
-            {
-                if (count > 0)
-                {
-                    throw new InvalidOperationException($"Expected no calls to {methodName} but found {count}.");
-                }
+            var resolvedMethod = ResolveMethod(typeof(T), method);
+            var mockParameter = Expression.Parameter(typeof(T), "mock");
+            var arguments = resolvedMethod
+                .GetParameters()
+                .Select(parameter => CreateAnyArgumentExpression(parameter.ParameterType))
+                .ToArray();
 
-                return;
-            }
-
-            if (times.Mode == TimesSpecMode.Exactly)
-            {
-                var expected = times.Count ?? throw new InvalidOperationException("TimesSpec.Exactly requires a count.");
-                if (count != expected)
-                {
-                    throw new InvalidOperationException($"Expected exactly {expected} call(s) to {methodName} but found {count}.");
-                }
-
-                return;
-            }
-
-            if (times.Mode == TimesSpecMode.AtLeast)
-            {
-                var minimum = times.Count ?? throw new InvalidOperationException("TimesSpec.AtLeast requires a count.");
-                if (count < minimum)
-                {
-                    throw new InvalidOperationException($"Expected at least {minimum} call(s) to {methodName} but found {count}.");
-                }
-
-                return;
-            }
-
-            if (times.Mode == TimesSpecMode.AtMost)
-            {
-                var maximum = times.Count ?? throw new InvalidOperationException("TimesSpec.AtMost requires a count.");
-                if (count > maximum)
-                {
-                    throw new InvalidOperationException($"Expected at most {maximum} call(s) to {methodName} but found {count}.");
-                }
-
-                return;
-            }
-
-            if (count == 0)
-            {
-                throw new InvalidOperationException($"Expected at least one call to {methodName} but found none.");
-            }
+            return Expression.Lambda<Action<T>>(Expression.Call(mockParameter, resolvedMethod, arguments), mockParameter);
         }
 
-        private static void MarkInvocationsVerified(IEnumerable<IInvocation> invocations)
+        private static void VerifyMethodWithReturnGeneric<T, TResult>(Mock<T> mock, MethodInfo method, TimesSpec? times)
+            where T : class
         {
-            foreach (var invocation in invocations)
-            {
-                invocation.GetType()
-                    .GetMethod("MarkAsVerified", BindingFlags.Instance | BindingFlags.NonPublic)
-                    ?.Invoke(invocation, null);
-            }
+            mock.Verify(BuildAnyArgsFuncExpression<T, TResult>(method), times.ToMoq());
         }
 
-        private static bool MethodsMatch(MethodInfo actualMethod, MethodInfo expectedMethod)
+        private static Expression<Func<T, TResult>> BuildAnyArgsFuncExpression<T, TResult>(MethodInfo method) where T : class
         {
-            if (actualMethod == expectedMethod)
+            var resolvedMethod = ResolveMethod(typeof(T), method);
+            if (resolvedMethod.ReturnType != typeof(TResult))
             {
-                return true;
+                throw new InvalidOperationException($"Method '{resolvedMethod.DeclaringType?.FullName}.{resolvedMethod.Name}' does not return '{typeof(TResult).FullName}'.");
             }
 
-            if (actualMethod.Name != expectedMethod.Name || actualMethod.ReturnType != expectedMethod.ReturnType)
+            var mockParameter = Expression.Parameter(typeof(T), "mock");
+            var arguments = resolvedMethod
+                .GetParameters()
+                .Select(parameter => CreateAnyArgumentExpression(parameter.ParameterType))
+                .ToArray();
+
+            return Expression.Lambda<Func<T, TResult>>(Expression.Call(mockParameter, resolvedMethod, arguments), mockParameter);
+        }
+
+        private static MethodInfo ResolveMethod(Type serviceType, MethodInfo selectedMethod)
+        {
+            if (selectedMethod.DeclaringType == serviceType)
             {
-                return false;
+                return selectedMethod;
             }
 
-            var actualParameters = actualMethod.GetParameters();
-            var expectedParameters = expectedMethod.GetParameters();
-            if (actualParameters.Length != expectedParameters.Length)
+            var parameterTypes = selectedMethod.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+            var resolvedMethod = serviceType.GetMethod(
+                selectedMethod.Name,
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null);
+
+            if (resolvedMethod is not null && resolvedMethod.ReturnType == selectedMethod.ReturnType)
             {
-                return false;
+                return resolvedMethod;
             }
 
-            for (var index = 0; index < actualParameters.Length; index++)
+            throw new InvalidOperationException(
+                $"Unable to map selected method '{selectedMethod.DeclaringType?.FullName}.{selectedMethod.Name}' back to '{serviceType.FullName}'. Use the method-name overload with explicit parameter types for this member.");
+        }
+
+        private static Expression CreateAnyArgumentExpression(Type parameterType)
+        {
+            if (parameterType.IsByRef)
             {
-                if (actualParameters[index].ParameterType != expectedParameters[index].ParameterType)
-                {
-                    return false;
-                }
+                throw new NotSupportedException($"Any-args verification does not support by-ref parameters. Parameter type: '{parameterType}'.");
             }
 
-            return true;
+            return Expression.Call(ItIsAnyMethodDefinition.MakeGenericMethod(parameterType));
         }
 
         private static void SetupLoggerCallbackGeneric<TLogger>(Mock logger, Action<LogLevel, EventId, string, Exception?> callback)

--- a/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
+++ b/FastMoq.Provider.Moq/Providers/Moq/MoqMockingProvider.cs
@@ -184,6 +184,39 @@ namespace FastMoq.Providers.MoqProvider
         }
 
         /// <summary>
+        /// Verifies that the supplied method was invoked on the wrapped Moq mock while treating every argument as a wildcard matcher.
+        /// </summary>
+        public void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            Mock<T>? moqMock = null;
+            try
+            {
+                moqMock = Mock.Get(mock.Instance);
+            }
+            catch
+            {
+            }
+
+            if (moqMock == null)
+            {
+                return;
+            }
+
+            times ??= default;
+            var matchingInvocations = moqMock.Invocations
+                .Where(invocation => MethodsMatch(invocation.Method, method))
+                .ToList();
+
+            AssertExpectedInvocationCount(method.Name, matchingInvocations.Count, times.Value);
+            if (times.Value.Mode != TimesSpecMode.Never && matchingInvocations.Count > 0)
+            {
+                MarkInvocationsVerified(matchingInvocations);
+            }
+        }
+
+        /// <summary>
         /// Verifies that no unverified Moq calls remain on the supplied mock.
         /// </summary>
         public void VerifyNoOtherCalls(IFastMock mock)
@@ -323,6 +356,97 @@ namespace FastMoq.Providers.MoqProvider
                     .CreateDelegate(typeof(Action<Mock, Action<LogLevel, EventId, string, Exception?>>)));
 
             dispatcher(logger, callback);
+        }
+
+        private static void AssertExpectedInvocationCount(string methodName, int count, TimesSpec times)
+        {
+            if (times.Mode == TimesSpecMode.Never)
+            {
+                if (count > 0)
+                {
+                    throw new InvalidOperationException($"Expected no calls to {methodName} but found {count}.");
+                }
+
+                return;
+            }
+
+            if (times.Mode == TimesSpecMode.Exactly)
+            {
+                var expected = times.Count ?? throw new InvalidOperationException("TimesSpec.Exactly requires a count.");
+                if (count != expected)
+                {
+                    throw new InvalidOperationException($"Expected exactly {expected} call(s) to {methodName} but found {count}.");
+                }
+
+                return;
+            }
+
+            if (times.Mode == TimesSpecMode.AtLeast)
+            {
+                var minimum = times.Count ?? throw new InvalidOperationException("TimesSpec.AtLeast requires a count.");
+                if (count < minimum)
+                {
+                    throw new InvalidOperationException($"Expected at least {minimum} call(s) to {methodName} but found {count}.");
+                }
+
+                return;
+            }
+
+            if (times.Mode == TimesSpecMode.AtMost)
+            {
+                var maximum = times.Count ?? throw new InvalidOperationException("TimesSpec.AtMost requires a count.");
+                if (count > maximum)
+                {
+                    throw new InvalidOperationException($"Expected at most {maximum} call(s) to {methodName} but found {count}.");
+                }
+
+                return;
+            }
+
+            if (count == 0)
+            {
+                throw new InvalidOperationException($"Expected at least one call to {methodName} but found none.");
+            }
+        }
+
+        private static void MarkInvocationsVerified(IEnumerable<IInvocation> invocations)
+        {
+            foreach (var invocation in invocations)
+            {
+                invocation.GetType()
+                    .GetMethod("MarkAsVerified", BindingFlags.Instance | BindingFlags.NonPublic)
+                    ?.Invoke(invocation, null);
+            }
+        }
+
+        private static bool MethodsMatch(MethodInfo actualMethod, MethodInfo expectedMethod)
+        {
+            if (actualMethod == expectedMethod)
+            {
+                return true;
+            }
+
+            if (actualMethod.Name != expectedMethod.Name || actualMethod.ReturnType != expectedMethod.ReturnType)
+            {
+                return false;
+            }
+
+            var actualParameters = actualMethod.GetParameters();
+            var expectedParameters = expectedMethod.GetParameters();
+            if (actualParameters.Length != expectedParameters.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < actualParameters.Length; index++)
+            {
+                if (actualParameters[index].ParameterType != expectedParameters[index].ParameterType)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static void SetupLoggerCallbackGeneric<TLogger>(Mock logger, Action<LogLevel, EventId, string, Exception?> callback)

--- a/FastMoq.Provider.NSubstitute/Providers/NSubstitute/NSubstituteMockingProvider.cs
+++ b/FastMoq.Provider.NSubstitute/Providers/NSubstitute/NSubstituteMockingProvider.cs
@@ -8,7 +8,7 @@ namespace FastMoq.Providers.NSubstituteProvider
     /// <summary>
     /// Provider implementation that adapts NSubstitute to the provider-neutral FastMoq abstractions.
     /// </summary>
-    public sealed class NSubstituteMockingProvider : IMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
+    public sealed class NSubstituteMockingProvider : IMockingProvider, IMethodVerifyingMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
     {
         private static readonly ConcurrentDictionary<object, ConcurrentBag<ICall>> VerifiedCalls = new();
         private static readonly ConcurrentDictionary<object, byte> ConfiguredLoggers = new();

--- a/FastMoq.Provider.NSubstitute/Providers/NSubstitute/NSubstituteMockingProvider.cs
+++ b/FastMoq.Provider.NSubstitute/Providers/NSubstitute/NSubstituteMockingProvider.cs
@@ -202,6 +202,26 @@ namespace FastMoq.Providers.NSubstituteProvider
         }
 
         /// <summary>
+        /// Verifies that the supplied method was invoked on the wrapped NSubstitute mock while treating every argument as a wildcard matcher.
+        /// </summary>
+        public void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            times ??= default;
+            var target = mock.Instance;
+            var methodCalls = target.ReceivedCalls()
+                .Where(call => MethodsMatch(call.GetMethodInfo(), method))
+                .ToList();
+
+            AssertExpectedInvocationCount(method.Name, methodCalls.Count, times.Value);
+            if (times.Value.Mode != TimesSpecMode.Never && methodCalls.Count > 0)
+            {
+                MarkSpecificCallsVerified(target, methodCalls);
+            }
+        }
+
+        /// <summary>
         /// Verifies that no unverified calls remain on the supplied mock.
         /// </summary>
         public void VerifyNoOtherCalls(IFastMock mock)
@@ -390,6 +410,36 @@ namespace FastMoq.Providers.NSubstituteProvider
             }
 
             return (null, 0);
+        }
+
+        private static bool MethodsMatch(MethodInfo actualMethod, MethodInfo expectedMethod)
+        {
+            if (actualMethod == expectedMethod)
+            {
+                return true;
+            }
+
+            if (actualMethod.Name != expectedMethod.Name || actualMethod.ReturnType != expectedMethod.ReturnType)
+            {
+                return false;
+            }
+
+            var actualParameters = actualMethod.GetParameters();
+            var expectedParameters = expectedMethod.GetParameters();
+            if (actualParameters.Length != expectedParameters.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < actualParameters.Length; index++)
+            {
+                if (actualParameters[index].ParameterType != expectedParameters[index].ParameterType)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static void MarkCallsVerified<T>(T target, Expression<Action<T>> expression, int expected) where T : class

--- a/FastMoq.Tests/MethodResultExtensionsTests.cs
+++ b/FastMoq.Tests/MethodResultExtensionsTests.cs
@@ -319,6 +319,24 @@ namespace FastMoq.Tests
             exception.StackTrace.Should().Contain(nameof(ThrowingGatewayDispatchProxy));
         }
 
+        [Fact]
+        public void AddMethodResult_ShouldOverrideConfiguredCall_OnStrictTrackedMock()
+        {
+            using var providerScope = MockingProviderRegistry.Push("moq");
+            var mocker = new Mocker
+            {
+                DefaultStrictMockCreation = true,
+            };
+
+            _ = mocker.GetOrCreateMock<IMethodResultGateway>();
+            var gateway = mocker.AddMethodResult<IMethodResultGateway, string?>(x => x.Fetch("alpha"), "configured");
+
+            var configured = gateway.Fetch("alpha");
+
+            configured.Should().Be("configured");
+            mocker.Verify<IMethodResultGateway>(x => x.Fetch("alpha"), TimesSpec.Once);
+        }
+
         public interface IMethodResultGateway
         {
             string? Fetch(string key);

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -276,6 +276,20 @@ namespace FastMoq.Tests
 
         [Theory]
         [MemberData(nameof(ProviderNames))]
+        public void VerifyAnyArgs_ShouldSupportNonVoidMethods_ForSelectedProvider(string providerName)
+        {
+            using var providerScope = PushProvider(providerName);
+            var mocker = new Mocker();
+            var dependency = mocker.GetOrCreateMock<IProviderResultDependency>();
+
+            _ = dependency.Instance.Lookup("alpha");
+
+            mocker.VerifyAnyArgs<IProviderResultDependency>(nameof(IProviderResultDependency.Lookup), TimesSpec.Once, typeof(string));
+            mocker.VerifyNoOtherCalls<IProviderResultDependency>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ProviderNames))]
         public void DetachedVerifyAnyArgs_ShouldSupportDelegateSelector_ForSelectedProvider(string providerName)
         {
             using var providerScope = PushProvider(providerName);
@@ -1688,6 +1702,11 @@ namespace FastMoq.Tests
             void Run(string value);
         }
 
+        public interface IProviderResultDependency
+        {
+            string? Lookup(string value);
+        }
+
         public interface IPropertySetterDependency
         {
             string? Value { get; set; }
@@ -1799,6 +1818,12 @@ namespace FastMoq.Tests
             public void Verify<T>(IFastMock<T> mock, Expression<Action<T>> expression, TimesSpec? times = null) where T : class
             {
                 NSubstituteMockingProvider.Instance.Verify(mock, expression, times);
+            }
+
+            /// <inheritdoc />
+            public void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+            {
+                NSubstituteMockingProvider.Instance.VerifyMethod(mock, method, times);
             }
 
             /// <inheritdoc />

--- a/FastMoq.Tests/ProviderTests.cs
+++ b/FastMoq.Tests/ProviderTests.cs
@@ -1779,7 +1779,7 @@ namespace FastMoq.Tests
         /// <summary>
         /// Test-only abstract base provider used by convention-discovery tests to delegate behavior to NSubstitute.
         /// </summary>
-        public abstract class ConventionDiscoveredDelegatingMockingProviderBase : IMockingProvider
+        public abstract class ConventionDiscoveredDelegatingMockingProviderBase : IMockingProvider, IMethodVerifyingMockingProvider
         {
             /// <inheritdoc />
             public IMockingProviderCapabilities Capabilities => NSubstituteMockingProvider.Instance.Capabilities;

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -1094,7 +1094,7 @@ namespace FastMoq.Tests
             public string? Name { get; set; }
         }
 
-        private sealed class DelegatingMoqPropertyConfiguratorProvider : IMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
+        private sealed class DelegatingMoqPropertyConfiguratorProvider : IMockingProvider, IMethodVerifyingMockingProvider, IMockingProviderCapabilities, ITrackedMockPropertyConfigurator
         {
             private readonly MoqMockingProvider _inner = MoqMockingProvider.Instance;
 

--- a/FastMoq.Tests/ServiceProviderHelperTests.cs
+++ b/FastMoq.Tests/ServiceProviderHelperTests.cs
@@ -659,6 +659,23 @@ namespace FastMoq.Tests
             existing.Instance.InvocationId.Should().Be("inv-456");
         }
 
+        [Fact]
+        public void AddFunctionContextInvocationId_ShouldRequireReplace_WhenHelperAlreadyConfigured()
+        {
+            using var providerScope = PushProviderScope("moq");
+            var mocker = new Mocker();
+
+            mocker.AddFunctionContextInvocationId("inv-123");
+
+            Action action = () => mocker.AddFunctionContextInvocationId("inv-456");
+
+            action.Should().Throw<ArgumentException>()
+                .WithMessage("*FunctionContext*already exists*");
+
+            var request = mocker.CreateHttpRequestData();
+            request.FunctionContext.InvocationId.Should().Be("inv-123");
+        }
+
         [Theory]
         [InlineData("moq", true)]
         [InlineData("moq", false)]
@@ -1116,6 +1133,11 @@ namespace FastMoq.Tests
             public void Verify<T>(IFastMock<T> mock, Expression<Action<T>> expression, TimesSpec? times = null) where T : class
             {
                 _inner.Verify((IFastMock<T>)Unwrap(mock), expression, times);
+            }
+
+            public void VerifyMethod<T>(IFastMock<T> mock, MethodInfo method, TimesSpec? times = null) where T : class
+            {
+                _inner.VerifyMethod((IFastMock<T>)Unwrap(mock), method, times);
             }
 
             public void VerifyNoOtherCalls(IFastMock mock)


### PR DESCRIPTION
## Summary
Fix the three release blockers found during the provider-first hardening review.

- restore provider-neutral `VerifyAnyArgs` support for non-void methods by adding method-based verification across providers
- honor `replace` semantics in `FunctionContext` helper registration flows
- make method-result overrides work with strict tracked mocks
- add regression coverage for provider verification, FunctionContext replace behavior, and strict method-result overrides

## Validation
- `dotnet test FastMoq.Tests/FastMoq.Tests.csproj`
- downstream unit consumers passed in Switchboard, web-tools, Processing, and Waiter
- remaining downstream failures were environmental or repo-runner blockers only
