### PR TITLE
Add helper composition analyzers and safe inheritance fix

### DIFF
--- a/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
+++ b/FastMoq.Analyzers.Tests/AnalyzerTestHelpers.cs
@@ -132,6 +132,11 @@ namespace FastMoq.Analyzers.Tests
                 .ToFullString();
         }
 
+        public static Document CreateDocumentForTest(string source, bool includeAzureFunctionsHelpers = false, bool includeMoqProviderPackage = true, bool includeNSubstituteProviderPackage = true, bool includeWebHelpers = true)
+        {
+            return CreateDocument(source, includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage, includeWebHelpers);
+        }
+
         private static Document CreateDocument(string source, bool includeAzureFunctionsHelpers = false, bool includeMoqProviderPackage = true, bool includeNSubstituteProviderPackage = true, bool includeWebHelpers = true)
         {
             var project = CreateProject([("Test.cs", source)], includeAzureFunctionsHelpers, includeMoqProviderPackage, includeNSubstituteProviderPackage, includeWebHelpers);

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -341,6 +341,178 @@ class SampleTests(Xunit.ITestOutputHelper output)
         }
 
         [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldRewrite_PrimaryConstructorWrapper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+{
+    SampleService Component => base.Component;
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldRewrite_TraditionalConstructorWrapper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper;
+
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+        _helper = new TestHelper(output);
+    }
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests : MockerTestBase<SampleService>
+{
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+    }
+
+    SampleService Component => base.Component;
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperOwnsUnsupportedHooks()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+
+        protected override Action<SampleService> CreatedComponentAction => component =>
+        {
+        };
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance);
+
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperConstructorContainsSetupStatements()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+            Mocks.AddLoggerFactory(output.WriteLine);
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance);
+
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
         public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldReport_WhenComponentAliasOnlyForwardsToHelper()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -238,7 +238,7 @@ class SampleTests(Xunit.ITestOutputHelper output)
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.DirectMockerTestBaseInheritance));
 
             Assert.Equal(DiagnosticIds.DirectMockerTestBaseInheritance, diagnostic.Id);
-            Assert.Equal("SampleTests", diagnostic.Location.GetLineSpan().Path.Length == 0 ? "SampleTests" : "SampleTests");
+            Assert.Contains("SampleTests", diagnostic.GetMessage());
         }
 
         [Fact]
@@ -496,6 +496,105 @@ class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService
         }
 
         [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldRewrite_ThisQualifiedHelperAccess()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper;
+
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+        this._helper = new TestHelper(output);
+    }
+
+    SampleService Component => this._helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests : MockerTestBase<SampleService>
+{
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+    }
+
+    SampleService Component => base.Component;
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldAddFastMoqUsing_WhenOnlyFullyQualifiedHelperBaseExists()
+        {
+            const string SOURCE = @"
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : FastMoq.MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+{
+    SampleService Component => base.Component;
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperOwnsUnsupportedHooks()
         {
             const string SOURCE = @"
@@ -648,6 +747,34 @@ class SampleTests
 
             Assert.Equal(DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection, diagnostic.Id);
             Assert.Contains("Store", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldReport_WhenComponentAliasUsesParentheses()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => (_helper.C);
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection));
+
+            Assert.Equal(DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection, diagnostic.Id);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -378,7 +378,6 @@ class SampleService
 
 class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
 {
-    SampleService Component => base.Component;
 }");
 
             Assert.Equal(expected, fixedSource);
@@ -434,8 +433,6 @@ class SampleTests : MockerTestBase<SampleService>
     public SampleTests(Xunit.ITestOutputHelper output)
     {
     }
-
-    SampleService Component => base.Component;
 }");
 
             Assert.Equal(expected, fixedSource);
@@ -485,8 +482,6 @@ class SampleService
 
 class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>, IDisposable
 {
-    SampleService Component => base.Component;
-
     public void Dispose()
     {
     }
@@ -545,8 +540,6 @@ class SampleTests : MockerTestBase<SampleService>
     public SampleTests(Xunit.ITestOutputHelper output)
     {
     }
-
-    SampleService Component => base.Component;
 }");
 
             Assert.Equal(expected, fixedSource);
@@ -588,7 +581,6 @@ class SampleService
 
 class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
 {
-    SampleService Component => base.Component;
 }");
 
             Assert.Equal(expected, fixedSource);
@@ -653,8 +645,94 @@ namespace TargetNamespace
 
     class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
     {
-        SampleService Component => base.Component;
     }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldPreserveNonShadowingOuterAlias()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Subject => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+{
+    SampleService Subject => base.Component;
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldRemoveRedundantMocksAlias()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    Mocker Mocks => _helper.Store;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public Mocker Store => Mocks;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests : MockerTestBase<SampleService>
+{
 }");
 
             Assert.Equal(expected, fixedSource);

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -442,6 +442,60 @@ class SampleTests : MockerTestBase<SampleService>
         }
 
         [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldPreserveImplementedInterfaces()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output) : IDisposable
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using System;
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>, IDisposable
+{
+    SampleService Component => base.Component;
+
+    public void Dispose()
+    {
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperOwnsUnsupportedHooks()
         {
             const string SOURCE = @"
@@ -565,6 +619,225 @@ class SampleTests(Xunit.ITestOutputHelper output)
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer());
 
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection);
+        }
+
+        [Fact]
+        public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldReport_WhenMocksAliasOnlyForwardsToHelper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    Mocker Mocks => _helper.Store;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public Mocker Store => Mocks;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection));
+
+            Assert.Equal(DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection, diagnostic.Id);
+            Assert.Contains("Store", diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task TrackedMockShimAnalyzer_ShouldReport_WhenHelperCompositionExposesVerificationOnlyMockAlias()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+class SampleService
+{
+}
+
+interface IService
+{
+    void Run();
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    void Execute()
+    {
+        _helper.VerifyDependency();
+    }
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public Mock<IService> DependencyMock => Mocks.GetMock<IService>();
+
+        public void VerifyDependency()
+        {
+            DependencyMock.Verify(x => x.Run());
+        }
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new TrackedMockShimAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.AvoidTrackedMockShimAlias));
+
+            Assert.Equal(DiagnosticIds.AvoidTrackedMockShimAlias, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task LoggerFactoryRegistrationAnalyzer_ShouldReport_WhenNestedHelperRegistersOutputLoggerFactory()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using Microsoft.Extensions.Logging;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+            Mocks.AddType<ILoggerFactory>(new OutputLoggerFactory(output), true);
+        }
+
+        public SampleService C => Component;
+    }
+}
+
+sealed class OutputLoggerFactory : ILoggerFactory
+{
+    public OutputLoggerFactory(Xunit.ITestOutputHelper output)
+    {
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName) => throw new System.NotImplementedException();
+
+    public void Dispose()
+    {
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new LoggerFactoryRegistrationAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.PreferLoggerFactoryHelpers));
+
+            Assert.Equal(DiagnosticIds.PreferLoggerFactoryHelpers, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReport_WhenNestedHelperWrapsDetachedProviderVerify()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+
+class SampleService
+{
+}
+
+interface IService
+{
+    void Run();
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        internal void Verify<T>(IFastMock<T> fastMock, Expression<Action<T>> expression, TimesSpec? times = null)
+            where T : class
+            => MockingProviderRegistry.Default.Verify(fastMock, expression, times);
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new FastMockVerifyHelperAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.AvoidFastMockVerifyHelperWrappers));
+
+            Assert.Equal(DiagnosticIds.AvoidFastMockVerifyHelperWrappers, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task FastMockVerifyHelperAnalyzer_ShouldReport_WhenNestedHelperWrapsProviderSpecificVerify()
+        {
+            const string SOURCE = @"
+using System;
+using System.Linq.Expressions;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Moq;
+
+class SampleService
+{
+}
+
+interface IService
+{
+    int Run();
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        internal void Verify<T, TResult>(IFastMock<T> fastMock, Expression<Func<T, TResult>> expression, TimesSpec times)
+            where T : class
+            => fastMock.AsMoq().Verify(expression, times.ToMoq());
+
+        private static Times ToMoq(TimesSpec times)
+            => times.Mode switch
+            {
+                TimesSpecMode.AtLeastOnce => Times.AtLeastOnce(),
+                TimesSpecMode.Exactly => Times.Exactly(times.Count ?? 0),
+                TimesSpecMode.AtLeast => Times.AtLeast(times.Count ?? 0),
+                TimesSpecMode.AtMost => Times.AtMost(times.Count ?? 0),
+                TimesSpecMode.Never => Times.Never(),
+                _ => throw new ArgumentOutOfRangeException(nameof(times), times.Mode, null),
+            };
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new FastMockVerifyHelperAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers));
+
+            Assert.Equal(DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers, diagnostic.Id);
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.AvoidFastMockVerifyHelperWrappers);
         }
 
         private static async Task<MockerTestBaseHelperCompositionCandidate> GetDirectMockerTestBaseInheritanceCandidateAsync(string source, string outerTypeName)

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -666,6 +666,80 @@ class SampleTests(Xunit.ITestOutputHelper output)
         }
 
         [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperAssignmentUsesExistingHelperValue()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper;
+
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+        var existingHelper = new TestHelper(output);
+        _helper = existingHelper;
+    }
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance);
+
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperFieldHasUnsupportedReference()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    TestHelper Helper => _helper;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance);
+
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
         public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldReport_WhenComponentAliasOnlyForwardsToHelper()
         {
             const string SOURCE = @"

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -595,6 +595,72 @@ class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService
         }
 
         [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldAddFastMoqUsing_WhenAnotherNamespaceOwnsTheOnlyNamespaceScopedUsing()
+        {
+            const string SOURCE = @"
+namespace ExistingNamespace
+{
+    using FastMoq;
+
+    class ExistingTests : MockerTestBase<SampleService>
+    {
+    }
+}
+
+namespace TargetNamespace
+{
+    class SampleService
+    {
+    }
+
+    class SampleTests(Xunit.ITestOutputHelper output)
+    {
+        private readonly TestHelper _helper = new(output);
+
+        SampleService Component => _helper.C;
+
+        private sealed class TestHelper(Xunit.ITestOutputHelper output) : FastMoq.MockerTestBase<SampleService>
+        {
+            public SampleService C => Component;
+        }
+    }
+}";
+
+            var fixedSource = await AnalyzerTestHelpers.ApplyCodeFixAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance,
+                codeFixTitle: "Use direct MockerTestBase inheritance");
+
+            var expected = AnalyzerTestHelpers.NormalizeCode(@"
+using FastMoq;
+
+namespace ExistingNamespace
+{
+    using FastMoq;
+
+    class ExistingTests : MockerTestBase<SampleService>
+    {
+    }
+}
+
+namespace TargetNamespace
+{
+    class SampleService
+    {
+    }
+
+    class SampleTests(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        SampleService Component => base.Component;
+    }
+}");
+
+            Assert.Equal(expected, fixedSource);
+        }
+
+        [Fact]
         public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperOwnsUnsupportedHooks()
         {
             const string SOURCE = @"
@@ -650,6 +716,49 @@ class SampleTests(Xunit.ITestOutputHelper output)
         public TestHelper(Xunit.ITestOutputHelper output)
         {
             Mocks.AddLoggerFactory(output.WriteLine);
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var codeFixTitles = await AnalyzerTestHelpers.GetCodeFixTitlesAsync(
+                SOURCE,
+                new DirectMockerTestBaseInheritanceAnalyzer(),
+                codeFixProvider,
+                DiagnosticIds.DirectMockerTestBaseInheritance);
+
+            Assert.Empty(codeFixTitles);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCodeFix_ShouldNotBeOffered_WhenHelperAssignmentUsesObjectInitializer()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper;
+
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+        _helper = new TestHelper(output)
+        {
+            Strict = true,
+        };
+    }
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
         }
 
         public SampleService C => Component;

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -3,10 +3,12 @@ using FastMoq.Analyzers.Analyzers;
 using FastMoq.Analyzers.CodeFixes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -32,6 +34,8 @@ namespace FastMoq.Analyzers.Tests
             { new OptionsSetupAnalyzer(), DiagnosticDescriptors.PreferSetupOptionsHelper },
             { new LoggerFactoryRegistrationAnalyzer(), DiagnosticDescriptors.PreferLoggerFactoryHelpers },
             { new LoggerSetupCallbackAnalyzer(), DiagnosticDescriptors.PreferSetupLoggerCallbackHelper },
+            { new DirectMockerTestBaseInheritanceAnalyzer(), DiagnosticDescriptors.DirectMockerTestBaseInheritance },
+            { new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer(), DiagnosticDescriptors.UnnecessaryMockerTestBaseHelperIndirection },
             { new SetupSetAnalyzer(), DiagnosticDescriptors.PreferPropertySetterCaptureHelper },
             { new SetupAllPropertiesAnalyzer(), DiagnosticDescriptors.PreferPropertyStateHelper },
             { new TrackedMockVerificationAnalyzer(), DiagnosticDescriptors.UseProviderFirstVerify },
@@ -94,6 +98,8 @@ namespace FastMoq.Analyzers.Tests
             { DiagnosticDescriptors.PreserveKeyedServiceDistinctness, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.PreserveTrackedResolutionDuringAddTypeMigration, DiagnosticSeverity.Warning },
             { DiagnosticDescriptors.RequireExplicitMoqOnboarding, DiagnosticSeverity.Warning },
+            { DiagnosticDescriptors.DirectMockerTestBaseInheritance, DiagnosticSeverity.Warning },
+            { DiagnosticDescriptors.UnnecessaryMockerTestBaseHelperIndirection, DiagnosticSeverity.Info },
         };
 
         [Theory]
