### PR TITLE
Fix provider analyzer effective provider resolution

### DIFF
--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -4798,6 +4798,47 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenCapturedLocalProviderVariableIsReassignedBeforeNestedLambdaExecutes()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var providerName = ""nsubstitute"";
+        Action run = () =>
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocks = new Mocker();
+            var dependency = mocks.GetOrCreateMock<IService>();
+            dependency.Received();
+        };
+
+        providerName = ""reflection"";
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldIgnoreTopLevelNestedLambdaProviderSelections_WhenDeterminingDefaults()
         {
             const string SOURCE = @"
@@ -4810,6 +4851,46 @@ Action bootstrap = () =>
 {
     using var providerScope = MockingProviderRegistry.Push(""moq"");
 };
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenProviderIsSelectedOnlyInStaticConstructor()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static Bootstrap()
+    {
+        MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance, setAsDefault: true);
+    }
+}
 
 class Sample
 {
@@ -5524,6 +5605,47 @@ class Sample
         }
 
         [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenCapturedLocalProviderVariableIsReassignedBeforeNestedLambdaExecutes()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var providerName = ""moq"";
+        Action run = () =>
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocks = new Mocker();
+            var dependency = mocks.GetMock<IService>();
+            dependency.AsMoq();
+        };
+
+        providerName = ""reflection"";
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new LegacyMoqOnboardingAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
+            Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
+        }
+
+        [Fact]
         public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenTheoryInlineDataAlwaysSelectsMoq()
         {
             const string SOURCE = @"
@@ -5556,6 +5678,46 @@ class Sample
                 includeNSubstituteProviderPackage: false,
                 new LegacyMoqOnboardingAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenProviderIsSelectedOnlyInStaticConstructor()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+static class Bootstrap
+{
+    static Bootstrap()
+    {
+        MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance, setAsDefault: true);
+    }
+}
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new LegacyMoqOnboardingAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
+            Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -4646,6 +4646,45 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenTheoryInlineDataRowsReuseSameConstantProviderField()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+using Xunit;
+
+class Sample
+{
+    private const string ProviderName = ""nsubstitute"";
+
+    interface IService
+    {
+        void Run();
+    }
+
+    [Theory]
+    [InlineData(ProviderName)]
+    [InlineData(ProviderName)]
+    public void Execute(string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenTheoryUsesMixedDataSources()
         {
             const string SOURCE = @"
@@ -4782,6 +4821,42 @@ class Sample
         var providerName = ""nsubstitute"";
         using var providerScope = MockingProviderRegistry.Push(providerName);
         providerName = ""reflection"";
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenNestedLambdaWritesLocalBeforeProviderSelectionButDoesNotRun()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var providerName = ""nsubstitute"";
+        Action mutate = () => providerName = ""reflection"";
+        using var providerScope = MockingProviderRegistry.Push(providerName);
         var mocks = new Mocker();
         var dependency = mocks.GetOrCreateMock<IService>();
         dependency.Received();
@@ -5676,6 +5751,79 @@ class Sample
                 includeAzureFunctionsHelpers: false,
                 includeMoqProviderPackage: true,
                 includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenTheoryInlineDataRowsReuseSameConstantProviderField()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Xunit;
+
+class Sample
+{
+    private const string ProviderName = ""moq"";
+
+    interface IService
+    {
+        void Run();
+    }
+
+    [Theory]
+    [InlineData(ProviderName)]
+    [InlineData(ProviderName)]
+    public void Execute(Mocker mocks, string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenNestedLambdaWritesLocalBeforeProviderSelectionButDoesNotRun()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var providerName = ""moq"";
+        Action mutate = () => providerName = ""reflection"";
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
                 new LegacyMoqOnboardingAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
         }

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -4646,6 +4646,50 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenTheoryUsesMixedDataSources()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+using System.Collections.Generic;
+using Xunit;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    public static IEnumerable<object[]> OtherProviderNames => new[]
+    {
+        new object[] { ""reflection"" },
+    };
+
+    [Theory]
+    [InlineData(""nsubstitute"")]
+    [MemberData(nameof(OtherProviderNames))]
+    public void Execute(string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenTheoryInlineDataSelectsDifferentProviders()
         {
             const string SOURCE = @"
@@ -4714,6 +4758,79 @@ class Sample
 }";
 
             var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(SOURCE, new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenLocalVariableIsReassignedAfterProviderSelection()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var providerName = ""nsubstitute"";
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        providerName = ""reflection"";
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldIgnoreTopLevelNestedLambdaProviderSelections_WhenDeterminingDefaults()
+        {
+            const string SOURCE = @"
+using System;
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+Action bootstrap = () =>
+{
+    using var providerScope = MockingProviderRegistry.Push(""moq"");
+};
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
             var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
             Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
         }
@@ -5439,6 +5556,50 @@ class Sample
                 includeNSubstituteProviderPackage: false,
                 new LegacyMoqOnboardingAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldReport_WhenTheoryUsesMixedDataSources()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using System.Collections.Generic;
+using Xunit;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    public static IEnumerable<object[]> OtherProviderNames => new[]
+    {
+        new object[] { ""reflection"" },
+    };
+
+    [Theory]
+    [InlineData(""moq"")]
+    [MemberData(nameof(OtherProviderNames))]
+    public void Execute(string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new LegacyMoqOnboardingAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding));
+            Assert.Equal(DiagnosticIds.RequireExplicitMoqOnboarding, diagnostic.Id);
         }
 
         [Fact]

--- a/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/FastMoq.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -4576,6 +4576,115 @@ class Sample
         }
 
         [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenProviderIsSelectedUsingSingleAssignmentLocalVariable()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute()
+    {
+        var providerName = ""nsubstitute"";
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenTheoryInlineDataAlwaysSelectsSameProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+using Xunit;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    [Theory]
+    [InlineData(""nsubstitute"")]
+    public void Execute(string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenTheoryInlineDataSelectsDifferentProviders()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.NSubstituteProvider;
+using System;
+using Xunit;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    [Theory]
+    [InlineData(""moq"")]
+    [InlineData(""reflection"")]
+    public void Execute(string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        Action assertion = () => dependency.AsNSubstitute();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            var diagnostic = Assert.Single(diagnostics.Where(item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi));
+            Assert.Equal(DiagnosticIds.SelectProviderBeforeProviderSpecificApi, diagnostic.Id);
+        }
+
+        [Fact]
         public async Task ProviderBootstrapAnalyzer_ShouldReport_WhenProviderIsSelectedOnlyInsideNestedLambda()
         {
             const string SOURCE = @"
@@ -4616,9 +4725,11 @@ class Sample
 using FastMoq;
 using FastMoq.Providers;
 using FastMoq.Providers.MoqProvider;
+using System.Runtime.CompilerServices;
 
 static class Bootstrap
 {
+    [ModuleInitializer]
     static void Initialize()
     {
         MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance, setAsDefault: true);
@@ -4655,9 +4766,11 @@ class Sample
 using FastMoq;
 using FastMoq.Providers;
 using FastMoq.Providers.MoqProvider;
+using System.Runtime.CompilerServices;
 
 static class Bootstrap
 {
+    [ModuleInitializer]
     static void Initialize()
     {
         MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance);
@@ -4684,6 +4797,137 @@ class Sample
                 includeAzureFunctionsHelpers: false,
                 includeMoqProviderPackage: true,
                 includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldIgnoreNonBootstrapSourceDefaultSelections_WhenAssemblyRegistersMoqAsDefaultProvider()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider), SetAsDefault = true)]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void ResetProvider()
+    {
+        MockingProviderRegistry.SetDefault(""reflection"");
+    }
+
+    void Execute()
+    {
+        var mocks = new Mocker();
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenReflectionDefaultClassSelectsDifferentProvidersPerMethod()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using FastMoq.Providers.NSubstituteProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider))]
+[assembly: FastMoqRegisterProvider(""nsubstitute"", typeof(NSubstituteMockingProvider))]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void ReflectionTest(Mocker mocks)
+    {
+        var dependency = mocks.GetObject<IService>();
+    }
+
+    void MoqTest()
+    {
+        using var providerScope = MockingProviderRegistry.Push(""moq"");
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.AsMoq();
+    }
+
+    void NSubstituteTest()
+    {
+        using var providerScope = MockingProviderRegistry.Push(""nsubstitute"");
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
+                new ProviderBootstrapAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
+        }
+
+        [Fact]
+        public async Task ProviderBootstrapAnalyzer_ShouldNotReport_WhenAssemblyDefaultsMoqAndNSubstituteIsSelectedPerMethod()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using FastMoq.Providers.NSubstituteProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider), SetAsDefault = true)]
+[assembly: FastMoqRegisterProvider(""nsubstitute"", typeof(NSubstituteMockingProvider))]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void MoqTest(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+
+    void NSubstituteTest()
+    {
+        using var providerScope = MockingProviderRegistry.Push(""nsubstitute"");
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
                 new ProviderBootstrapAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.SelectProviderBeforeProviderSpecificApi);
         }
@@ -5059,9 +5303,11 @@ class Sample
 using FastMoq;
 using FastMoq.Providers;
 using FastMoq.Providers.MoqProvider;
+using System.Runtime.CompilerServices;
 
 static class Bootstrap
 {
+    [ModuleInitializer]
     static void Initialize()
     {
         MockingProviderRegistry.Register(""moq"", MoqMockingProvider.Instance);
@@ -5086,6 +5332,154 @@ class Sample
                 includeAzureFunctionsHelpers: false,
                 includeMoqProviderPackage: true,
                 includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldIgnoreNonBootstrapSourceDefaultSelections_WhenAssemblyDefaultIsVisible()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider), SetAsDefault = true)]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void ResetProvider()