@@ -108,6 +114,305 @@ namespace FastMoq.Analyzers.Tests
         public void Descriptor_ShouldExposeExpectedDefaultSeverity(DiagnosticDescriptor descriptor, DiagnosticSeverity expectedSeverity)
         {
             Assert.Equal(expectedSeverity, descriptor.DefaultSeverity);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCandidate_ShouldBeFixable_WhenHelperSetupIsEmpty()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var candidate = await GetDirectMockerTestBaseInheritanceCandidateAsync(SOURCE, "SampleTests");
+
+            Assert.Equal("SampleTests", candidate.OuterType.Name);
+            Assert.Equal("TestHelper", candidate.HelperType.Name);
+            Assert.Equal("SampleService", candidate.TargetType.Name);
+            Assert.True(candidate.IsFixable);
+            Assert.Equal(MockerTestBaseHelperCompositionFixBlockReason.None, candidate.FixBlockReason);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCandidate_ShouldBlockFix_WhenHelperOwnsUnsupportedHooks()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper = new();
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+
+        protected override Action<SampleService> CreatedComponentAction => component =>
+        {
+        };
+    }
+}";
+
+            var candidate = await GetDirectMockerTestBaseInheritanceCandidateAsync(SOURCE, "SampleTests");
+
+            Assert.False(candidate.IsFixable);
+            Assert.Equal(MockerTestBaseHelperCompositionFixBlockReason.UnsupportedHooks, candidate.FixBlockReason);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceCandidate_ShouldBlockFix_WhenHelperConstructorHasSetupStatements()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+            Mocks.AddLoggerFactory(output.WriteLine);
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var candidate = await GetDirectMockerTestBaseInheritanceCandidateAsync(SOURCE, "SampleTests");
+
+            Assert.False(candidate.IsFixable);
+            Assert.Equal(MockerTestBaseHelperCompositionFixBlockReason.UnsupportedForNow, candidate.FixBlockReason);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceAnalyzer_ShouldReport_WhenPrimaryConstructorOuterWrapsLocalHelper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new DirectMockerTestBaseInheritanceAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.DirectMockerTestBaseInheritance));
+
+            Assert.Equal(DiagnosticIds.DirectMockerTestBaseInheritance, diagnostic.Id);
+            Assert.Equal("SampleTests", diagnostic.Location.GetLineSpan().Path.Length == 0 ? "SampleTests" : "SampleTests");
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceAnalyzer_ShouldReport_WhenTraditionalConstructorOuterWrapsLocalHelper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests
+{
+    private readonly TestHelper _helper;
+
+    public SampleTests(Xunit.ITestOutputHelper output)
+    {
+        _helper = new TestHelper(output);
+    }
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public TestHelper(Xunit.ITestOutputHelper output)
+        {
+        }
+
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new DirectMockerTestBaseInheritanceAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.DirectMockerTestBaseInheritance));
+
+            Assert.Equal(DiagnosticIds.DirectMockerTestBaseInheritance, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceAnalyzer_ShouldNotReport_WhenOuterAlreadyUsesSharedInheritedBase()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+abstract class SharedBase : MockerTestBase<SampleService>
+{
+}
+
+class SampleTests : SharedBase
+{
+    private readonly TestHelper _helper = new();
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new DirectMockerTestBaseInheritanceAnalyzer());
+
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.DirectMockerTestBaseInheritance);
+        }
+
+        [Fact]
+        public async Task DirectMockerTestBaseInheritanceAnalyzer_ShouldNotReport_WhenHelperOwnsMeaningfulBehavior()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+
+        public void Arrange()
+        {
+        }
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new DirectMockerTestBaseInheritanceAnalyzer());
+
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.DirectMockerTestBaseInheritance);
+        }
+
+        [Fact]
+        public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldReport_WhenComponentAliasOnlyForwardsToHelper()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Component => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection));
+
+            Assert.Equal(DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task UnnecessaryMockerTestBaseHelperIndirectionAnalyzer_ShouldNotReport_WhenPropertyUsesDifferentVocabulary()
+        {
+            const string SOURCE = @"
+using FastMoq;
+
+class SampleService
+{
+}
+
+class SampleTests(Xunit.ITestOutputHelper output)
+{
+    private readonly TestHelper _helper = new(output);
+
+    SampleService Subject => _helper.C;
+
+    private sealed class TestHelper(Xunit.ITestOutputHelper output) : MockerTestBase<SampleService>
+    {
+        public SampleService C => Component;
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new UnnecessaryMockerTestBaseHelperIndirectionAnalyzer());
+
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection);
+        }
+
+        private static async Task<MockerTestBaseHelperCompositionCandidate> GetDirectMockerTestBaseInheritanceCandidateAsync(string source, string outerTypeName)
+        {
+            var document = AnalyzerTestHelpers.CreateDocumentForTest(source);
+            var root = await document.GetSyntaxRootAsync(CancellationToken.None).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(CancellationToken.None).ConfigureAwait(false);
+
+            Assert.NotNull(root);
+            Assert.NotNull(semanticModel);
+
+            var outerTypeDeclaration = root!
+                .DescendantNodes()
+                .OfType<TypeDeclarationSyntax>()
+                .Single(typeDeclaration => typeDeclaration.Identifier.ValueText == outerTypeName);
+
+            Assert.True(
+                FastMoqAnalysisHelpers.TryGetDirectMockerTestBaseInheritanceCandidate(outerTypeDeclaration, semanticModel!, CancellationToken.None, out var candidate));
+
+            return candidate;
         }
 
         [Fact]

--- a/FastMoq.Analyzers/Analyzers/DirectMockerTestBaseInheritanceAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/DirectMockerTestBaseInheritanceAnalyzer.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DirectMockerTestBaseInheritanceAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.DirectMockerTestBaseInheritance);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, Microsoft.CodeAnalysis.CSharp.SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var classDeclaration = (ClassDeclarationSyntax) context.Node;
+            if (!FastMoqAnalysisHelpers.TryGetDirectMockerTestBaseInheritanceCandidate(classDeclaration, context.SemanticModel, context.CancellationToken, out var candidate))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.DirectMockerTestBaseInheritance,
+                classDeclaration.Identifier.GetLocation(),
+                candidate.OuterType.Name,
+                candidate.TargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                candidate.HelperType.Name));
+        }
+    }
+}

--- a/FastMoq.Analyzers/Analyzers/UnnecessaryMockerTestBaseHelperIndirectionAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/UnnecessaryMockerTestBaseHelperIndirectionAnalyzer.cs
@@ -1,0 +1,84 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace FastMoq.Analyzers.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnnecessaryMockerTestBaseHelperIndirectionAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.UnnecessaryMockerTestBaseHelperIndirection);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzePropertyDeclaration, Microsoft.CodeAnalysis.CSharp.SyntaxKind.PropertyDeclaration);
+        }
+
+        private static void AnalyzePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var propertyDeclaration = (PropertyDeclarationSyntax) context.Node;
+            if (context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken) is not IPropertySymbol propertySymbol ||
+                propertySymbol.IsStatic ||
+                propertySymbol.Name is not "Component" and not "Mocks" ||
+                propertyDeclaration.Parent is not TypeDeclarationSyntax containingType ||
+                !FastMoqAnalysisHelpers.TryGetDirectMockerTestBaseInheritanceCandidate(containingType, context.SemanticModel, context.CancellationToken, out var candidate) ||
+                !TryGetHelperForwardingMemberName(propertyDeclaration, context.SemanticModel, context.CancellationToken, candidate.HelperMember, out var helperMemberName))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.UnnecessaryMockerTestBaseHelperIndirection,
+                propertyDeclaration.Identifier.GetLocation(),
+                propertySymbol.Name,
+                helperMemberName));
+        }
+
+        private static bool TryGetHelperForwardingMemberName(PropertyDeclarationSyntax propertyDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken, ISymbol helperMember, out string helperMemberName)
+        {
+            if (!TryGetPropertyReturnExpression(propertyDeclaration, out var expression) ||
+                expression is not MemberAccessExpressionSyntax memberAccess ||
+                semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol is not { } accessSymbol ||
+                !SymbolEqualityComparer.Default.Equals(accessSymbol, helperMember))
+            {
+                helperMemberName = string.Empty;
+                return false;
+            }
+
+            helperMemberName = memberAccess.Name.Identifier.ValueText;
+            return true;
+        }
+
+        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
+        {
+            if (propertyDeclaration.ExpressionBody is not null)
+            {
+                expression = propertyDeclaration.ExpressionBody.Expression;
+                return true;
+            }
+
+            if (propertyDeclaration.AccessorList?.Accessors.Count == 1 && propertyDeclaration.AccessorList.Accessors[0].Keyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GetKeyword))
+            {
+                var getter = propertyDeclaration.AccessorList.Accessors[0];
+                if (getter.ExpressionBody is not null)
+                {
+                    expression = getter.ExpressionBody.Expression;
+                    return true;
+                }
+
+                if (getter.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement && returnStatement.Expression is not null)
+                {
+                    expression = returnStatement.Expression;
+                    return true;
+                }
+            }
+
+            expression = default!;
+            return false;
+        }
+    }
+}

--- a/FastMoq.Analyzers/Analyzers/UnnecessaryMockerTestBaseHelperIndirectionAnalyzer.cs
+++ b/FastMoq.Analyzers/Analyzers/UnnecessaryMockerTestBaseHelperIndirectionAnalyzer.cs
@@ -40,8 +40,14 @@ namespace FastMoq.Analyzers.Analyzers
 
         private static bool TryGetHelperForwardingMemberName(PropertyDeclarationSyntax propertyDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken, ISymbol helperMember, out string helperMemberName)
         {
-            if (!TryGetPropertyReturnExpression(propertyDeclaration, out var expression) ||
-                expression is not MemberAccessExpressionSyntax memberAccess ||
+            if (!FastMoqAnalysisHelpers.TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
+            {
+                helperMemberName = string.Empty;
+                return false;
+            }
+
+            expression = FastMoqAnalysisHelpers.Unwrap(expression);
+            if (expression is not MemberAccessExpressionSyntax memberAccess ||
                 semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol is not { } accessSymbol ||
                 !SymbolEqualityComparer.Default.Equals(accessSymbol, helperMember))
             {
@@ -51,34 +57,6 @@ namespace FastMoq.Analyzers.Analyzers
 
             helperMemberName = memberAccess.Name.Identifier.ValueText;
             return true;
-        }
-
-        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
-        {
-            if (propertyDeclaration.ExpressionBody is not null)
-            {
-                expression = propertyDeclaration.ExpressionBody.Expression;
-                return true;
-            }
-
-            if (propertyDeclaration.AccessorList?.Accessors.Count == 1 && propertyDeclaration.AccessorList.Accessors[0].Keyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GetKeyword))
-            {
-                var getter = propertyDeclaration.AccessorList.Accessors[0];
-                if (getter.ExpressionBody is not null)
-                {
-                    expression = getter.ExpressionBody.Expression;
-                    return true;
-                }
-
-                if (getter.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement && returnStatement.Expression is not null)
-                {
-                    expression = returnStatement.Expression;
-                    return true;
-                }
-            }
-
-            expression = default!;
-            return false;
         }
     }
 }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -603,7 +603,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
             if (requiresProvidersNamespace)
             {
-                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
             }
 
             return document.WithSyntaxRoot(updatedRoot);
@@ -625,7 +625,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
             if (requiresProvidersNamespace)
             {
-                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+                updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
             }
 
             return document.WithSyntaxRoot(updatedRoot);
@@ -739,6 +739,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementOuter = annotatedOuter.WithBaseList(
                 SyntaxFactory.BaseList(baseTypes));
             updatedRoot = updatedRoot.ReplaceNode(annotatedOuter, replacementOuter);
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq");
 
             return document.WithSyntaxRoot(updatedRoot);
         }
@@ -756,7 +757,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -817,7 +818,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Web.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Web.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -869,7 +870,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementStatement = SyntaxFactory.ParseStatement(replacementText)
                 .WithTriviaFrom(annotatedTargetStatement);
             updatedRoot = updatedRoot.ReplaceNode(annotatedTargetStatement, replacementStatement);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Web.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Web.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -890,7 +891,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -911,7 +912,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -1023,7 +1024,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
 
-            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions"));
+            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions"));
         }
 
         private static async Task<Document> ReplaceLoggerFactoryHelperInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
@@ -1045,7 +1046,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
 
-            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions"));
+            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions"));
         }
 
         private static async Task<Document> ReplaceSetupLoggerCallbackInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
@@ -1067,7 +1068,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 .WithTriviaFrom(invocationExpression);
             var updatedRoot = root.ReplaceNode(invocationExpression, replacementExpression);
 
-            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions"));
+            return document.WithSyntaxRoot(AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions"));
         }
 
         private static async Task<Document> ReplaceProviderNeutralHttpHelperInvocationAsync(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
@@ -1144,8 +1145,8 @@ namespace FastMoq.Analyzers.CodeFixes
                 updatedRoot = updatedRoot.ReplaceNode(annotatedClientExpression, replacementExpression);
             }
 
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.Extensions");
-            updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, edit.RequiredNamespaces);
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.Extensions");
+            updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, semanticModel.Compilation, edit.RequiredNamespaces);
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -1166,7 +1167,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(targetInvocation);
             var updatedRoot = root.ReplaceNode(targetInvocation, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.AzureFunctions.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.AzureFunctions.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -1187,7 +1188,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(targetInvocation);
             var updatedRoot = root.ReplaceNode(targetInvocation, replacementExpression);
-            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, "FastMoq.AzureFunctions.Extensions");
+            updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, semanticModel.Compilation, "FastMoq.AzureFunctions.Extensions");
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -1238,7 +1239,7 @@ namespace FastMoq.Analyzers.CodeFixes
             var replacementExpression = SyntaxFactory.ParseExpression(replacementText)
                 .WithTriviaFrom(annotatedTargetInvocation);
             updatedRoot = updatedRoot.ReplaceNode(annotatedTargetInvocation, replacementExpression);
-            updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, requiredNamespaces);
+            updatedRoot = AddUsingDirectivesIfMissing(updatedRoot, semanticModel.Compilation, requiredNamespaces);
             return document.WithSyntaxRoot(updatedRoot);
         }
 
@@ -1261,12 +1262,13 @@ namespace FastMoq.Analyzers.CodeFixes
         private static async Task<Document> AddAssemblyDefaultProviderAsync(Document document, string providerName, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) as CompilationUnitSyntax;
+            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
             if (root is null || HasAssemblyDefaultProviderAttribute(root, providerName))
             {
                 return document;
             }
 
-            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectiveIfMissing(root, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
+            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectiveIfMissing(root, compilation, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
             updatedRoot = updatedRoot.AddAttributeLists(CreateAssemblyDefaultProviderAttribute(providerName));
             return document.WithSyntaxRoot(updatedRoot);
         }
@@ -1274,12 +1276,13 @@ namespace FastMoq.Analyzers.CodeFixes
         private static async Task<Document> AddAssemblyRegisteredDefaultProviderAsync(Document document, string providerName, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) as CompilationUnitSyntax;
+            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
             if (root is null || HasAssemblyRegisteredDefaultProviderAttribute(root, providerName))
             {
                 return document;
             }
 
-            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectivesIfMissing(root, [FastMoqAnalysisHelpers.FastMoqProvidersNamespace, FastMoqAnalysisHelpers.MoqProviderNamespace]);
+            var updatedRoot = (CompilationUnitSyntax) AddUsingDirectivesIfMissing(root, compilation, [FastMoqAnalysisHelpers.FastMoqProvidersNamespace, FastMoqAnalysisHelpers.MoqProviderNamespace]);
             updatedRoot = updatedRoot.AddAttributeLists(CreateAssemblyRegisteredDefaultProviderAttribute(providerName));
             return document.WithSyntaxRoot(updatedRoot);
         }
@@ -1395,22 +1398,66 @@ namespace FastMoq.Analyzers.CodeFixes
 
         private static SyntaxNode AddUsingDirectiveIfMissing(SyntaxNode root, string namespaceName)
         {
-            if (root is CompilationUnitSyntax compilationUnit && !compilationUnit.Usings.Any(@using => @using.Name?.ToString() == namespaceName))
+            return AddUsingDirectiveIfMissing(root, compilation: null, namespaceName);
+        }
+
+        private static SyntaxNode AddUsingDirectiveIfMissing(SyntaxNode root, Compilation? compilation, string namespaceName)
+        {
+            if (root is not CompilationUnitSyntax compilationUnit || IsNamespaceAlreadyImported(compilationUnit, compilation, namespaceName))
             {
-                return compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+                return root;
+            }
+
+            return compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+        }
+
+        private static SyntaxNode AddUsingDirectivesIfMissing(SyntaxNode root, IReadOnlyList<string> namespaceNames)
+        {
+            return AddUsingDirectivesIfMissing(root, compilation: null, namespaceNames);
+        }
+
+        private static SyntaxNode AddUsingDirectivesIfMissing(SyntaxNode root, Compilation? compilation, IReadOnlyList<string> namespaceNames)
+        {
+            foreach (var namespaceName in namespaceNames)
+            {
+                root = AddUsingDirectiveIfMissing(root, compilation, namespaceName);
             }
 
             return root;
         }
 