+    {
+        MockingProviderRegistry.SetDefault(""reflection"");
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenProviderIsSelectedUsingSingleAssignmentLocalVariable()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void Execute(Mocker mocks)
+    {
+        var providerName = ""moq"";
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenTheoryInlineDataAlwaysSelectsMoq()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using Xunit;
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    [Theory]
+    [InlineData(""moq"")]
+    public void Execute(Mocker mocks, string providerName)
+    {
+        using var providerScope = MockingProviderRegistry.Push(providerName);
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: false,
+                new LegacyMoqOnboardingAnalyzer());
+            Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
+        }
+
+        [Fact]
+        public async Task LegacyMoqOnboardingAnalyzer_ShouldNotReport_WhenAssemblyDefaultsMoqAndOtherProvidersAreAlsoRegistered()
+        {
+            const string SOURCE = @"
+using FastMoq;
+using FastMoq.Providers;
+using FastMoq.Providers.MoqProvider;
+using FastMoq.Providers.NSubstituteProvider;
+
+[assembly: FastMoqRegisterProvider(""moq"", typeof(MoqMockingProvider), SetAsDefault = true)]
+[assembly: FastMoqRegisterProvider(""nsubstitute"", typeof(NSubstituteMockingProvider))]
+
+class Sample
+{
+    interface IService
+    {
+        void Run();
+    }
+
+    void MoqTest(Mocker mocks)
+    {
+        var dependency = mocks.GetMock<IService>();
+        dependency.AsMoq();
+    }
+
+    void NSubstituteTest()
+    {
+        using var providerScope = MockingProviderRegistry.Push(""nsubstitute"");
+        var mocks = new Mocker();
+        var dependency = mocks.GetOrCreateMock<IService>();
+        dependency.Received();
+    }
+}";
+
+            var diagnostics = await AnalyzerTestHelpers.GetDiagnosticsAsync(
+                SOURCE,
+                includeAzureFunctionsHelpers: false,
+                includeMoqProviderPackage: true,
+                includeNSubstituteProviderPackage: true,
                 new LegacyMoqOnboardingAnalyzer());
             Assert.DoesNotContain(diagnostics, item => item.Id == DiagnosticIds.RequireExplicitMoqOnboarding);
         }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -150,6 +150,7 @@ namespace FastMoq.Analyzers
         internal const string RegisterProviderSetAsDefaultParameterName = "setAsDefault";
         private const string FASTMOQ_DEFAULT_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqDefaultProviderAttribute";
         private const string FASTMOQ_REGISTER_PROVIDER_ATTRIBUTE = "FastMoq.Providers.FastMoqRegisterProviderAttribute";
+        private const string MODULE_INITIALIZER_ATTRIBUTE = "System.Runtime.CompilerServices.ModuleInitializerAttribute";
         private const string FASTMOQ_MOCKER_TEST_BASE_METADATA_NAME = "MockerTestBase`1";
         private const string CONTROLLER_CONTEXT_TYPE = "Microsoft.AspNetCore.Mvc.ControllerContext";
         private const string DEFAULT_HTTP_CONTEXT_TYPE = "Microsoft.AspNetCore.Http.DefaultHttpContext";
@@ -5441,6 +5442,7 @@ namespace FastMoq.Analyzers
                 foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
                 {
                     if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out var providerType, out _, out var isScopedSelection, out var isRegistration) ||
+                        !IsCompilationLevelProviderSelectionInvocation(invocationExpression, semanticModel, cancellationToken) ||
                         isScopedSelection ||
                         !isRegistration)
                     {
@@ -5462,7 +5464,8 @@ namespace FastMoq.Analyzers
 
                 foreach (var invocationExpression in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
                 {
-                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out _, out var selectsByDefault, out var isScopedSelection, out _))
+                    if (!TryGetProviderRegistrationInvocation(invocationExpression, semanticModel, cancellationToken, out var providerName, out _, out var selectsByDefault, out var isScopedSelection, out _) ||
+                        !IsCompilationLevelProviderSelectionInvocation(invocationExpression, semanticModel, cancellationToken))
                     {
                         continue;
                     }
@@ -5478,6 +5481,44 @@ namespace FastMoq.Analyzers
                     }
                 }
             }