-        private static SyntaxNode AddUsingDirectivesIfMissing(SyntaxNode root, IReadOnlyList<string> namespaceNames)
+        private static bool IsNamespaceAlreadyImported(CompilationUnitSyntax compilationUnit, Compilation? compilation, string namespaceName)
         {
-            foreach (var namespaceName in namespaceNames)
+            if (compilationUnit.DescendantNodes().OfType<UsingDirectiveSyntax>().Any(@using => @using.Name?.ToString() == namespaceName))
             {
-                root = AddUsingDirectiveIfMissing(root, namespaceName);
+                return true;
             }
 
-            return root;
+            if (compilation is null)
+            {
+                return false;
+            }
+
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                if (syntaxTree.GetRoot() is not CompilationUnitSyntax candidateCompilationUnit)
+                {
+                    continue;
+                }
+
+                if (candidateCompilationUnit.Usings.Any(@using => @using.GlobalKeyword != default && @using.Name?.ToString() == namespaceName))
+                {
+                    return true;
+                }
+            }
+
+            if (compilation.Options is CSharpCompilationOptions csharpCompilationOptions &&
+                csharpCompilationOptions.Usings.Any(@using => string.Equals(@using, namespaceName, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static InvocationExpressionSyntax? FindInvocationExpression(SyntaxNode root, TextSpan span)
@@ -1466,27 +1513,29 @@ namespace FastMoq.Analyzers.CodeFixes
                     continue;
                 }
 
-                foreach (var identifierName in member.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+                foreach (var memberAccess in member.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
                 {
-                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol, helperField))
+                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol, helperField))
                     {
                         continue;
                     }
 
-                    if (identifierName.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == identifierName)
+                    if (!aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
                     {
-                        if (!aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
-                        {
-                            return false;
-                        }
+                        return false;
+                    }
 
-                        memberAccessReplacements.Add(new DirectMockerTestBaseInheritanceReplacement(memberAccess, $"base.{baseMemberName}"));
+                    memberAccessReplacements.Add(new DirectMockerTestBaseInheritanceReplacement(memberAccess, $"base.{baseMemberName}"));
+                }
+
+                foreach (var assignmentExpression in member.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignmentExpression.Left, cancellationToken).Symbol, helperField))
+                    {
                         continue;
                     }
 
-                    if (identifierName.Parent is AssignmentExpressionSyntax assignmentExpression &&
-                        assignmentExpression.Left == identifierName &&
-                        assignmentExpression.Parent is ExpressionStatementSyntax expressionStatement &&
+                    if (assignmentExpression.Parent is ExpressionStatementSyntax expressionStatement &&
                         TryIsHelperConstructionAssignment(assignmentExpression.Right, candidate.HelperType, semanticModel, cancellationToken))
                     {
                         statementsToRemove.Add(expressionStatement);
@@ -1513,12 +1562,12 @@ namespace FastMoq.Analyzers.CodeFixes
 
             foreach (var propertyDeclaration in helperTypeDeclaration.Members.OfType<PropertyDeclarationSyntax>())
             {
-                if (!TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
+                if (!FastMoqAnalysisHelpers.TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
                 {
                     return false;
                 }
 
-                expression = UnwrapExpression(expression);
+                expression = FastMoqAnalysisHelpers.Unwrap(expression);
                 string? baseMemberName = expression switch
                 {
                     IdentifierNameSyntax identifierName when identifierName.Identifier.ValueText is "Component" or "Mocks" => identifierName.Identifier.ValueText,
@@ -1535,44 +1584,6 @@ namespace FastMoq.Analyzers.CodeFixes
             }
 
             return aliasMap.Count > 0;
-        }
-
-        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
-        {
-            if (propertyDeclaration.ExpressionBody is not null)
-            {
-                expression = propertyDeclaration.ExpressionBody.Expression;
-                return true;
-            }
-
-            if (propertyDeclaration.AccessorList?.Accessors.Count == 1 && propertyDeclaration.AccessorList.Accessors[0].Keyword.IsKind(SyntaxKind.GetKeyword))
-            {
-                var getter = propertyDeclaration.AccessorList.Accessors[0];
-                if (getter.ExpressionBody is not null)
-                {
-                    expression = getter.ExpressionBody.Expression;
-                    return true;
-                }
-
-                if (getter.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement && returnStatement.Expression is not null)
-                {
-                    expression = returnStatement.Expression;
-                    return true;
-                }
-            }
-
-            expression = default!;
-            return false;
-        }
-
-        private static ExpressionSyntax UnwrapExpression(ExpressionSyntax expression)
-        {
-            while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
-            {
-                expression = parenthesizedExpression.Expression;
-            }
-
-            return expression;
         }
 
         private static bool TryIsHelperConstructionAssignment(ExpressionSyntax expression, INamedTypeSymbol helperType, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -647,6 +647,9 @@ namespace FastMoq.Analyzers.CodeFixes
             var memberAccessAnnotations = fix.MemberAccessReplacements
                 .Select(item => (Replacement: item, Annotation: new SyntaxAnnotation()))
                 .ToArray();
+            var memberRemovalAnnotations = fix.MembersToRemove
+                .Select(item => (Member: item, Annotation: new SyntaxAnnotation()))
+                .ToArray();
             var statementAnnotations = fix.StatementsToRemove
                 .Select(item => (Statement: item, Annotation: new SyntaxAnnotation()))
                 .ToArray();
@@ -657,6 +660,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 fix.HelperFieldDeclaration,
             };
             nodesToAnnotate.AddRange(memberAccessAnnotations.Select(item => (SyntaxNode) item.Replacement.MemberAccess));
+            nodesToAnnotate.AddRange(memberRemovalAnnotations.Select(item => (SyntaxNode) item.Member));
             nodesToAnnotate.AddRange(statementAnnotations.Select(item => (SyntaxNode) item.Statement));
 
             var updatedRoot = root.ReplaceNodes(
@@ -684,6 +688,12 @@ namespace FastMoq.Analyzers.CodeFixes
                         return rewrittenNode.WithAdditionalAnnotations(memberAccessAnnotation);
                     }
 
+                    var memberRemovalAnnotation = memberRemovalAnnotations.SingleOrDefault(item => item.Member == originalNode).Annotation;
+                    if (memberRemovalAnnotation is not null)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(memberRemovalAnnotation);
+                    }
+
                     var statementAnnotation = statementAnnotations.Single(item => item.Statement == originalNode).Annotation;
                     return rewrittenNode.WithAdditionalAnnotations(statementAnnotation);
                 });
@@ -707,6 +717,15 @@ namespace FastMoq.Analyzers.CodeFixes
                 if (currentStatement is not null)
                 {
                     updatedRoot = updatedRoot.RemoveNode(currentStatement, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
+                }
+            }
+
+            foreach (var (_, annotation) in memberRemovalAnnotations)
+            {
+                var currentMember = updatedRoot.GetAnnotatedNodes(annotation).OfType<MemberDeclarationSyntax>().SingleOrDefault();
+                if (currentMember is not null)
+                {
+                    updatedRoot = updatedRoot.RemoveNode(currentMember, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
                 }
             }
 
@@ -1504,12 +1523,19 @@ namespace FastMoq.Analyzers.CodeFixes
             }
 
             var memberAccessReplacements = new List<DirectMockerTestBaseInheritanceReplacement>();
+            var membersToRemove = new List<MemberDeclarationSyntax>();
             var statementsToRemove = new List<StatementSyntax>();
 
             foreach (var member in classDeclaration.Members)
             {
                 if (member == candidate.HelperTypeDeclaration || member == helperFieldDeclaration)
                 {
+                    continue;
+                }
+
+                if (TryGetRedundantOuterHelperAliasMemberToRemove(member, helperField, aliasMap, semanticModel, cancellationToken))
+                {
+                    membersToRemove.Add(member);
                     continue;
                 }
 
@@ -1551,8 +1577,35 @@ namespace FastMoq.Analyzers.CodeFixes
                 helperFieldDeclaration,
                 candidate.TargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                 memberAccessReplacements,
+                membersToRemove,
                 statementsToRemove);
             return true;
+        }
+
+        private static bool TryGetRedundantOuterHelperAliasMemberToRemove(
+            MemberDeclarationSyntax member,
+            IFieldSymbol helperField,
+            IReadOnlyDictionary<string, string> aliasMap,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken)
+        {
+            if (member is not PropertyDeclarationSyntax propertyDeclaration ||
+                propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword) ||
+                propertyDeclaration.Identifier.ValueText is not "Component" and not "Mocks" ||
+                !FastMoqAnalysisHelpers.TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
+            {
+                return false;
+            }
+
+            expression = FastMoqAnalysisHelpers.Unwrap(expression);
+            if (expression is not MemberAccessExpressionSyntax memberAccess ||
+                !TryGetReferencedHelperExpression(memberAccess.Expression, helperField, semanticModel, cancellationToken, out _) ||
+                !aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
+            {
+                return false;
+            }
+
+            return string.Equals(baseMemberName, propertyDeclaration.Identifier.ValueText, StringComparison.Ordinal);
         }
 
         private static bool TryGetHelperAliasMap(TypeDeclarationSyntax helperTypeDeclaration, out Dictionary<string, string> aliasMap)
@@ -1647,6 +1700,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 FieldDeclarationSyntax helperFieldDeclaration,
                 string targetTypeName,
                 IReadOnlyList<DirectMockerTestBaseInheritanceReplacement> memberAccessReplacements,
+                IReadOnlyList<MemberDeclarationSyntax> membersToRemove,
                 IReadOnlyList<StatementSyntax> statementsToRemove)
             {
                 OuterClassDeclaration = outerClassDeclaration;
@@ -1654,6 +1708,7 @@ namespace FastMoq.Analyzers.CodeFixes
                 HelperFieldDeclaration = helperFieldDeclaration;
                 TargetTypeName = targetTypeName;
                 MemberAccessReplacements = memberAccessReplacements;
+                MembersToRemove = membersToRemove;
                 StatementsToRemove = statementsToRemove;
             }
 
@@ -1666,6 +1721,8 @@ namespace FastMoq.Analyzers.CodeFixes
             public string TargetTypeName { get; }
 
             public IReadOnlyList<DirectMockerTestBaseInheritanceReplacement> MemberAccessReplacements { get; }
+
+            public IReadOnlyList<MemberDeclarationSyntax> MembersToRemove { get; }
 
             public IReadOnlyList<StatementSyntax> StatementsToRemove { get; }
         }

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -1513,29 +1513,28 @@ namespace FastMoq.Analyzers.CodeFixes
                     continue;
                 }
 
-                foreach (var memberAccess in member.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+                foreach (var helperReference in member.DescendantNodesAndSelf().OfType<ExpressionSyntax>())
                 {
-                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol, helperField))
+                    if (!TryGetReferencedHelperExpression(helperReference, helperField, semanticModel, cancellationToken, out var referencedHelperExpression))
                     {
                         continue;
                     }
 
-                    if (!aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
+                    if (helperReference.Parent is MemberAccessExpressionSyntax memberAccess &&
+                        memberAccess.Expression == helperReference)
                     {
-                        return false;
-                    }
+                        if (!aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
+                        {
+                            return false;
+                        }
 
-                    memberAccessReplacements.Add(new DirectMockerTestBaseInheritanceReplacement(memberAccess, $"base.{baseMemberName}"));
-                }
-
-                foreach (var assignmentExpression in member.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
-                {
-                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignmentExpression.Left, cancellationToken).Symbol, helperField))
-                    {
+                        memberAccessReplacements.Add(new DirectMockerTestBaseInheritanceReplacement(memberAccess, $"base.{baseMemberName}"));
                         continue;
                     }
 
-                    if (assignmentExpression.Parent is ExpressionStatementSyntax expressionStatement &&
+                    if (helperReference.Parent is AssignmentExpressionSyntax assignmentExpression &&
+                        assignmentExpression.Left == referencedHelperExpression &&
+                        assignmentExpression.Parent is ExpressionStatementSyntax expressionStatement &&
                         TryIsHelperConstructionAssignment(assignmentExpression.Right, candidate.HelperType, semanticModel, cancellationToken))
                     {
                         statementsToRemove.Add(expressionStatement);
@@ -1588,8 +1587,42 @@ namespace FastMoq.Analyzers.CodeFixes
 
         private static bool TryIsHelperConstructionAssignment(ExpressionSyntax expression, INamedTypeSymbol helperType, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
+            if (expression is not ObjectCreationExpressionSyntax && expression is not ImplicitObjectCreationExpressionSyntax)
+            {
+                return false;
+            }
+
             var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type as INamedTypeSymbol;
             return type is not null && SymbolEqualityComparer.Default.Equals(type, helperType);
+        }
+
+        private static bool TryGetReferencedHelperExpression(ExpressionSyntax expression, IFieldSymbol helperField, SemanticModel semanticModel, CancellationToken cancellationToken, out ExpressionSyntax referencedHelperExpression)
+        {
+            if (expression is IdentifierNameSyntax identifierName)
+            {
+                if (identifierName.Parent is MemberAccessExpressionSyntax parentMemberAccess &&
+                    parentMemberAccess.Name == identifierName)
+                {
+                    referencedHelperExpression = default!;
+                    return false;
+                }
+
+                if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol, helperField))
+                {
+                    referencedHelperExpression = identifierName;
+                    return true;
+                }
+            }
+
+            if (expression is MemberAccessExpressionSyntax memberAccess &&
+                SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol, helperField))
+            {
+                referencedHelperExpression = expression;
+                return true;
+            }
+
+            referencedHelperExpression = default!;
+            return false;
         }
 
         private readonly struct DirectMockerTestBaseInheritanceFix

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -26,6 +26,7 @@ namespace FastMoq.Analyzers.CodeFixes
             DiagnosticIds.UseProviderFirstReset,
             DiagnosticIds.UseVerifyLogged,
             DiagnosticIds.PreferSetupLoggerCallbackHelper,
+            DiagnosticIds.DirectMockerTestBaseInheritance,
             DiagnosticIds.UseProviderFirstVerify,
             DiagnosticIds.AvoidFastMockVerifyHelperWrappers,
             DiagnosticIds.AvoidProviderSpecificFastMockVerifyHelperWrappers,
@@ -124,6 +125,30 @@ namespace FastMoq.Analyzers.CodeFixes
                                 "Use SetupLoggerCallback(...)",
                                 cancellationToken => ReplaceSetupLoggerCallbackInvocationAsync(document, invocationExpression, cancellationToken),
                                 nameof(DiagnosticIds.PreferSetupLoggerCallbackHelper)),
+                            diagnostic);
+                        break;
+                    }
+
+                case DiagnosticIds.DirectMockerTestBaseInheritance:
+                    {
+                        var classDeclaration = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                        if (classDeclaration is null)
+                        {
+                            return;
+                        }
+
+                        var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                        if (semanticModel is null ||
+                            !TryBuildDirectMockerTestBaseInheritanceFix(classDeclaration, semanticModel, context.CancellationToken, out _))
+                        {
+                            return;
+                        }
+
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Use direct MockerTestBase inheritance",
+                                cancellationToken => ReplaceDirectMockerTestBaseInheritanceAsync(document, classDeclaration, cancellationToken),
+                                nameof(DiagnosticIds.DirectMockerTestBaseInheritance)),
                             diagnostic);
                         break;
                     }
@@ -602,6 +627,108 @@ namespace FastMoq.Analyzers.CodeFixes
             {
                 updatedRoot = AddUsingDirectiveIfMissing(updatedRoot, FastMoqAnalysisHelpers.FastMoqProvidersNamespace);
             }