+        }
+
+        private static bool IsCompilationLevelProviderSelectionInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (invocationExpression.Ancestors().OfType<GlobalStatementSyntax>().Any())
+            {
+                return true;
+            }
+
+            var executableScope = invocationExpression.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+
+            return executableScope switch
+            {
+                ConstructorDeclarationSyntax constructorDeclaration => constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword),
+                MethodDeclarationSyntax methodDeclaration => HasModuleInitializerAttribute(methodDeclaration, semanticModel, cancellationToken),
+                _ => false,
+            };
+        }
+
+        private static bool HasModuleInitializerAttribute(MethodDeclarationSyntax methodDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (!TryGetSemanticModelForNode(methodDeclaration, semanticModel, out semanticModel))
+            {
+                return false;
+            }
+
+            foreach (var attributeSyntax in methodDeclaration.AttributeLists.SelectMany(attributeList => attributeList.Attributes))
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(attributeSyntax, cancellationToken);
+                var attributeSymbol = symbolInfo.Symbol as IMethodSymbol ?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+                if (attributeSymbol?.ContainingType?.ToDisplayString() == MODULE_INITIALIZER_ATTRIBUTE)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryGetProviderRegistrationInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out string providerName, out ITypeSymbol? providerType, out bool selectsByDefault, out bool isScopedSelection, out bool isRegistration)
@@ -5608,6 +5649,13 @@ namespace FastMoq.Analyzers
 
         private static bool TryGetStringConstant(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, out string value)
         {
+            return TryGetStringConstant(expression, semanticModel, cancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out value);
+        }
+
+        private static bool TryGetStringConstant(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out string value)
+        {
+            expression = Unwrap(expression);
+
             var constantValue = semanticModel.GetConstantValue(expression, cancellationToken);
             if (constantValue.HasValue && constantValue.Value is string text && !string.IsNullOrWhiteSpace(text))
             {
@@ -5615,7 +5663,170 @@ namespace FastMoq.Analyzers
                 return true;
             }
 
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            if (symbol is null || !visitedSymbols.Add(symbol))
+            {
+                value = string.Empty;
+                return false;
+            }
+
+            if (symbol is IFieldSymbol fieldSymbol &&
+                fieldSymbol.HasConstantValue &&
+                fieldSymbol.ConstantValue is string fieldText &&
+                !string.IsNullOrWhiteSpace(fieldText))
+            {
+                value = fieldText;
+                return true;
+            }
+
+            if (symbol is IParameterSymbol parameterSymbol &&
+                TryResolveInlineDataParameterStringConstant(parameterSymbol, semanticModel, cancellationToken, visitedSymbols, out value))
+            {
+                return true;
+            }
+
+            if (symbol is ILocalSymbol localSymbol &&
+                TryResolveSingleAssignmentLocalStringConstant(localSymbol, expression, semanticModel, cancellationToken, visitedSymbols, out value))
+            {
+                return true;
+            }
+
             value = string.Empty;
+            return false;
+        }
+
+        private static bool TryResolveSingleAssignmentLocalStringConstant(ILocalSymbol localSymbol, SyntaxNode referenceNode, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out string value)
+        {
+            if (localSymbol.HasConstantValue &&
+                localSymbol.ConstantValue is string localText &&
+                !string.IsNullOrWhiteSpace(localText))
+            {
+                value = localText;
+                return true;
+            }
+
+            var declaration = localSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken) as VariableDeclaratorSyntax;
+            if (declaration?.Initializer?.Value is not ExpressionSyntax initializer)
+            {
+                value = string.Empty;
+                return false;
+            }
+
+            var containingScope = referenceNode.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+
+            if (containingScope is not null && IsLocalVariableWrittenAfterDeclaration(localSymbol, declaration, containingScope, semanticModel, cancellationToken))
+            {
+                value = string.Empty;
+                return false;
+            }
+
+            return TryGetStringConstant(initializer, semanticModel, cancellationToken, visitedSymbols, out value);
+        }
+
+        private static bool TryResolveInlineDataParameterStringConstant(IParameterSymbol parameterSymbol, SemanticModel semanticModel, CancellationToken cancellationToken, ISet<ISymbol> visitedSymbols, out string value)
+        {
+            value = string.Empty;
+
+            if (parameterSymbol.ContainingSymbol is not IMethodSymbol methodSymbol)
+            {
+                return false;
+            }
+
+            string? resolvedValue = null;
+            var foundInlineData = false;
+
+            foreach (var attribute in methodSymbol.GetAttributes())
+            {
+                if (attribute.AttributeClass?.ToDisplayString() != "Xunit.InlineDataAttribute" ||
+                    attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is not AttributeSyntax attributeSyntax ||
+                    attributeSyntax.ArgumentList is null ||
+                    parameterSymbol.Ordinal >= attributeSyntax.ArgumentList.Arguments.Count)
+                {
+                    continue;
+                }
+
+                if (!TryGetSemanticModelForNode(attributeSyntax, semanticModel, out var attributeSemanticModel) ||
+                    !TryGetStringConstant(attributeSyntax.ArgumentList.Arguments[parameterSymbol.Ordinal].Expression, attributeSemanticModel, cancellationToken, visitedSymbols, out var candidateValue))
+                {
+                    return false;
+                }
+
+                foundInlineData = true;
+                if (resolvedValue is null)
+                {
+                    resolvedValue = candidateValue;
+                    continue;
+                }
+
+                if (!string.Equals(resolvedValue, candidateValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            if (!foundInlineData || string.IsNullOrWhiteSpace(resolvedValue))
+            {
+                return false;
+            }
+
+            value = resolvedValue!;
+            return true;
+        }
+
+        private static bool IsLocalVariableWrittenAfterDeclaration(ILocalSymbol localSymbol, VariableDeclaratorSyntax declaration, SyntaxNode containingScope, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            foreach (var identifierName in containingScope.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifierName.SpanStart <= declaration.SpanStart)
+                {
+                    continue;
+                }
+
+                var symbolInfo = semanticModel.GetSymbolInfo(identifierName, cancellationToken);
+                if (!SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, localSymbol))
+                {
+                    continue;
+                }
+
+                if (IsWriteReference(identifierName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsWriteReference(IdentifierNameSyntax identifierName)
+        {
+            if (identifierName.Parent is AssignmentExpressionSyntax assignmentExpression && assignmentExpression.Left == identifierName)
+            {
+                return true;
+            }
+
+            if (identifierName.Parent is ArgumentSyntax argumentSyntax &&
+                (argumentSyntax.RefOrOutKeyword.IsKind(SyntaxKind.RefKeyword) ||
+                 argumentSyntax.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)))
+            {
+                return true;
+            }
+
+            if (identifierName.Parent is PrefixUnaryExpressionSyntax prefixUnaryExpression &&
+                (prefixUnaryExpression.IsKind(SyntaxKind.PreIncrementExpression) ||
+                 prefixUnaryExpression.IsKind(SyntaxKind.PreDecrementExpression)))
+            {
+                return true;
+            }
+
+            if (identifierName.Parent is PostfixUnaryExpressionSyntax postfixUnaryExpression &&
+                (postfixUnaryExpression.IsKind(SyntaxKind.PostIncrementExpression) ||
+                 postfixUnaryExpression.IsKind(SyntaxKind.PostDecrementExpression)))
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -5759,8 +5759,9 @@ namespace FastMoq.Analyzers
                     return false;
                 }
 
+                var candidateVisitedSymbols = new HashSet<ISymbol>(visitedSymbols, SymbolEqualityComparer.Default);
                 if (!TryGetSemanticModelForNode(attributeSyntax, semanticModel, out var attributeSemanticModel) ||
-                    !TryGetStringConstant(attributeSyntax.ArgumentList.Arguments[parameterSymbol.Ordinal].Expression, attributeSemanticModel, cancellationToken, visitedSymbols, out var candidateValue))
+                    !TryGetStringConstant(attributeSyntax.ArgumentList.Arguments[parameterSymbol.Ordinal].Expression, attributeSemanticModel, cancellationToken, candidateVisitedSymbols, out var candidateValue))
                 {
                     return false;
                 }
@@ -5807,6 +5808,11 @@ namespace FastMoq.Analyzers
             {
                 if (identifierName.SpanStart <= declaration.SpanStart ||
                     identifierName.SpanStart >= referenceNode.SpanStart)
+                {
+                    continue;
+                }
+
+                if (!ReferenceEquals(GetContainingExecutableScope(identifierName), containingScope))
                 {
                     continue;
                 }

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -5485,20 +5485,21 @@ namespace FastMoq.Analyzers
 
         private static bool IsCompilationLevelProviderSelectionInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            var executableScope = invocationExpression.AncestorsAndSelf().FirstOrDefault(ancestor =>
-                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+            var executableScope = GetContainingExecutableScope(invocationExpression);
 
             if (executableScope is null)
             {
                 return invocationExpression.Ancestors().OfType<GlobalStatementSyntax>().Any();
             }
 
-            return executableScope switch
-            {
-                ConstructorDeclarationSyntax constructorDeclaration => constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword),
-                MethodDeclarationSyntax methodDeclaration => HasModuleInitializerAttribute(methodDeclaration, semanticModel, cancellationToken),
-                _ => false,
-            };
+            return executableScope is MethodDeclarationSyntax methodDeclaration &&
+                HasModuleInitializerAttribute(methodDeclaration, semanticModel, cancellationToken);
+        }
+
+        private static SyntaxNode? GetContainingExecutableScope(SyntaxNode node)
+        {
+            return node.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
         }
 
         private static bool HasModuleInitializerAttribute(MethodDeclarationSyntax methodDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -5713,10 +5714,16 @@ namespace FastMoq.Analyzers
                 return false;
             }
 
-            var containingScope = referenceNode.AncestorsAndSelf().FirstOrDefault(ancestor =>
-                ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+            var declarationScope = GetContainingExecutableScope(declaration);
+            var referenceScope = GetContainingExecutableScope(referenceNode);
 
-            if (containingScope is not null && IsLocalVariableWrittenBeforeReference(localSymbol, declaration, referenceNode, containingScope, semanticModel, cancellationToken))
+            if (!ReferenceEquals(declarationScope, referenceScope))
+            {
+                value = string.Empty;
+                return false;
+            }
+
+            if (referenceScope is not null && IsLocalVariableWrittenBeforeReference(localSymbol, declaration, referenceNode, referenceScope, semanticModel, cancellationToken))
             {
                 value = string.Empty;
                 return false;

--- a/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
+++ b/FastMoq.Analyzers/FastMoqAnalysisHelpers.cs
@@ -5485,13 +5485,13 @@ namespace FastMoq.Analyzers
 
         private static bool IsCompilationLevelProviderSelectionInvocation(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (invocationExpression.Ancestors().OfType<GlobalStatementSyntax>().Any())
-            {
-                return true;
-            }
-
             var executableScope = invocationExpression.AncestorsAndSelf().FirstOrDefault(ancestor =>
                 ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
+
+            if (executableScope is null)
+            {
+                return invocationExpression.Ancestors().OfType<GlobalStatementSyntax>().Any();
+            }
 
             return executableScope switch
             {
@@ -5716,7 +5716,7 @@ namespace FastMoq.Analyzers
             var containingScope = referenceNode.AncestorsAndSelf().FirstOrDefault(ancestor =>
                 ancestor is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax);
 
-            if (containingScope is not null && IsLocalVariableWrittenAfterDeclaration(localSymbol, declaration, containingScope, semanticModel, cancellationToken))
+            if (containingScope is not null && IsLocalVariableWrittenBeforeReference(localSymbol, declaration, referenceNode, containingScope, semanticModel, cancellationToken))
             {
                 value = string.Empty;
                 return false;
@@ -5739,12 +5739,17 @@ namespace FastMoq.Analyzers
 
             foreach (var attribute in methodSymbol.GetAttributes())
             {
+                if (!IsXunitDataAttribute(attribute.AttributeClass))
+                {
+                    continue;
+                }
+
                 if (attribute.AttributeClass?.ToDisplayString() != "Xunit.InlineDataAttribute" ||
                     attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is not AttributeSyntax attributeSyntax ||
                     attributeSyntax.ArgumentList is null ||
                     parameterSymbol.Ordinal >= attributeSyntax.ArgumentList.Arguments.Count)
                 {
-                    continue;
+                    return false;
                 }
 
                 if (!TryGetSemanticModelForNode(attributeSyntax, semanticModel, out var attributeSemanticModel) ||
@@ -5775,11 +5780,26 @@ namespace FastMoq.Analyzers
             return true;
         }
 
-        private static bool IsLocalVariableWrittenAfterDeclaration(ILocalSymbol localSymbol, VariableDeclaratorSyntax declaration, SyntaxNode containingScope, SemanticModel semanticModel, CancellationToken cancellationToken)
+        private static bool IsXunitDataAttribute(INamedTypeSymbol? attributeType)
+        {
+            for (var current = attributeType; current is not null; current = current.BaseType)
+            {
+                if (current.Name == "DataAttribute" &&
+                    current.ContainingNamespace.ToDisplayString().StartsWith("Xunit", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsLocalVariableWrittenBeforeReference(ILocalSymbol localSymbol, VariableDeclaratorSyntax declaration, SyntaxNode referenceNode, SyntaxNode containingScope, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             foreach (var identifierName in containingScope.DescendantNodes().OfType<IdentifierNameSyntax>())
             {
-                if (identifierName.SpanStart <= declaration.SpanStart)
+                if (identifierName.SpanStart <= declaration.SpanStart ||
+                    identifierName.SpanStart >= referenceNode.SpanStart)
                 {
                     continue;
                 }

--- a/FastMoq.Tests/FastMoq.Tests.csproj
+++ b/FastMoq.Tests/FastMoq.Tests.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>1701;1702;S1309;S4018;S2436;CS8618;CS0618</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);FMOQ0009;FMOQ0023</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FastMoq.Tests/NSubstituteProviderExtensionTests.cs
+++ b/FastMoq.Tests/NSubstituteProviderExtensionTests.cs
@@ -25,7 +25,7 @@ namespace FastMoq.Tests
 
         [Theory]
         [InlineData(false, "nsubstitute", true)]
-        public void AsNSubstitute_ShouldReturnUnderlyingSubstitute_WhenProviderNameTheoryIsNSubstitute(bool var1, string providerName, bool var2)
+        public void AsNSubstitute_ShouldReturnUnderlyingSubstitute_WhenProviderNameTheoryIsNSubstitute(bool leadingSentinel, string providerName, bool trailingSentinel)
         {
             using var providerScope = MockingProviderRegistry.Push(providerName);
             var mocker = new Mocker();
@@ -37,8 +37,8 @@ namespace FastMoq.Tests
             substitute.Should().BeSameAs(dependency.Instance);
             dependency.Instance.GetValue().Returns("configured");
             substitute.GetValue().Should().Be("configured");
-            var1.Should().Be(false);
-            var2.Should().Be(true);
+            leadingSentinel.Should().Be(false);
+            trailingSentinel.Should().Be(true);
         }
 
         [Fact]

--- a/FastMoq.Tests/NSubstituteProviderExtensionTests.cs
+++ b/FastMoq.Tests/NSubstituteProviderExtensionTests.cs
@@ -24,6 +24,40 @@ namespace FastMoq.Tests
         }
 
         [Theory]
+        [InlineData(false, "nsubstitute", true)]
+        public void AsNSubstitute_ShouldReturnUnderlyingSubstitute_WhenProviderNameTheoryIsNSubstitute(bool var1, string providerName, bool var2)
+        {
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var dependency = mocker.GetOrCreateMock<IProviderValueDependency>();
+
+            var substitute = dependency.AsNSubstitute();
+
+            substitute.Should().BeSameAs(dependency.Instance);
+            dependency.Instance.GetValue().Returns("configured");
+            substitute.GetValue().Should().Be("configured");
+            var1.Should().Be(false);
+            var2.Should().Be(true);
+        }
+
+        [Fact]
+        public void AsNSubstitute_ShouldReturnUnderlyingSubstitute_WhenProviderNameVariableIsNSubstitute()
+        {
+            var providerName = "nsubstitute";
+            using var providerScope = MockingProviderRegistry.Push(providerName);
+            var mocker = new Mocker();
+
+            var dependency = mocker.GetOrCreateMock<IProviderValueDependency>();
+
+            var substitute = dependency.AsNSubstitute();
+
+            substitute.Should().BeSameAs(dependency.Instance);
+            dependency.Instance.GetValue().Returns("configured");
+            substitute.GetValue().Should().Be("configured");
+        }
+
+        [Theory]
         [InlineData("moq")]
         [InlineData("reflection")]
         public void AsNSubstitute_ShouldThrow_WhenProviderIsNotNSubstitute(string providerName)
@@ -33,7 +67,9 @@ namespace FastMoq.Tests
 
             var dependency = mocker.GetOrCreateMock<IProviderValueDependency>();
 
+#pragma warning disable FMOQ0009 // Intentional negative coverage uses runtime-selected providers that exclude nsubstitute.
             Action action = () => dependency.AsNSubstitute();
+#pragma warning restore FMOQ0009 // Intentional negative coverage uses runtime-selected providers that exclude nsubstitute.
 
             var exception = action.Should().Throw<NotSupportedException>().Which;
             exception.Message.Should().Contain("requires the 'nsubstitute' provider");


### PR DESCRIPTION
## Summary
- restrict compilation-wide provider default detection to real bootstrap locations instead of any source call site
- resolve effective providers from single-assignment local string variables and xUnit InlineData theory parameters when they resolve to one provider value
- add analyzer regressions for mixed-provider classes, bootstrap/module-initializer cases, local-variable scopes, and positive/negative theory patterns
- add NSubstitute extension tests covering variable and theory-backed provider selection, with a narrow suppression on the intentional negative theory

## Validation
- dotnet test FastMoq.Analyzers.Tests/FastMoq.Analyzers.Tests.csproj
- dotnet build FastMoq.Tests/FastMoq.Tests.csproj

## Notes
- confirmed the source-scan regression predates 4.4.1 and was introduced by #115, not the latest merged PR
- packages.lock.json was intentionally left out of this commit