+
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+
+        private static async Task<Document> ReplaceDirectMockerTestBaseInheritanceAsync(Document document, ClassDeclarationSyntax classDeclaration, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null ||
+                !TryBuildDirectMockerTestBaseInheritanceFix(classDeclaration, semanticModel, cancellationToken, out var fix))
+            {
+                return document;
+            }
+
+            var outerAnnotation = new SyntaxAnnotation();
+            var helperDeclarationAnnotation = new SyntaxAnnotation();
+            var helperFieldAnnotation = new SyntaxAnnotation();
+            var memberAccessAnnotations = fix.MemberAccessReplacements
+                .Select(item => (Replacement: item, Annotation: new SyntaxAnnotation()))
+                .ToArray();
+            var statementAnnotations = fix.StatementsToRemove
+                .Select(item => (Statement: item, Annotation: new SyntaxAnnotation()))
+                .ToArray();
+            var nodesToAnnotate = new List<SyntaxNode>
+            {
+                fix.OuterClassDeclaration,
+                fix.HelperTypeDeclaration,
+                fix.HelperFieldDeclaration,
+            };
+            nodesToAnnotate.AddRange(memberAccessAnnotations.Select(item => (SyntaxNode) item.Replacement.MemberAccess));
+            nodesToAnnotate.AddRange(statementAnnotations.Select(item => (SyntaxNode) item.Statement));
+
+            var updatedRoot = root.ReplaceNodes(
+                nodesToAnnotate,
+                (originalNode, rewrittenNode) =>
+                {
+                    if (originalNode == fix.OuterClassDeclaration)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(outerAnnotation);
+                    }
+
+                    if (originalNode == fix.HelperTypeDeclaration)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(helperDeclarationAnnotation);
+                    }
+
+                    if (originalNode == fix.HelperFieldDeclaration)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(helperFieldAnnotation);
+                    }
+
+                    var memberAccessAnnotation = memberAccessAnnotations.SingleOrDefault(item => item.Replacement.MemberAccess == originalNode).Annotation;
+                    if (memberAccessAnnotation is not null)
+                    {
+                        return rewrittenNode.WithAdditionalAnnotations(memberAccessAnnotation);
+                    }
+
+                    var statementAnnotation = statementAnnotations.Single(item => item.Statement == originalNode).Annotation;
+                    return rewrittenNode.WithAdditionalAnnotations(statementAnnotation);
+                });
+
+            foreach (var (replacement, annotation) in memberAccessAnnotations)
+            {
+                var currentMemberAccess = updatedRoot.GetAnnotatedNodes(annotation).OfType<MemberAccessExpressionSyntax>().SingleOrDefault();
+                if (currentMemberAccess is null)
+                {
+                    continue;
+                }
+
+                updatedRoot = updatedRoot.ReplaceNode(
+                    currentMemberAccess,
+                    SyntaxFactory.ParseExpression(replacement.ReplacementText).WithTriviaFrom(currentMemberAccess));
+            }
+
+            foreach (var (_, annotation) in statementAnnotations)
+            {
+                var currentStatement = updatedRoot.GetAnnotatedNodes(annotation).OfType<StatementSyntax>().SingleOrDefault();
+                if (currentStatement is not null)
+                {
+                    updatedRoot = updatedRoot.RemoveNode(currentStatement, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
+                }
+            }
+
+            var helperDeclarationNode = updatedRoot.GetAnnotatedNodes(helperDeclarationAnnotation).SingleOrDefault();
+            if (helperDeclarationNode is not null)
+            {
+                updatedRoot = updatedRoot.RemoveNode(helperDeclarationNode, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
+            }
+
+            var helperFieldNode = updatedRoot.GetAnnotatedNodes(helperFieldAnnotation).SingleOrDefault();
+            if (helperFieldNode is not null)
+            {
+                updatedRoot = updatedRoot.RemoveNode(helperFieldNode, SyntaxRemoveOptions.KeepExteriorTrivia) ?? updatedRoot;
+            }
+
+            var annotatedOuter = (ClassDeclarationSyntax) updatedRoot.GetAnnotatedNodes(outerAnnotation).Single();
+            var replacementOuter = annotatedOuter.WithBaseList(
+                SyntaxFactory.BaseList(
+                    SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(
+                        SyntaxFactory.SimpleBaseType(
+                            SyntaxFactory.ParseTypeName($"MockerTestBase<{fix.TargetTypeName}>")))));
+            updatedRoot = updatedRoot.ReplaceNode(annotatedOuter, replacementOuter);
 
             return document.WithSyntaxRoot(updatedRoot);
         }
@@ -1298,6 +1425,194 @@ namespace FastMoq.Analyzers.CodeFixes
             parsedStatements[0] = parsedStatements[0].WithLeadingTrivia(originalStatement.GetLeadingTrivia());
             parsedStatements[parsedStatements.Length - 1] = parsedStatements[parsedStatements.Length - 1].WithTrailingTrivia(originalStatement.GetTrailingTrivia());
             return parsedStatements;
+        }
+
+        private static bool TryBuildDirectMockerTestBaseInheritanceFix(
+            ClassDeclarationSyntax classDeclaration,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            out DirectMockerTestBaseInheritanceFix fix)
+        {
+            fix = default;
+
+            if (!FastMoqAnalysisHelpers.TryGetDirectMockerTestBaseInheritanceCandidate(classDeclaration, semanticModel, cancellationToken, out var candidate) ||
+                !candidate.IsFixable ||
+                candidate.HelperMember is not IFieldSymbol helperField ||
+                helperField.DeclaringSyntaxReferences.SingleOrDefault()?.GetSyntax(cancellationToken) is not VariableDeclaratorSyntax helperVariable ||
+                helperVariable.Parent?.Parent is not FieldDeclarationSyntax helperFieldDeclaration ||
+                helperFieldDeclaration.Declaration.Variables.Count != 1 ||
+                !TryGetHelperAliasMap(candidate.HelperTypeDeclaration, out var aliasMap))
+            {
+                return false;
+            }
+
+            var memberAccessReplacements = new List<DirectMockerTestBaseInheritanceReplacement>();
+            var statementsToRemove = new List<StatementSyntax>();
+
+            foreach (var member in classDeclaration.Members)
+            {
+                if (member == candidate.HelperTypeDeclaration || member == helperFieldDeclaration)
+                {
+                    continue;
+                }
+
+                foreach (var identifierName in member.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol, helperField))
+                    {
+                        continue;
+                    }
+
+                    if (identifierName.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == identifierName)
+                    {
+                        if (!aliasMap.TryGetValue(memberAccess.Name.Identifier.ValueText, out var baseMemberName))
+                        {
+                            return false;
+                        }
+
+                        memberAccessReplacements.Add(new DirectMockerTestBaseInheritanceReplacement(memberAccess, $"base.{baseMemberName}"));
+                        continue;
+                    }
+
+                    if (identifierName.Parent is AssignmentExpressionSyntax assignmentExpression &&
+                        assignmentExpression.Left == identifierName &&
+                        assignmentExpression.Parent is ExpressionStatementSyntax expressionStatement &&
+                        TryIsHelperConstructionAssignment(assignmentExpression.Right, candidate.HelperType, semanticModel, cancellationToken))
+                    {
+                        statementsToRemove.Add(expressionStatement);
+                        continue;
+                    }
+
+                    return false;
+                }
+            }
+
+            fix = new DirectMockerTestBaseInheritanceFix(
+                classDeclaration,
+                candidate.HelperTypeDeclaration,
+                helperFieldDeclaration,
+                candidate.TargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                memberAccessReplacements,
+                statementsToRemove);
+            return true;
+        }
+
+        private static bool TryGetHelperAliasMap(TypeDeclarationSyntax helperTypeDeclaration, out Dictionary<string, string> aliasMap)
+        {
+            aliasMap = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var propertyDeclaration in helperTypeDeclaration.Members.OfType<PropertyDeclarationSyntax>())
+            {
+                if (!TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
+                {
+                    return false;
+                }
+
+                expression = UnwrapExpression(expression);
+                string? baseMemberName = expression switch
+                {
+                    IdentifierNameSyntax identifierName when identifierName.Identifier.ValueText is "Component" or "Mocks" => identifierName.Identifier.ValueText,
+                    MemberAccessExpressionSyntax memberAccess when memberAccess.Expression is ThisExpressionSyntax && memberAccess.Name.Identifier.ValueText is "Component" or "Mocks" => memberAccess.Name.Identifier.ValueText,
+                    _ => null,
+                };
+
+                if (baseMemberName is null)
+                {
+                    return false;
+                }
+
+                aliasMap[propertyDeclaration.Identifier.ValueText] = baseMemberName;
+            }
+
+            return aliasMap.Count > 0;
+        }
+
+        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
+        {
+            if (propertyDeclaration.ExpressionBody is not null)
+            {
+                expression = propertyDeclaration.ExpressionBody.Expression;
+                return true;
+            }
+
+            if (propertyDeclaration.AccessorList?.Accessors.Count == 1 && propertyDeclaration.AccessorList.Accessors[0].Keyword.IsKind(SyntaxKind.GetKeyword))
+            {
+                var getter = propertyDeclaration.AccessorList.Accessors[0];
+                if (getter.ExpressionBody is not null)
+                {
+                    expression = getter.ExpressionBody.Expression;
+                    return true;
+                }
+
+                if (getter.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement && returnStatement.Expression is not null)
+                {
+                    expression = returnStatement.Expression;
+                    return true;
+                }
+            }
+
+            expression = default!;
+            return false;
+        }
+
+        private static ExpressionSyntax UnwrapExpression(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
+            {
+                expression = parenthesizedExpression.Expression;
+            }
+
+            return expression;
+        }
+
+        private static bool TryIsHelperConstructionAssignment(ExpressionSyntax expression, INamedTypeSymbol helperType, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type as INamedTypeSymbol;
+            return type is not null && SymbolEqualityComparer.Default.Equals(type, helperType);
+        }
+
+        private readonly struct DirectMockerTestBaseInheritanceFix
+        {
+            public DirectMockerTestBaseInheritanceFix(
+                ClassDeclarationSyntax outerClassDeclaration,
+                TypeDeclarationSyntax helperTypeDeclaration,
+                FieldDeclarationSyntax helperFieldDeclaration,
+                string targetTypeName,
+                IReadOnlyList<DirectMockerTestBaseInheritanceReplacement> memberAccessReplacements,
+                IReadOnlyList<StatementSyntax> statementsToRemove)
+            {
+                OuterClassDeclaration = outerClassDeclaration;
+                HelperTypeDeclaration = helperTypeDeclaration;
+                HelperFieldDeclaration = helperFieldDeclaration;
+                TargetTypeName = targetTypeName;
+                MemberAccessReplacements = memberAccessReplacements;
+                StatementsToRemove = statementsToRemove;
+            }
+
+            public ClassDeclarationSyntax OuterClassDeclaration { get; }
+
+            public TypeDeclarationSyntax HelperTypeDeclaration { get; }
+
+            public FieldDeclarationSyntax HelperFieldDeclaration { get; }
+
+            public string TargetTypeName { get; }
+
+            public IReadOnlyList<DirectMockerTestBaseInheritanceReplacement> MemberAccessReplacements { get; }
+
+            public IReadOnlyList<StatementSyntax> StatementsToRemove { get; }
+        }
+
+        private readonly struct DirectMockerTestBaseInheritanceReplacement
+        {
+            public DirectMockerTestBaseInheritanceReplacement(MemberAccessExpressionSyntax memberAccess, string replacementText)
+            {
+                MemberAccess = memberAccess;
+                ReplacementText = replacementText;
+            }
+
+            public MemberAccessExpressionSyntax MemberAccess { get; }
+
+            public string ReplacementText { get; }
         }
 
         private static bool TryBuildProviderNeutralHttpHelperEdit(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out ProviderNeutralHttpHelperEdit edit)

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -723,11 +723,21 @@ namespace FastMoq.Analyzers.CodeFixes
             }
 
             var annotatedOuter = (ClassDeclarationSyntax) updatedRoot.GetAnnotatedNodes(outerAnnotation).Single();
+            var baseTypes = new SeparatedSyntaxList<BaseTypeSyntax>()
+                .Add(
+                    SyntaxFactory.SimpleBaseType(
+                        SyntaxFactory.ParseTypeName($"MockerTestBase<{fix.TargetTypeName}>")));
+
+            if (annotatedOuter.BaseList is not null)
+            {
+                foreach (var existingBaseType in annotatedOuter.BaseList.Types)
+                {
+                    baseTypes = baseTypes.Add(existingBaseType);
+                }
+            }
+
             var replacementOuter = annotatedOuter.WithBaseList(
-                SyntaxFactory.BaseList(
-                    SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(
-                        SyntaxFactory.SimpleBaseType(
-                            SyntaxFactory.ParseTypeName($"MockerTestBase<{fix.TargetTypeName}>")))));
+                SyntaxFactory.BaseList(baseTypes));
             updatedRoot = updatedRoot.ReplaceNode(annotatedOuter, replacementOuter);
 
             return document.WithSyntaxRoot(updatedRoot);

--- a/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
+++ b/FastMoq.Analyzers/CodeFixes/FastMoqMigrationCodeFixProvider.cs
@@ -1428,7 +1428,7 @@ namespace FastMoq.Analyzers.CodeFixes
 
         private static bool IsNamespaceAlreadyImported(CompilationUnitSyntax compilationUnit, Compilation? compilation, string namespaceName)
         {
-            if (compilationUnit.DescendantNodes().OfType<UsingDirectiveSyntax>().Any(@using => @using.Name?.ToString() == namespaceName))
+            if (compilationUnit.Usings.Any(@using => @using.Name?.ToString() == namespaceName))
             {
                 return true;
             }
@@ -1587,7 +1587,21 @@ namespace FastMoq.Analyzers.CodeFixes
 
         private static bool TryIsHelperConstructionAssignment(ExpressionSyntax expression, INamedTypeSymbol helperType, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (expression is not ObjectCreationExpressionSyntax && expression is not ImplicitObjectCreationExpressionSyntax)
+            if (expression is ObjectCreationExpressionSyntax objectCreationExpression)
+            {
+                if (objectCreationExpression.Initializer is not null)
+                {
+                    return false;
+                }
+            }
+            else if (expression is ImplicitObjectCreationExpressionSyntax implicitObjectCreationExpression)
+            {
+                if (implicitObjectCreationExpression.Initializer is not null)
+                {
+                    return false;
+                }
+            }
+            else
             {
                 return false;
             }

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -343,7 +343,7 @@ namespace FastMoq.Analyzers
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "When a local nested helper only wraps MockerTestBase<TComponent> for a single outer test class, prefer direct inheritance on the outer class or a manually authored shared intermediate base instead of keeping the helper as an extra instance-composition layer. Phase 1 keeps the automatic fix narrow and only rewrites clearly mechanical local wrapper shapes.");
+            description: "When a nested helper only wraps MockerTestBase<T> for one test class, prefer inheriting from MockerTestBase<T> on the test class itself or extracting a shared base when multiple tests need the same setup. Keep the helper only when it adds meaningful behavior beyond forwarding the inherited FastMoq surface.");
 
         public static readonly DiagnosticDescriptor UnnecessaryMockerTestBaseHelperIndirection = new(
             DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection,
@@ -352,6 +352,6 @@ namespace FastMoq.Analyzers
             Category,
             DiagnosticSeverity.Info,
             isEnabledByDefault: true,
-            description: "Thin aliases such as helper-backed Component or Mocks accessors, and helper members that only forward to inherited tracked-mock retrieval, can add another indirection layer without improving behavior. Keep the advisory rule conservative and leave readability- or behavior-improving wrappers alone.");
+            description: "When a helper property or method only forwards to inherited MockerTestBase<T> members such as Component or Mocks, prefer using the inherited member directly instead of keeping an extra wrapper. Keep the wrapper when it adds readability, setup, naming value, or other behavior that the inherited member does not provide.");
     }
 }

--- a/FastMoq.Analyzers/DiagnosticDescriptors.cs
+++ b/FastMoq.Analyzers/DiagnosticDescriptors.cs
@@ -335,5 +335,23 @@ namespace FastMoq.Analyzers
             DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: "Some provider-first helper replacements live in split FastMoq packages such as FastMoq.Web or FastMoq.AzureFunctions. When the helper package is missing, guide the user to the package and namespace instead of surfacing a non-actionable rewrite diagnostic.");
+
+        public static readonly DiagnosticDescriptor DirectMockerTestBaseInheritance = new(
+            DiagnosticIds.DirectMockerTestBaseInheritance,
+            "Prefer inheritance over MockerTestBase helper composition",
+            "Nested helper '{2}' composes MockerTestBase<{1}> through an instance wrapper. Prefer inheritance in test class '{0}' directly or through a dedicated shared test base.",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "When a local nested helper only wraps MockerTestBase<TComponent> for a single outer test class, prefer direct inheritance on the outer class or a manually authored shared intermediate base instead of keeping the helper as an extra instance-composition layer. Phase 1 keeps the automatic fix narrow and only rewrites clearly mechanical local wrapper shapes.");
+
+        public static readonly DiagnosticDescriptor UnnecessaryMockerTestBaseHelperIndirection = new(
+            DiagnosticIds.UnnecessaryMockerTestBaseHelperIndirection,
+            "Avoid unnecessary MockerTestBase helper indirection",
+            "Helper member '{0}' only forwards to inherited MockerTestBase behavior through '{1}'. Prefer the inherited surface directly when the wrapper adds no meaningful behavior.",
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Thin aliases such as helper-backed Component or Mocks accessors, and helper members that only forward to inherited tracked-mock retrieval, can add another indirection layer without improving behavior. Keep the advisory rule conservative and leave readability- or behavior-improving wrappers alone.");
     }
 }

--- a/FastMoq.Analyzers/DiagnosticIds.cs
+++ b/FastMoq.Analyzers/DiagnosticIds.cs
@@ -184,5 +184,15 @@ namespace FastMoq.Analyzers
         /// Prefer provider-neutral logger callback capture over provider-specific ILogger.Log setup when the callback only needs normalized output.
         /// </summary>
         public const string PreferSetupLoggerCallbackHelper = "FMOQ0036";
+
+        /// <summary>
+        /// Prefer inheritance over thin local helper-instance composition around MockerTestBase&lt;T&gt;.
+        /// </summary>
+        public const string DirectMockerTestBaseInheritance = "FMOQ0037";
+
+        /// <summary>
+        /// Avoid unnecessary helper indirection around inherited MockerTestBase&lt;T&gt; members.
+        /// </summary>
+        public const string UnnecessaryMockerTestBaseHelperIndirection = "FMOQ0038";
     }
 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -4812,7 +4812,7 @@ namespace FastMoq.Analyzers
             };
         }
 
-        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
+        internal static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
         {
             if (propertyDeclaration.ExpressionBody is not null)
             {

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -67,6 +67,50 @@ namespace FastMoq.Analyzers
         ProviderSpecific,
     }
 
+    internal enum MockerTestBaseHelperCompositionFixBlockReason
+    {
+        None,
+        UnsupportedHooks,
+        UnsupportedForNow,
+    }
+
+    internal readonly struct MockerTestBaseHelperCompositionCandidate
+    {
+        public MockerTestBaseHelperCompositionCandidate(
+            TypeDeclarationSyntax outerTypeDeclaration,
+            INamedTypeSymbol outerType,
+            TypeDeclarationSyntax helperTypeDeclaration,
+            INamedTypeSymbol helperType,
+            ISymbol helperMember,
+            INamedTypeSymbol targetType,
+            MockerTestBaseHelperCompositionFixBlockReason fixBlockReason)
+        {
+            OuterTypeDeclaration = outerTypeDeclaration;
+            OuterType = outerType;
+            HelperTypeDeclaration = helperTypeDeclaration;
+            HelperType = helperType;
+            HelperMember = helperMember;
+            TargetType = targetType;
+            FixBlockReason = fixBlockReason;
+        }
+
+        public TypeDeclarationSyntax OuterTypeDeclaration { get; }
+
+        public INamedTypeSymbol OuterType { get; }
+
+        public TypeDeclarationSyntax HelperTypeDeclaration { get; }
+
+        public INamedTypeSymbol HelperType { get; }
+
+        public ISymbol HelperMember { get; }
+
+        public INamedTypeSymbol TargetType { get; }
+
+        public MockerTestBaseHelperCompositionFixBlockReason FixBlockReason { get; }
+
+        public bool IsFixable => FixBlockReason == MockerTestBaseHelperCompositionFixBlockReason.None;
+    }
+
     internal readonly struct ProviderRegistrationCandidate
     {
         public ProviderRegistrationCandidate(string providerName, ITypeSymbol? providerType)
@@ -4416,20 +4460,35 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
-            for (var current = containingType.BaseType; current is not null; current = current.BaseType)
+            return TryGetMockerTestBaseTargetType(containingType, out targetType);
+        }
+
+        public static bool TryGetDirectMockerTestBaseInheritanceCandidate(TypeDeclarationSyntax typeDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken, out MockerTestBaseHelperCompositionCandidate candidate)
+        {
+            semanticModel = GetSemanticModelForNode(typeDeclaration, semanticModel);
+
+            if (semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is not INamedTypeSymbol outerType ||
+                outerType.TypeKind != TypeKind.Class ||
+                outerType.IsStatic ||
+                (outerType.BaseType is not null && outerType.BaseType.SpecialType != SpecialType.System_Object) ||
+                !TryGetNestedMockerTestBaseHelperMember(typeDeclaration, semanticModel, cancellationToken, outerType, out var helperMember, out var helperTypeDeclaration, out var helperType) ||
+                !TryGetDirectMockerTestBaseTargetType(helperType, out var targetType) ||
+                !HelperHasThinWrapperShape(helperTypeDeclaration, out var hasUnsupportedHooks) ||
+                !TryGetHelperCompositionFixBlockReason(helperTypeDeclaration, hasUnsupportedHooks, out var fixBlockReason))
             {
-                if (current.OriginalDefinition.MetadataName == FASTMOQ_MOCKER_TEST_BASE_METADATA_NAME &&
-                    current.OriginalDefinition.ContainingNamespace.ToDisplayString() == "FastMoq" &&
-                    current.TypeArguments.Length == 1 &&
-                    current.TypeArguments[0] is INamedTypeSymbol namedTargetType)
-                {
-                    targetType = namedTargetType;
-                    return true;
-                }
+                candidate = default;
+                return false;
             }
 
-            targetType = default!;
-            return false;
+            candidate = new MockerTestBaseHelperCompositionCandidate(
+                typeDeclaration,
+                outerType,
+                helperTypeDeclaration,
+                helperType,
+                helperMember,
+                targetType,
+                fixBlockReason);
+            return true;
         }
 
         public static bool IsMoqVerifyMethod(IMethodSymbol method)
@@ -4521,6 +4580,287 @@ namespace FastMoq.Analyzers
         public static bool IsIFileSystemType(ITypeSymbol? type)
         {
             return type?.ToDisplayString() == IFileSystemTypeName;
+        }
+
+        private static bool TryGetMockerTestBaseTargetType(INamedTypeSymbol typeSymbol, out INamedTypeSymbol targetType)
+        {
+            for (var current = typeSymbol.BaseType; current is not null; current = current.BaseType)
+            {
+                if (TryGetMockerTestBaseTargetTypeCore(current, out targetType))
+                {
+                    return true;
+                }
+            }
+
+            targetType = default!;
+            return false;
+        }
+
+        private static bool TryGetDirectMockerTestBaseTargetType(INamedTypeSymbol typeSymbol, out INamedTypeSymbol targetType)
+        {
+            return TryGetMockerTestBaseTargetTypeCore(typeSymbol.BaseType, out targetType);
+        }
+
+        private static bool TryGetMockerTestBaseTargetTypeCore(INamedTypeSymbol? typeSymbol, out INamedTypeSymbol targetType)
+        {
+            if (typeSymbol is not null &&
+                typeSymbol.OriginalDefinition.MetadataName == FASTMOQ_MOCKER_TEST_BASE_METADATA_NAME &&
+                typeSymbol.OriginalDefinition.ContainingNamespace.ToDisplayString() == "FastMoq" &&
+                typeSymbol.TypeArguments.Length == 1 &&
+                typeSymbol.TypeArguments[0] is INamedTypeSymbol namedTargetType)
+            {
+                targetType = namedTargetType;
+                return true;
+            }
+
+            targetType = default!;
+            return false;
+        }
+
+        private static bool TryGetNestedMockerTestBaseHelperMember(
+            TypeDeclarationSyntax outerTypeDeclaration,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            INamedTypeSymbol outerType,
+            out ISymbol helperMember,
+            out TypeDeclarationSyntax helperTypeDeclaration,
+            out INamedTypeSymbol helperType)
+        {
+            var nestedTypes = outerTypeDeclaration.Members
+                .OfType<TypeDeclarationSyntax>()
+                .Select(typeSyntax => (TypeSyntax: typeSyntax, TypeSymbol: semanticModel.GetDeclaredSymbol(typeSyntax, cancellationToken) as INamedTypeSymbol))
+                .Where(item => item.TypeSymbol is not null)
+                .Select(item => (item.TypeSyntax, TypeSymbol: item.TypeSymbol!))
+                .ToDictionary(item => item.TypeSymbol, item => item.TypeSyntax, SymbolEqualityComparer.Default);
+
+            if (nestedTypes.Count == 0)
+            {
+                helperMember = default!;
+                helperTypeDeclaration = default!;
+                helperType = default!;
+                return false;
+            }
+
+            var candidates = new List<(ISymbol Member, TypeDeclarationSyntax HelperSyntax, INamedTypeSymbol HelperType)>();
+
+            foreach (var fieldDeclaration in outerTypeDeclaration.Members.OfType<FieldDeclarationSyntax>())
+            {
+                if (fieldDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword) ||
+                    semanticModel.GetTypeInfo(fieldDeclaration.Declaration.Type, cancellationToken).Type is not INamedTypeSymbol fieldType ||
+                    !SymbolEqualityComparer.Default.Equals(fieldType.ContainingType, outerType) ||
+                    !nestedTypes.TryGetValue(fieldType, out var nestedTypeSyntax))
+                {
+                    continue;
+                }
+
+                foreach (var variable in fieldDeclaration.Declaration.Variables)
+                {
+                    if (semanticModel.GetDeclaredSymbol(variable, cancellationToken) is IFieldSymbol fieldSymbol && !fieldSymbol.IsStatic)
+                    {
+                        candidates.Add((fieldSymbol, nestedTypeSyntax, fieldType));
+                    }
+                }
+            }
+
+            foreach (var propertyDeclaration in outerTypeDeclaration.Members.OfType<PropertyDeclarationSyntax>())
+            {
+                if (propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword) ||
+                    semanticModel.GetDeclaredSymbol(propertyDeclaration, cancellationToken) is not IPropertySymbol propertySymbol ||
+                    propertySymbol.IsStatic ||
+                    semanticModel.GetTypeInfo(propertyDeclaration.Type, cancellationToken).Type is not INamedTypeSymbol propertyType ||
+                    !SymbolEqualityComparer.Default.Equals(propertyType.ContainingType, outerType) ||
+                    !nestedTypes.TryGetValue(propertyType, out var nestedTypeSyntax))
+                {
+                    continue;
+                }
+
+                candidates.Add((propertySymbol, nestedTypeSyntax, propertyType));
+            }
+
+            var distinctCandidates = candidates
+                .Where(candidate => HasHelperMemberUsage(outerTypeDeclaration, candidate.Member, semanticModel, cancellationToken))
+                .Distinct(new HelperMemberCandidateComparer())
+                .ToArray();
+
+            if (distinctCandidates.Length != 1)
+            {
+                helperMember = default!;
+                helperTypeDeclaration = default!;
+                helperType = default!;
+                return false;
+            }
+
+            helperMember = distinctCandidates[0].Member;
+            helperTypeDeclaration = distinctCandidates[0].HelperSyntax;
+            helperType = distinctCandidates[0].HelperType;
+            return true;
+        }
+
+        private static bool HasHelperMemberUsage(TypeDeclarationSyntax outerTypeDeclaration, ISymbol helperMember, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            foreach (var member in outerTypeDeclaration.Members)
+            {
+                if (member is TypeDeclarationSyntax)
+                {
+                    continue;
+                }
+
+                foreach (var memberAccess in member.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+                {
+                    if (semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol is { } accessSymbol &&
+                        SymbolEqualityComparer.Default.Equals(accessSymbol, helperMember))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HelperHasThinWrapperShape(TypeDeclarationSyntax helperTypeDeclaration, out bool hasUnsupportedHooks)
+        {
+            hasUnsupportedHooks = false;
+
+            foreach (var member in helperTypeDeclaration.Members)
+            {
+                switch (member)
+                {
+                    case ConstructorDeclarationSyntax:
+                        continue;
+
+                    case PropertyDeclarationSyntax propertyDeclaration:
+                        {
+                            var propertyName = propertyDeclaration.Identifier.ValueText;
+                            if (propertyName is "ComponentConstructorParameterTypes" or "CreateComponentAction" or "CreatedComponentAction")
+                            {
+                                hasUnsupportedHooks = true;
+                                continue;
+                            }
+
+                            if (!IsThinHelperAliasProperty(propertyDeclaration))
+                            {
+                                return false;
+                            }
+
+                            continue;
+                        }
+
+                    case MethodDeclarationSyntax:
+                    case FieldDeclarationSyntax:
+                    case EventDeclarationSyntax:
+                    case EventFieldDeclarationSyntax:
+                    case IndexerDeclarationSyntax:
+                    case OperatorDeclarationSyntax:
+                    case ConversionOperatorDeclarationSyntax:
+                    case DestructorDeclarationSyntax:
+                    case TypeDeclarationSyntax:
+                        return false;
+
+                    default:
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryGetHelperCompositionFixBlockReason(
+            TypeDeclarationSyntax helperTypeDeclaration,
+            bool hasUnsupportedHooks,
+            out MockerTestBaseHelperCompositionFixBlockReason fixBlockReason)
+        {
+            if (hasUnsupportedHooks)
+            {
+                fixBlockReason = MockerTestBaseHelperCompositionFixBlockReason.UnsupportedHooks;
+                return true;
+            }
+
+            foreach (var constructorDeclaration in helperTypeDeclaration.Members.OfType<ConstructorDeclarationSyntax>())
+            {
+                if (constructorDeclaration.Initializer is not null)
+                {
+                    fixBlockReason = MockerTestBaseHelperCompositionFixBlockReason.UnsupportedForNow;
+                    return true;
+                }
+
+                if (constructorDeclaration.ExpressionBody is not null ||
+                    constructorDeclaration.Body?.Statements.Count > 0)
+                {
+                    fixBlockReason = MockerTestBaseHelperCompositionFixBlockReason.UnsupportedForNow;
+                    return true;
+                }
+            }
+
+            fixBlockReason = MockerTestBaseHelperCompositionFixBlockReason.None;
+            return true;
+        }
+
+        private static bool IsThinHelperAliasProperty(PropertyDeclarationSyntax propertyDeclaration)
+        {
+            if (!TryGetPropertyReturnExpression(propertyDeclaration, out var expression))
+            {
+                return false;
+            }
+
+            expression = Unwrap(expression);
+            return expression switch
+            {
+                IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText is "Component" or "Mocks",
+                MemberAccessExpressionSyntax memberAccess when memberAccess.Expression is ThisExpressionSyntax => memberAccess.Name.Identifier.ValueText is "Component" or "Mocks",
+                _ => false,
+            };
+        }
+
+        private static bool TryGetPropertyReturnExpression(PropertyDeclarationSyntax propertyDeclaration, out ExpressionSyntax expression)
+        {
+            if (propertyDeclaration.ExpressionBody is not null)
+            {
+                expression = propertyDeclaration.ExpressionBody.Expression;
+                return true;
+            }
+
+            if (propertyDeclaration.AccessorList is null)
+            {
+                expression = default!;
+                return false;
+            }
+
+            var accessors = propertyDeclaration.AccessorList.Accessors;
+            if (accessors.Count != 1 || !accessors[0].Keyword.IsKind(SyntaxKind.GetKeyword))
+            {
+                expression = default!;
+                return false;
+            }
+
+            var getter = accessors[0];
+            if (getter.ExpressionBody is not null)
+            {
+                expression = getter.ExpressionBody.Expression;
+                return true;
+            }
+
+            if (getter.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement && returnStatement.Expression is not null)
+            {
+                expression = returnStatement.Expression;
+                return true;
+            }
+
+            expression = default!;
+            return false;
+        }
+
+        private sealed class HelperMemberCandidateComparer : IEqualityComparer<(ISymbol Member, TypeDeclarationSyntax HelperSyntax, INamedTypeSymbol HelperType)>
+        {
+            public bool Equals((ISymbol Member, TypeDeclarationSyntax HelperSyntax, INamedTypeSymbol HelperType) x, (ISymbol Member, TypeDeclarationSyntax HelperSyntax, INamedTypeSymbol HelperType) y)
+            {
+                return SymbolEqualityComparer.Default.Equals(x.Member, y.Member);
+            }
+
+            public int GetHashCode((ISymbol Member, TypeDeclarationSyntax HelperSyntax, INamedTypeSymbol HelperType) obj)
+            {
+                return SymbolEqualityComparer.Default.GetHashCode(obj.Member);
+            }
         }
 
         public static bool IsMockFileSystemType(ITypeSymbol? type)

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -115,6 +115,8 @@ This is the full public analyzer catalog for the current v4 line. Use it as the 
 | `FMOQ0034` | Inside provider-first `Verify(...)`, replace mechanical `It.*` matchers with `FastArg` equivalents so the assertion stays provider-neutral |
 | `FMOQ0035` | Flag remaining Moq-specific matchers inside provider-first `Verify(...)` when no direct `FastArg` rewrite exists |
 | `FMOQ0036` | Prefer `SetupLoggerCallback(...)` over tracked `ILogger.Log<TState>` setup when the callback only needs normalized message or exception output |
+| `FMOQ0037` | Prefer direct inheritance or a shared inherited base over thin local helper-instance composition around `MockerTestBase<T>` |
+| `FMOQ0038` | Flag thin helper indirection that only forwards to inherited `MockerTestBase<T>` members without adding meaningful behavior |
 
 For a successful v4 migration, use this boundary:
 


### PR DESCRIPTION
## Summary
Add the helper-composition migration work for `MockerTestBase<T>` wrappers and thin helper indirection.

This PR:
- adds `FMOQ0037` and `FMOQ0038` ids, descriptors, and migration catalog entries
- adds one shared helper-composition classifier used by analyzer and code-fix paths
- adds the `FMOQ0037` analyzer plus a narrow direct-inheritance code fix
- adds the `FMOQ0038` advisory analyzer plus explicit regressions for `FMOQ0026`, `FMOQ0030`, `FMOQ0031`, and `FMOQ0032`
- preserves existing implemented interfaces during the `FMOQ0037` direct-inheritance rewrite

## Validation
- `dotnet test c:\Users\chriswin\source\repos\FastMoq\FastMoq.Analyzers.Tests\FastMoq.Analyzers.Tests.csproj`
- Full analyzer suite passed: `813` tests, `0` failures

## Issues
Closes #153
Closes #154
Closes #155
Closes #156